### PR TITLE
docs: refine VPTO type and shared dialect docs

### DIFF
--- a/docs/isa/14-shared-arith.md
+++ b/docs/isa/14-shared-arith.md
@@ -1,10 +1,10 @@
 # 14. Arith (Shared MLIR Dialect)
 
-> **Category:** Shared scalar and index operations used around PTO ops
+> **Category:** Shared full scalar `arith` surface used around PTO ops
 > **Dialect:** `arith`
 > **Upstream Reference:** https://mlir.llvm.org/docs/Dialects/ArithOps/
 
-The upstream MLIR `arith` dialect defines primitive arithmetic, comparison, select, and cast operations over signless integer, index, and floating-point values. In VPTO programs, these ops are used as the scalar and index layer around PTO instructions: they build constants, compute offsets and loop bounds, derive valid-shape metadata, and form predicates for `scf` control flow.
+The upstream MLIR `arith` dialect defines primitive arithmetic, comparison, select, and cast operations over signless integer, index, floating-point, and boolean-compatible scalar values. In VPTO programs, the full scalar operation surface of `arith` is supported. These ops are used around PTO instructions to build constants, compute offsets and loop bounds, perform general scalar math, derive valid-shape metadata, and form predicates for `scf` control flow.
 
 These ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and do not map to CCE builtins directly.
 
@@ -14,54 +14,36 @@ These ops are part of the supported VPTO source surface, but they are not PTO IS
 
 - materialize scalar constants used by PTO scalar operands and loop bounds
 - compute scalar/index offsets for tensor views, partitioning, and dynamic shapes
+- perform general scalar integer and floating-point math outside PTO vector/tile payload operations
 - derive scalar predicates that guard `scf.if` or `scf.while`
-- select between scalar values without introducing PTO-specific control ops
+- apply scalar casts, width changes, bitwise ops, and selects without introducing PTO-specific control ops
 
-Prefer PTO ops for vector or tile payload math. Use `arith` for scalar/index bookkeeping that surrounds PTO regions.
-
----
-
-## Supported Author-Facing Ops
-
-| Op | Typical VPTO Use | Notes |
-|----|------------------|-------|
-| `arith.constant` | index, integer, boolean, and float constants | ubiquitous in samples and tests |
-| `arith.addi` | scalar/index addition | loop-carried counters, offsets, break-like state |
-| `arith.subi` | scalar/index subtraction | remainder or tail-size computation |
-| `arith.muli` | scalar/index multiplication | row-stride and chunk-offset computation |
-| `arith.cmpi` | integer/index comparison | branch predicates and loop conditions |
-| `arith.select` | scalar select | choose scalar/index values without branching |
-| `arith.index_cast` | cast integer to `index` or back | dynamic shape and ABI glue |
-| `arith.index_castui` | unsigned cast into `index`/integer | lowering and copy-shape helpers |
-| `arith.andi` | boolean / integer AND | combine loop-continue flags |
-| `arith.xori` | boolean / integer XOR | negate or flip boolean state |
-| `arith.remui` | unsigned remainder | parity and chunk splitting helpers |
-| `arith.ceildivsi` | signed ceil division | tile-count and chunk-count setup |
+Prefer PTO ops for vector or tile payload math. Use `arith` for scalar computation and bookkeeping that surrounds PTO regions.
 
 ---
 
-## Lowering-Generated Helper Ops
+## Supported Surface
 
-The PTO lowering and LLVM emission paths may also introduce a few additional `arith` ops as internal helpers even when authors do not write them directly:
+VPTO supports the full scalar operation surface of upstream `arith`. The upstream `arith` dialect reference remains authoritative for the exhaustive op-by-op syntax and semantics. The categories below summarize how that support is used in VPTO programs.
 
-- `arith.extui`
-- `arith.extsi`
-- `arith.trunci`
-- `arith.shli`
-- `arith.ori`
-- `arith.divui`
-
-These helper ops are useful for integer width adjustment or packed-parameter construction, but they are not the primary author-facing surface documented for VPTO kernels.
+| Category | Representative Ops | Typical VPTO Use |
+|----------|--------------------|------------------|
+| Constants | `arith.constant` | integer, floating-point, boolean, and `index` constants |
+| Integer / Index Arithmetic | `arith.addi`, `arith.subi`, `arith.muli`, `arith.divsi`, `arith.divui`, `arith.ceildivsi`, `arith.ceildivui`, `arith.floordivsi`, `arith.remsi`, `arith.remui` | offsets, bounds, chunk sizes, scalar math |
+| Floating-Point Arithmetic | `arith.addf`, `arith.subf`, `arith.mulf`, `arith.divf`, `arith.negf`, `arith.maximumf`, `arith.minimumf`, `arith.maxnumf`, `arith.minnumf` | scalar math around PTO regions |
+| Bitwise / Shift Ops | `arith.andi`, `arith.ori`, `arith.xori`, `arith.shli`, `arith.shrsi`, `arith.shrui` | flags, masks, packed scalar fields |
+| Comparisons / Select | `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.maxsi`, `arith.minui` | predicates, clamps, scalar muxes |
+| Casts / Width Changes | `arith.index_cast`, `arith.index_castui`, `arith.extsi`, `arith.extui`, `arith.trunci`, `arith.sitofp`, `arith.uitofp`, `arith.fptosi`, `arith.fptoui`, `arith.extf`, `arith.truncf`, `arith.bitcast` | ABI glue, dynamic-shape plumbing, scalar type adaptation |
 
 ---
 
 ## Current PTOAS Coverage
 
-- the A5VM shared-dialect fixture explicitly exercises `arith.addi` together with `scf.for` and `scf.yield`
-- the A5VM text emitter currently has explicit handling for `arith.constant`, `arith.index_castui`, `arith.muli`, `arith.addi`, `arith.subi`, `arith.cmpi`, and `arith.select`
-- the broader PTO lowering and view/materialization helpers also rely on `arith.index_cast`, `arith.extui`, `arith.extsi`, `arith.trunci`, `arith.shli`, `arith.ori`, and related scalar integer helpers
+- the current repository examples are still dominated by constants, casts, integer/index arithmetic, compares, and selects because those are the most common surrounding-scalar patterns in existing kernels
+- backend-specific tests such as the A5VM shared-dialect fixture visibly exercise only a representative subset of `arith` ops in a single path
+- the documented VPTO source contract is nevertheless the full scalar `arith` surface, not just the index-heavy subset that appears most often in current samples
 
-This means the author-facing subset above is intentionally larger than the one A5VM text emission test exercises in a single path, but it stays within the scalar/index patterns already present in the repository.
+This section therefore uses representative categories and examples instead of pretending that the supported `arith` surface is limited to the currently most common sample patterns.
 
 ---
 
@@ -83,6 +65,14 @@ This means the author-facing subset above is intentionally larger than the one A
 %tail = arith.subi %limit, %chunk : index
 ```
 
+### General Scalar Arithmetic
+
+```mlir
+%sum_i = arith.addi %lhs_i, %rhs_i : i32
+%sum_f = arith.addf %lhs_f, %rhs_f : f32
+%prod_f = arith.mulf %sum_f, %scale : f32
+```
+
 ### Scalar Predicate and Selection
 
 ```mlir
@@ -90,18 +80,20 @@ This means the author-facing subset above is intentionally larger than the one A
 %active = arith.select %is_first, %first_count, %steady_count : index
 ```
 
-### Break-Like Boolean Update
+### Bitwise / Width Adaptation
 
 ```mlir
-%break_now = arith.cmpi eq, %i, %c2 : index
-%alive_next = arith.xori %break_now, %true : i1
+%flags = arith.andi %flags0, %flags1 : i32
+%wide = arith.extui %flags : i32 to i64
+%shrunk = arith.trunci %wide : i64 to i16
 ```
 
 ---
 
 ## Authoring Guidance
 
+- treat upstream `arith` scalar semantics as the source of truth for supported scalar ops
 - keep `arith` values scalar or `index` typed; do not use `arith` as a substitute for PTO vector/tile compute
-- use `arith.cmpi` plus `scf.if` / `scf.while` for control flow, not ad hoc control intrinsics
-- prefer `arith.index_cast` / `arith.index_castui` at ABI or shape boundaries where `index` is required
-- keep branch predicates and loop bounds explicit; this helps PTO analyses reason about memory scope and synchronization
+- use `arith` for general scalar math, scalar comparisons, bitwise operations, and casts around PTO regions, not just for `index` arithmetic
+- use `arith.cmpi` / `arith.cmpf` plus `scf.if` / `scf.while` for control flow, not ad hoc control intrinsics
+- prefer `arith.index_cast` / `arith.index_castui` at ABI or shape boundaries where `index` is required, but do not read that as a restriction on the rest of scalar `arith`

--- a/docs/isa/14-shared-arith.md
+++ b/docs/isa/14-shared-arith.md
@@ -1,0 +1,107 @@
+# 14. Arith (Shared MLIR Dialect)
+
+> **Category:** Shared scalar and index operations used around PTO ops
+> **Dialect:** `arith`
+> **Upstream Reference:** https://mlir.llvm.org/docs/Dialects/ArithOps/
+
+The upstream MLIR `arith` dialect defines primitive arithmetic, comparison, select, and cast operations over signless integer, index, and floating-point values. In VPTO programs, these ops are used as the scalar and index layer around PTO instructions: they build constants, compute offsets and loop bounds, derive valid-shape metadata, and form predicates for `scf` control flow.
+
+These ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and do not map to CCE builtins directly.
+
+---
+
+## Role in VPTO Programs
+
+- materialize scalar constants used by PTO scalar operands and loop bounds
+- compute scalar/index offsets for tensor views, partitioning, and dynamic shapes
+- derive scalar predicates that guard `scf.if` or `scf.while`
+- select between scalar values without introducing PTO-specific control ops
+
+Prefer PTO ops for vector or tile payload math. Use `arith` for scalar/index bookkeeping that surrounds PTO regions.
+
+---
+
+## Supported Author-Facing Ops
+
+| Op | Typical VPTO Use | Notes |
+|----|------------------|-------|
+| `arith.constant` | index, integer, boolean, and float constants | ubiquitous in samples and tests |
+| `arith.addi` | scalar/index addition | loop-carried counters, offsets, break-like state |
+| `arith.subi` | scalar/index subtraction | remainder or tail-size computation |
+| `arith.muli` | scalar/index multiplication | row-stride and chunk-offset computation |
+| `arith.cmpi` | integer/index comparison | branch predicates and loop conditions |
+| `arith.select` | scalar select | choose scalar/index values without branching |
+| `arith.index_cast` | cast integer to `index` or back | dynamic shape and ABI glue |
+| `arith.index_castui` | unsigned cast into `index`/integer | lowering and copy-shape helpers |
+| `arith.andi` | boolean / integer AND | combine loop-continue flags |
+| `arith.xori` | boolean / integer XOR | negate or flip boolean state |
+| `arith.remui` | unsigned remainder | parity and chunk splitting helpers |
+| `arith.ceildivsi` | signed ceil division | tile-count and chunk-count setup |
+
+---
+
+## Lowering-Generated Helper Ops
+
+The PTO lowering and LLVM emission paths may also introduce a few additional `arith` ops as internal helpers even when authors do not write them directly:
+
+- `arith.extui`
+- `arith.extsi`
+- `arith.trunci`
+- `arith.shli`
+- `arith.ori`
+- `arith.divui`
+
+These helper ops are useful for integer width adjustment or packed-parameter construction, but they are not the primary author-facing surface documented for VPTO kernels.
+
+---
+
+## Current PTOAS Coverage
+
+- the A5VM shared-dialect fixture explicitly exercises `arith.addi` together with `scf.for` and `scf.yield`
+- the A5VM text emitter currently has explicit handling for `arith.constant`, `arith.index_castui`, `arith.muli`, `arith.addi`, `arith.subi`, `arith.cmpi`, and `arith.select`
+- the broader PTO lowering and view/materialization helpers also rely on `arith.index_cast`, `arith.extui`, `arith.extsi`, `arith.trunci`, `arith.shli`, `arith.ori`, and related scalar integer helpers
+
+This means the author-facing subset above is intentionally larger than the one A5VM text emission test exercises in a single path, but it stays within the scalar/index patterns already present in the repository.
+
+---
+
+## Typical Patterns
+
+### Scalar Setup
+
+```mlir
+%c0 = arith.constant 0 : index
+%c1 = arith.constant 1 : index
+%scale = arith.constant 2.0 : f32
+```
+
+### Dynamic Offset Computation
+
+```mlir
+%vrow = arith.index_cast %valid_row : i32 to index
+%chunk = arith.muli %row, %c32 : index
+%tail = arith.subi %limit, %chunk : index
+```
+
+### Scalar Predicate and Selection
+
+```mlir
+%is_first = arith.cmpi eq, %i, %c0 : index
+%active = arith.select %is_first, %first_count, %steady_count : index
+```
+
+### Break-Like Boolean Update
+
+```mlir
+%break_now = arith.cmpi eq, %i, %c2 : index
+%alive_next = arith.xori %break_now, %true : i1
+```
+
+---
+
+## Authoring Guidance
+
+- keep `arith` values scalar or `index` typed; do not use `arith` as a substitute for PTO vector/tile compute
+- use `arith.cmpi` plus `scf.if` / `scf.while` for control flow, not ad hoc control intrinsics
+- prefer `arith.index_cast` / `arith.index_castui` at ABI or shape boundaries where `index` is required
+- keep branch predicates and loop bounds explicit; this helps PTO analyses reason about memory scope and synchronization

--- a/docs/isa/15-shared-scf.md
+++ b/docs/isa/15-shared-scf.md
@@ -1,0 +1,97 @@
+# 15. SCF (Shared MLIR Dialect)
+
+> **Category:** Shared structured control flow around PTO regions
+> **Dialect:** `scf`
+> **Upstream Reference:** https://mlir.llvm.org/docs/Dialects/SCFDialect/
+
+The upstream MLIR `scf` dialect defines structured control flow operations with regions, including counted loops, conditional regions, and while-style loops. In VPTO programs, `scf` is the control shell around PTO ops: it sequences DMA, vector, and tile operations; carries scalar or tile state across iterations; and preserves analyzable control flow for PTO-specific analyses and lowerings.
+
+These ops are part of the supported VPTO source surface, but they are shared MLIR control-flow constructs rather than PTO ISA instructions.
+
+---
+
+## Supported Ops
+
+| Op | Role in VPTO Programs | Notes |
+|----|------------------------|-------|
+| `scf.for` | counted loops and loop-carried values | also used for `__VEC_SCOPE__` dummy-loop form |
+| `scf.if` | structured conditional execution | may yield values or act as side-effect-only branch |
+| `scf.yield` | region terminator for `for` / `if` / `while` bodies | carries loop or branch results |
+| `scf.while` | break-like or stateful loops | useful for source-level structured control |
+| `scf.condition` | loop-continue / loop-exit decision for `scf.while` | placed in the "before" region |
+
+Ops such as `scf.execute_region`, `scf.forall`, or `scf.index_switch` are not part of the documented VPTO shared-dialect surface here.
+
+---
+
+## Current PTOAS Coverage
+
+- `scf.for`, `scf.if`, and `scf.yield` are directly exercised in the shared-dialect A5VM fixture and appear widely across PTO samples
+- the VPTO `__VEC_SCOPE__` contract is modeled as a specialized `scf.for` annotated with `llvm.loop.aivector_scope`
+- PTO synchronization and memory analyses explicitly reason about `scf.for`, `scf.if`, `scf.yield`, and `scf.while`
+- `scf.while` and `scf.condition` appear in control-flow samples and are handled in PTO-to-EmitC control-flow lowering, but they are less broadly exercised than `for` / `if` on all backend paths
+
+---
+
+## Typical Patterns
+
+### Counted Loop
+
+```mlir
+scf.for %i = %c0 to %c4 step %c1 {
+  %offset = arith.muli %i, %c32 : index
+  %v = pto.vlds %ub[%offset] : !llvm.ptr<6> -> !pto.vreg<64xf32>
+  %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+  pto.vsts %abs, %ub_out[%offset] : !pto.vreg<64xf32>, !llvm.ptr<6>
+}
+```
+
+### Counted Loop with Loop-Carried State
+
+```mlir
+%final_alive = scf.for %i = %c0 to %c4 step %c1
+    iter_args(%alive = %true) -> (i1) {
+  %break_now = arith.cmpi eq, %i, %c2 : index
+  %next_alive = scf.if %break_now -> (i1) {
+    scf.yield %false : i1
+  } else {
+    scf.yield %alive : i1
+  }
+  scf.yield %next_alive : i1
+}
+```
+
+### Structured Conditional Region
+
+```mlir
+%is_mode_a = arith.cmpi eq, %mode, %c0_i32 : i32
+scf.if %is_mode_a {
+  pto.tmuls ins(%data, %scale_a : !pto.tile_buf<...>, f32) outs(%data : !pto.tile_buf<...>)
+} else {
+  pto.tadds ins(%data, %bias_b : !pto.tile_buf<...>, f32) outs(%data : !pto.tile_buf<...>)
+}
+```
+
+### While-Style Break Loop
+
+```mlir
+%final:2 = scf.while (%i = %c0, %alive = %true) : (index, i1) -> (index, i1) {
+  %lt = arith.cmpi slt, %i, %c4 : index
+  %go = arith.andi %lt, %alive : i1
+  scf.condition(%go) %i, %alive : index, i1
+} do {
+^bb0(%i2: index, %alive2: i1):
+  %next_i = arith.addi %i2, %c1 : index
+  scf.yield %next_i, %alive2 : index, i1
+}
+```
+
+---
+
+## Authoring Guidance
+
+- use `scf.for` for regular counted loops and loop-carried scalar/tile state
+- use `scf.if` for structured branching around PTO regions instead of inventing PTO-specific branch ops
+- keep region results explicit with `scf.yield`; this is important for PTO analyses that track carried buffers and aliasing
+- use `scf.while` only when a counted loop cannot express the control cleanly; `scf.for` remains the more common and better-exercised form in the current repository
+- build branch predicates and loop conditions with `arith` ops, not PTO vector masks, unless the control decision truly comes from a scalarized value

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -11,68 +11,30 @@
 
 ### Overview
 
-This document defines the Vector PTO (VPTO) Intermediate Representation (IR), a
-compiler-internal and externally facing specification designed to represent
-vector compute kernels within the PTO architecture. Much like NVVM provides a
-robust IR for GPU architectures, VPTO serves as the direct bridge between
-high-level programming models and the underlying hardware ISA, providing a
-precise, low-level representation of vector workloads explicitly designed for
-the Ascend 950 architecture.
+This document defines the Vector PTO (VPTO) Intermediate Representation (IR), a compiler-internal and externally facing specification designed to represent vector compute kernels within the PTO architecture. Much like NVVM provides a robust IR for GPU architectures, VPTO serves as the direct bridge between high-level programming models and the underlying hardware ISA, providing a precise, low-level representation of vector workloads explicitly designed for the Ascend 950 architecture.
 
 #### Position in the Stack and Layer Modeled
 
-VPTO operates as a very low-level intermediate representation within the PTO
-compiler stack. It is uniquely designed to accurately and comprehensively
-express all architectural information of the Ascend 950 hardware. It
-specifically models the bare-metal vector execution layer, making
-hardware-specific capabilities and constraints, such as exact vector lane
-configurations, memory space hierarchies, and hardware-specific fusion
-semantics, fully transparent and controllable.
+VPTO operates as a very low-level intermediate representation within the PTO compiler stack. It is uniquely designed to accurately and comprehensively express all architectural information of the Ascend 950 hardware. It specifically models the bare-metal vector execution layer, making hardware-specific capabilities and constraints, such as exact vector lane configurations, memory space hierarchies, and hardware-specific fusion semantics, fully transparent and controllable.
 
 #### Why External Developers Read or Author VPTO
 
-While the majority of users will interact with the PTO architecture via
-higher-level frameworks, external developers may need to read or author VPTO IR
-directly for several key reasons:
+While the majority of users will interact with the PTO architecture via higher-level frameworks, external developers may need to read or author VPTO IR directly for several key reasons:
 
-- Custom Toolchain Development:
-  build custom compiler frontends or domain-specific languages (DSLs) that
-  target the Ascend 950 architecture with maximum hardware utilization.
-- Performance Engineering:
-  inspect the output of high-level compiler passes, verify fine-grained
-  optimization behaviors, and pinpoint performance bottlenecks at the
-  architectural level.
-- Micro-Optimization:
-  hand-author highly optimized, critical mathematical kernels using a stable,
-  precise IR when higher-level abstractions cannot achieve the theoretical peak
-  performance of the hardware.
+- Custom Toolchain Development: build custom compiler frontends or domain-specific languages (DSLs) that target the Ascend 950 architecture with maximum hardware utilization.
+- Performance Engineering: inspect the output of high-level compiler passes, verify fine-grained optimization behaviors, and pinpoint performance bottlenecks at the architectural level.
+- Micro-Optimization: hand-author highly optimized, critical mathematical kernels using a stable, precise IR when higher-level abstractions cannot achieve the theoretical peak performance of the hardware.
 
 #### Relationship to CCE
 
-VPTO is designed to express the full semantic capabilities of the Compute Cube
-Engine (CCE), but with significant structural and pipeline advantages for
-compiler development.
+VPTO is designed to express the full semantic capabilities of the Compute Cube Engine (CCE), but with significant structural and pipeline advantages for compiler development.
 
-- Bypassing the C/Clang Pipeline:
-  while CCE heavily relies on C/C++ extensions parsed by Clang, VPTO operates
-  entirely independently of the C language frontend. By bypassing Clang AST
-  generation and frontend processing, utilizing VPTO significantly reduces
-  overall compilation time and memory overhead.
-- Enhanced IR Verification:
-  because VPTO is a strongly typed, SSA-based (Static Single Assignment)
-  compiler IR rather than a C-wrapper API, it provides a much more rigorous and
-  detailed IR verification process. Structural inconsistencies, invalid memory
-  access patterns, and operand type mismatches are caught immediately with
-  precise, explicit diagnostic feedback, providing developers with much higher
-  visibility into kernel correctness than traditional CCE error reporting.
+- Bypassing the C/Clang Pipeline: while CCE heavily relies on C/C++ extensions parsed by Clang, VPTO operates entirely independently of the C language frontend. By bypassing Clang AST generation and frontend processing, utilizing VPTO significantly reduces overall compilation time and memory overhead.
+- Enhanced IR Verification: because VPTO is a strongly typed, SSA-based (Static Single Assignment) compiler IR rather than a C-wrapper API, it provides a much more rigorous and detailed IR verification process. Structural inconsistencies, invalid memory access patterns, and operand type mismatches are caught immediately with precise, explicit diagnostic feedback, providing developers with much higher visibility into kernel correctness than traditional CCE error reporting.
 
 #### Intended Audience
 
-This document is written for compiler engineers, library writers, and advanced
-performance architects. We expect the reader to have a working understanding of
-modern compiler infrastructure, specifically MLIR, the principles of Static
-Single Assignment (SSA) form, and a deep understanding of the vector-processing
-capabilities of the Ascend 950 architecture.
+This document is written for compiler engineers, library writers, and advanced performance architects. We expect the reader to have a working understanding of modern compiler infrastructure, specifically MLIR, the principles of Static Single Assignment (SSA) form, and a deep understanding of the vector-processing capabilities of the Ascend 950 architecture.
 
 ### Getting Started
 
@@ -193,38 +155,22 @@ In ZEROING mode, inactive lanes produce zero. This is the native hardware predic
 
 #### Execution Scopes (__VEC_SCOPE__)
 
-`__VEC_SCOPE__` is the IR-level representation of a Vector Function (VF)
-launch. In the PTO architecture, it defines the hardware interface between the
-Scalar Unit and the Vector Thread.
+`__VEC_SCOPE__` is the IR-level representation of a Vector Function (VF) launch. In the PTO architecture, it defines the hardware interface between the Scalar Unit and the Vector Thread.
 
-It is not a dedicated `pto` op. In VPTO IR, this scope is modeled as a
-specialized `scf.for` loop annotated with `llvm.loop.aivector_scope`. This
-gives the compiler a natural structural boundary for identifying the code block
-that must be lowered into a discrete VF hardware instruction sequence.
+It is not a dedicated `pto` op. In VPTO IR, this scope is modeled as a specialized `scf.for` loop annotated with `llvm.loop.aivector_scope`. This gives the compiler a natural structural boundary for identifying the code block that must be lowered into a discrete VF hardware instruction sequence.
 
 **Scalar-Vector Interface:**
 
 The execution model follows non-blocking fork semantics:
 
-- Scalar invocation:
-  the scalar processor invokes a vector thread by calling a VF. Once the launch
-  command is issued, the scalar unit does not stall and continues executing
-  subsequent instructions in the pipeline.
-- Vector execution:
-  after invocation, the vector thread independently fetches and executes the
-  instructions defined within the VF scope.
-- Parallelism:
-  this decoupled execution allows the scalar and vector units to run in
-  parallel, so the scalar unit can prepare addresses or manage control flow
-  while the vector unit performs heavy SIMD computation.
+- Scalar invocation: the scalar processor invokes a vector thread by calling a VF. Once the launch command is issued, the scalar unit does not stall and continues executing subsequent instructions in the pipeline.
+- Vector execution: after invocation, the vector thread independently fetches and executes the instructions defined within the VF scope.
+- Parallelism: this decoupled execution allows the scalar and vector units to run in parallel, so the scalar unit can prepare addresses or manage control flow while the vector unit performs heavy SIMD computation.
 
 **Launch Mechanism And Constraints:**
 
-- Parameter buffering:
-  all arguments required by the VF must be staged in hardware-specific buffers.
-- Launch overhead:
-  launching a VF incurs a latency of a few cycles. Very small VFs should
-  account for this overhead because launch cost can rival useful computation time.
+- Parameter buffering: all arguments required by the VF must be staged in hardware-specific buffers.
+- Launch overhead: launching a VF incurs a latency of a few cycles. Very small VFs should account for this overhead because launch cost can rival useful computation time.
 
 **MLIR Representation:**
 
@@ -284,15 +230,10 @@ It does not describe lowering strategy.
 
 ### Core Types
 
-- `vreg<T>`: `!pto.vreg<NxT>`
-  Fixed-width VPTO vector type with total width exactly 256 bytes (2048 bits).
-  `N` is the lane count, `T` is the element type, and `N * bitwidth(T) = 2048`.
-- `mask`: `!pto.mask`
-  Models an A5 predicate register (256-bit). Per-lane enable/disable state.
-- `align`: `!pto.align`
-  Models the A5 vector-align carrier state for unaligned load/store sequences.
-- `buf`: `!llvm.ptr<AS>`
-  Buffer-like LLVM pointer type. AS=1 for GM, AS=6 for UB.
+- `vreg<T>`: `!pto.vreg<NxT>` Fixed-width VPTO vector type with total width exactly 256 bytes (2048 bits). `N` is the lane count, `T` is the element type, and `N * bitwidth(T) = 2048`.
+- `mask`: `!pto.mask` Models an A5 predicate register (256-bit). Per-lane enable/disable state.
+- `align`: `!pto.align` Models the A5 vector-align carrier state for unaligned load/store sequences.
+- `buf`: `!llvm.ptr<AS>` Buffer-like LLVM pointer type. AS=1 for GM, AS=6 for UB.
 - `idx`: `index`
 - `i32`: `i32`
 - `i64`: `i64`
@@ -315,10 +256,14 @@ It does not describe lowering strategy.
 
 | Type | Bits | Description |
 |------|------|-------------|
-| `i8` / `u8` | 8 | Signed/unsigned 8-bit integer |
-| `i16` / `u16` | 16 | Signed/unsigned 16-bit integer |
-| `i32` / `u32` | 32 | Signed/unsigned 32-bit integer |
-| `i64` / `u64` | 64 | Signed/unsigned 64-bit integer |
+| `s8` / `u8` | 8 | Signed/unsigned 8-bit integer |
+| `i8` | 8 | Signless 8-bit integer |
+| `s16` / `u16` | 16 | Signed/unsigned 16-bit integer |
+| `i16` | 16 | Signless 16-bit integer |
+| `s32` / `u32` | 32 | Signed/unsigned 32-bit integer |
+| `i32` | 32 | Signless 32-bit integer |
+| `s64` / `u64` | 64 | Signed/unsigned 64-bit integer |
+| `i64` | 64 | Signless 64-bit integer |
 | `f16` | 16 | IEEE 754 half precision |
 | `bf16` | 16 | Brain floating point |
 | `f32` | 32 | IEEE 754 single precision |
@@ -336,21 +281,6 @@ Valid `!pto.vreg<NxT>` configurations: `N * bitwidth(T) = 2048`
 
 `!pto.mask` models an A5 predicate register, not an integer vector.
 
-- producers:
-  `pto.vpset_b8`, `pto.vpset_b16`, `pto.vpset_b32`,
-  `pto.vpge_b8`, `pto.vpge_b16`, `pto.vpge_b32`,
-  `pto.vplds`, `pto.vpld`, `pto.vpldi`,
-  `pto.vcmp`, `pto.vcmps`
-- consumers:
-  `pto.vsel`,
-  `pto.vaddc`, `pto.vsubc`, `pto.vaddcs`, `pto.vsubcs`,
-  `pto.vpnot`, `pto.vpsel`,
-  `pto.vgather2_bc`,
-  `pto.vstx2`, `pto.vsstb`,
-  `pto.vpsts`, `pto.vpst`, `pto.vpsti`,
-  `pto.vpstu`,
-  `pto.vmula`
-
 ```mlir
 %mask = pto.vcmp %lhs, %rhs, %seed, "lt" : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.mask
 %out = pto.vsel %x, %y, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
@@ -360,65 +290,10 @@ Valid `!pto.vreg<NxT>` configurations: `N * bitwidth(T) = 2048`
 
 `!pto.align` models the A5 vector-align carrier state. It is not payload data.
 
-- producers: `pto.vldas`, `pto.vpstu`, `pto.vstu`, `pto.vstus`, `pto.vstur`
-- consumers: `pto.vldus`, `pto.vsta`, `pto.vstas`, `pto.vstar`, `pto.vpstu`, `pto.vstu`, `pto.vstus`, `pto.vstur`
-
 ```mlir
 %align = pto.vldas %ub[%c0] : !llvm.ptr<6> -> !pto.align
 %vec = pto.vldus %align, %ub[%c64] : !pto.align, !llvm.ptr<6> -> !pto.vreg<64xf32>
 ```
-
-### Implemented String Constraints
-
-#### Predicate Patterns
-
-Used by `pto.vpset_b*`, `pto.vpge_b*`:
-`PAT_ALL | PAT_VL1 | PAT_VL2 | PAT_VL3 | PAT_VL4 | PAT_VL8 | PAT_VL16 | PAT_VL32 | PAT_VL64 | PAT_VL128 | PAT_M3 | PAT_M4 | PAT_H | PAT_Q | PAT_ALLF`
-
-#### Distribution Tokens
-
-| Op | Allowed Values |
-|----|---------------|
-| `pto.vlds` | `NORM \| BLK \| DINTLV_B32 \| UNPK_B16 \| BRC_B8 \| BRC_B16 \| BRC_B32 \| US_B8 \| US_B16 \| DS_B8 \| DS_B16 \| SPLT4CHN_B8 \| SPLT2CHN_B8 \| SPLT2CHN_B16 \| UNPK_B8 \| UNPK_B32` |
-| `pto.vpld`, `pto.vpldi` | `NORM \| US \| DS` |
-| `pto.vpst`, `pto.vpsti` | `NORM \| PK` |
-| `pto.vldx2` | `DINTLV_B8 \| DINTLV_B16 \| DINTLV_B32 \| BDINTLV` |
-| `pto.vstx2` | `INTLV_B8 \| INTLV_B16 \| INTLV_B32` |
-| `pto.vsts` | `NORM_B8 \| NORM_B16 \| NORM_B32 \| PK_B16 \| PK_B32 \| MRG4CHN_B8 \| MRG2CHN_B8 \| MRG2CHN_B16` |
-
-#### Stride Tokens
-
-Used by `pto.vsld`, `pto.vsst`:
-`STRIDE_S3_B16 | STRIDE_S4_B64 | STRIDE_S8_B32 | STRIDE_S2_B64 | STRIDE_VSST_S8_B16`
-
-#### Compare Modes
-
-Used by `pto.vcmp`, `pto.vcmps`:
-`eq | ne | lt | le | gt | ge`
-
-#### Part Tokens
-
-Used by `pto.vppack`, `pto.vpunpack`:
-`LOWER | HIGHER`
-
-#### Mode Tokens
-
-Used by `pto.vmula`:
-`MODE_ZEROING | MODE_UNKNOWN | MODE_MERGING`
-
-Used by `pto.vstu`, `pto.vstus`, `pto.vstur`:
-`POST_UPDATE | NO_POST_UPDATE`
-
-#### Conversion Control Tokens
-
-- Round mode (`pto.vcvt`): `ROUND_R | ROUND_A | ROUND_F | ROUND_C | ROUND_Z | ROUND_O`
-- Saturation (`pto.vcvt`): `RS_ENABLE | RS_DISABLE`
-- Part (`pto.vcvt`): `PART_EVEN | PART_ODD`
-
-#### Memory Barrier Types
-
-Used by `pto.mem_bar`:
-`VV_ALL | VST_VLD | VLD_VST`
 
 ### Correspondence Categories
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -230,13 +230,20 @@ It does not describe lowering strategy.
 
 ### Core Types
 
-- `vreg<T>`: `!pto.vreg<NxT>` Fixed-width VPTO vector type with total width exactly 256 bytes (2048 bits). `N` is the lane count, `T` is the element type, and `N * bitwidth(T) = 2048`.
-- `mask`: `!pto.mask` Models an A5 predicate register (256-bit). Per-lane enable/disable state.
-- `align`: `!pto.align` Models the A5 vector-align carrier state for unaligned load/store sequences.
-- `buf`: `!llvm.ptr<AS>` Buffer-like LLVM pointer type. AS=1 for GM, AS=6 for UB.
-- `idx`: `index`
-- `i32`: `i32`
-- `i64`: `i64`
+### Element Types
+`vreg<T>`: `!pto.vreg<NxT>` Fixed-width VPTO vector type with total width exactly 256 bytes (2048 bits). `N` is the lane count, `T` is the element type, and `N * bitwidth(T) = 2048`.
+
+| Type | Bits | Description |
+|------|------|-------------|
+| `i8` / `s8` / `u8` | 8 | Signless/signed/unsigned 8-bit integer |
+| `i16` / `s16` / `u16` | 16 | Signless/signed/unsigned 16-bit integer |
+| `i32` / `s32` / `u32` | 32 | Signless/signed/unsigned 32-bit integer |
+| `i64` / `s64` / `u64` | 64 | Signless/signed/unsigned 64-bit integer |
+| `f16` | 16 | IEEE 754 half precision |
+| `bf16` | 16 | Brain floating point |
+| `f32` | 32 | IEEE 754 single precision |
+| `f8e4m3` | 8 | FP8 (4-bit exponent, 3-bit mantissa) |
+| `f8e5m2` | 8 | FP8 (5-bit exponent, 2-bit mantissa) |
 
 ### Address Space Conventions
 
@@ -252,28 +259,6 @@ It does not describe lowering strategy.
 | `7` | `BIAS` | Bias buffer |
 | `8` | `SCALING` | Scaling buffer |
 
-### Element Type Constraints
-
-| Type | Bits | Description |
-|------|------|-------------|
-| `s8` / `u8` | 8 | Signed/unsigned 8-bit integer |
-| `i8` | 8 | Signless 8-bit integer |
-| `s16` / `u16` | 16 | Signed/unsigned 16-bit integer |
-| `i16` | 16 | Signless 16-bit integer |
-| `s32` / `u32` | 32 | Signed/unsigned 32-bit integer |
-| `i32` | 32 | Signless 32-bit integer |
-| `s64` / `u64` | 64 | Signed/unsigned 64-bit integer |
-| `i64` | 64 | Signless 64-bit integer |
-| `f16` | 16 | IEEE 754 half precision |
-| `bf16` | 16 | Brain floating point |
-| `f32` | 32 | IEEE 754 single precision |
-| `f8e4m3` | 8 | FP8 (4-bit exponent, 3-bit mantissa) |
-| `f8e5m2` | 8 | FP8 (5-bit exponent, 2-bit mantissa) |
-| `f8e8m0` | 8 | FP8 scale factor (8-bit exponent only) |
-| `f4e2m1` | 4 | FP4 (2-bit exponent, 1-bit mantissa) |
-| `f4e1m2` | 4 | FP4 (1-bit exponent, 2-bit mantissa) |
-
-Valid `!pto.vreg<NxT>` configurations: `N * bitwidth(T) = 2048`
 
 ### Special Types
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -228,11 +228,11 @@ It only describes:
 
 It does not describe lowering strategy.
 
-VPTO source programs are not restricted to `pto` operations alone. In practice they also use a small set of shared MLIR dialect ops, most notably `arith` and `scf`, to express scalar constants, scalar/index arithmetic, comparisons, and structured control flow around PTO vector or tile regions. These shared-dialect ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and generally do not map to CCE builtins directly.
+VPTO source programs are not restricted to `pto` operations alone. In practice they also use shared MLIR dialect ops, most notably the full scalar operation surface of `arith` together with structured control-flow ops from `scf`, to express scalar constants, scalar arithmetic, type conversion, comparisons, and structured control flow around PTO vector or tile regions. These shared-dialect ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and generally do not map to CCE builtins directly.
 
 ### Shared MLIR Dialects
 
-- `arith`: primitive scalar and index operations used to build constants, compute offsets and bounds, cast between index and integer types, compare scalar values, and select between scalar results.
+- `arith`: the full scalar `arith` surface is supported in VPTO programs, covering scalar integer, floating-point, boolean, and `index` operations. In current samples the most common uses are still constants, offset/bounds arithmetic, casts, compares, and selects.
 - `scf`: structured control flow used to model counted loops, conditional regions, loop-carried state, and break-like control around PTO compute and data-movement ops.
 - Shared dialect ops remain in standard MLIR form so that PTO analyses and backend passes can reason about control flow and scalar state without re-encoding them as PTO-specific instructions.
 
@@ -375,12 +375,21 @@ pto.mem_bar "VV_ALL"
 ### Shared Dialect Syntax Patterns
 
 VPTO programs may interleave PTO ops with standard MLIR `arith` and `scf` ops.
+The examples below emphasize common index-heavy patterns, but `arith` support is not limited to index arithmetic.
 
 **Scalar / index constant:**
 
 ```mlir
 %c0 = arith.constant 0 : index
 %zero = arith.constant 0.0 : f32
+```
+
+**Scalar arithmetic (integer / float / boolean-style bitwise):**
+
+```mlir
+%sum_i = arith.addi %lhs_i, %rhs_i : i32
+%sum_f = arith.addf %lhs_f, %rhs_f : f32
+%bits = arith.andi %flags0, %flags1 : i32
 ```
 
 **Scalar compare and select:**
@@ -505,7 +514,7 @@ This section provides a categorized overview of all VPTO instructions plus the s
 | 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` |
 | 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 11 | `pto.vintlv`, `pto.vdintlv`, `pto.vslide`, `pto.vshift`, `pto.vsqz`, `pto.vusqz`, `pto.vperm`, `pto.vpack`, `pto.vsunpack`, `pto.vzunpack`, `pto.vselr` |
 | 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Fused ops, special functions, UB-to-UB, sorting | ~12 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vci`, `pto.vtranspose`, `pto.vsort32`, `pto.vmrgsort`, etc. |
-| 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Scalar constants, scalar/index arithmetic, compares, casts, and selects used around PTO ops | ~12 | `arith.constant`, `arith.addi`, `arith.subi`, `arith.muli`, `arith.cmpi`, `arith.select`, `arith.index_cast`, `arith.index_castui`, `arith.andi`, `arith.xori`, `arith.remui`, `arith.ceildivsi` |
+| 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
 ---
@@ -555,12 +564,16 @@ This section provides a categorized overview of all VPTO instructions plus the s
 
 ### Scalar & Control Operations
 
+Group 14 covers the full scalar `arith` surface. The rows below list common VPTO patterns rather than an exhaustive partition of `arith` ops.
+
 | Operation | Group | Description |
 |-----------|-------|-------------|
-| Scalar / Index Constants | 14 | `arith.constant` |
-| Scalar Compare & Select | 14 | `arith.cmpi`, `arith.select` |
-| Scalar / Index Arithmetic | 14 | `arith.addi`, `arith.subi`, `arith.muli`, `arith.remui`, `arith.ceildivsi` |
-| Casts Between Index and Integer | 14 | `arith.index_cast`, `arith.index_castui` |
+| Scalar Constants | 14 | `arith.constant` |
+| Scalar Integer / Index Arithmetic | 14 | `arith.addi`, `arith.subi`, `arith.muli`, `arith.divsi`, `arith.remui`, `arith.ceildivsi`, etc. |
+| Scalar Floating-Point Arithmetic | 14 | `arith.addf`, `arith.subf`, `arith.mulf`, `arith.divf`, `arith.maximumf`, etc. |
+| Scalar Compare & Select | 14 | `arith.cmpi`, `arith.cmpf`, `arith.select` |
+| Scalar Casts / Width Changes | 14 | `arith.index_cast`, `arith.index_castui`, `arith.extsi`, `arith.extui`, `arith.trunci`, `arith.sitofp`, etc. |
+| Scalar Bitwise / Shift Ops | 14 | `arith.andi`, `arith.ori`, `arith.xori`, `arith.shli`, `arith.shrsi`, `arith.shrui`, etc. |
 | Counted Loops | 15 | `scf.for` |
 | Conditional Regions | 15 | `scf.if`, `scf.yield` |
 | Break-like Structured Loops | 15 | `scf.while`, `scf.condition`, `scf.yield` |

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -223,12 +223,11 @@ It only describes:
 - operand and result lists
 - operand and result types
 - important attributes
-- corresponding CCE builtin or CCE wrapper family, when applicable
 - C-style semantics for each operation
 
 It does not describe lowering strategy.
 
-VPTO source programs are not restricted to `pto` operations alone. In practice they also use shared MLIR dialect ops, most notably the full scalar operation surface of `arith` together with structured control-flow ops from `scf`, to express scalar constants, scalar arithmetic, type conversion, comparisons, and structured control flow around PTO vector or tile regions. These shared-dialect ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and generally do not map to CCE builtins directly.
+VPTO source programs are not restricted to `pto` operations alone. In practice they also use shared MLIR dialect ops, most notably the full scalar operation surface of `arith` together with structured control-flow ops from `scf`, to express scalar constants, scalar arithmetic, type conversion, comparisons, and structured control flow around PTO vector or tile regions. These shared-dialect ops are part of the supported VPTO source surface and should be regarded as part of PTO-ISA alongside `pto` dialect operations.
 
 ### Shared MLIR Dialects
 
@@ -287,11 +286,6 @@ VPTO source programs are not restricted to `pto` operations alone. In practice t
 %align = pto.vldas %ub[%c0] : !llvm.ptr<6> -> !pto.align
 %vec = pto.vldus %align, %ub[%c64] : !pto.align, !llvm.ptr<6> -> !pto.vreg<64xf32>
 ```
-
-### Correspondence Categories
-
-- `direct builtin`: maps to one CCE builtin family (`__builtin_cce_*`)
-- `wrapper family`: corresponds to a CCE wrapper that may dispatch to multiple builtins
 
 ---
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -215,7 +215,7 @@ pto.copy_ubuf_to_gm %8, %14, %3, %3, %c0_i64, %c32_i64, %4, %c0_i64, %c128_i64, 
 
 ### Scope
 
-This document is the interface specification for the `mlir::pto` dialect.
+This document is the interface specification centered on the `mlir::pto` dialect and the shared MLIR surface used alongside it in VPTO programs.
 
 It only describes:
 
@@ -223,10 +223,18 @@ It only describes:
 - operand and result lists
 - operand and result types
 - important attributes
-- corresponding CCE builtin or CCE wrapper family
+- corresponding CCE builtin or CCE wrapper family, when applicable
 - C-style semantics for each operation
 
 It does not describe lowering strategy.
+
+VPTO source programs are not restricted to `pto` operations alone. In practice they also use a small set of shared MLIR dialect ops, most notably `arith` and `scf`, to express scalar constants, scalar/index arithmetic, comparisons, and structured control flow around PTO vector or tile regions. These shared-dialect ops are part of the supported VPTO source surface, but they are not PTO ISA instructions and generally do not map to CCE builtins directly.
+
+### Shared MLIR Dialects
+
+- `arith`: primitive scalar and index operations used to build constants, compute offsets and bounds, cast between index and integer types, compare scalar values, and select between scalar results.
+- `scf`: structured control flow used to model counted loops, conditional regions, loop-carried state, and break-like control around PTO compute and data-movement ops.
+- Shared dialect ops remain in standard MLIR form so that PTO analyses and backend passes can reason about control flow and scalar state without re-encoding them as PTO-specific instructions.
 
 ### Core Types
 
@@ -364,6 +372,57 @@ pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 pto.mem_bar "VV_ALL"
 ```
 
+### Shared Dialect Syntax Patterns
+
+VPTO programs may interleave PTO ops with standard MLIR `arith` and `scf` ops.
+
+**Scalar / index constant:**
+
+```mlir
+%c0 = arith.constant 0 : index
+%zero = arith.constant 0.0 : f32
+```
+
+**Scalar compare and select:**
+
+```mlir
+%cond = arith.cmpi eq, %lhs, %rhs : index
+%bound = arith.select %cond, %a, %b : index
+```
+
+**Counted loop with loop-carried values:**
+
+```mlir
+%result = scf.for %iv = %lb to %ub step %step
+    iter_args(%acc = %init) -> (index) {
+  %next = arith.addi %acc, %iv : index
+  scf.yield %next : index
+}
+```
+
+**Structured conditional region:**
+
+```mlir
+%selected = scf.if %cond -> (index) {
+  scf.yield %then_value : index
+} else {
+  scf.yield %else_value : index
+}
+```
+
+**Structured while loop:**
+
+```mlir
+%state:2 = scf.while (%iv = %c0, %alive = %true) : (index, i1) -> (index, i1) {
+  %keep_going = arith.cmpi slt, %iv, %limit : index
+  scf.condition(%keep_going) %iv, %alive : index, i1
+} do {
+^bb0(%iv_in: index, %alive_in: i1):
+  %iv_next = arith.addi %iv_in, %c1 : index
+  scf.yield %iv_next, %alive_in : index, i1
+}
+```
+
 ### C-Style Semantics Convention
 
 For each ISA operation in Part III, semantics are expressed as C code. The convention:
@@ -410,7 +469,7 @@ for (int g = 0; g < 8; g++) {
 |-------------|---------|
 | `"SRC_PIPE"`, `"DST_PIPE"` | Pipeline identifiers: `"PIPE_MTE2"`, `"PIPE_V"`, `"PIPE_MTE3"` |
 | `"EVENT_ID"` | Event identifier: `"EVENT_ID0"` etc. |
-| `"DIST"` | Distribution mode string (see String Constraints in Part I) |
+| `"DIST"` | Distribution mode string (see the relevant load/store ISA group in Part III) |
 | `"CMP_MODE"` | Compare predicate: `eq \| ne \| lt \| le \| gt \| ge` |
 | `"ROUND_MODE"` | Rounding mode: `ROUND_R \| ROUND_A \| ROUND_F \| ROUND_C \| ROUND_Z` |
 | `"SAT_MODE"` | Saturation: `RS_ENABLE \| RS_DISABLE` |
@@ -425,7 +484,7 @@ for (int g = 0; g < 8; g++) {
 ## Part III: ISA Instruction Reference
 # Part III: ISA Instruction Reference — Summary
 
-This section provides a categorized overview of all VPTO instructions. Detailed documentation for each group is available in the linked files.
+This section provides a categorized overview of all VPTO instructions plus the shared MLIR `arith` and `scf` ops that may appear in VPTO programs. Detailed documentation for each group is available in the linked files.
 
 ---
 
@@ -446,6 +505,8 @@ This section provides a categorized overview of all VPTO instructions. Detailed 
 | 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` |
 | 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 11 | `pto.vintlv`, `pto.vdintlv`, `pto.vslide`, `pto.vshift`, `pto.vsqz`, `pto.vusqz`, `pto.vperm`, `pto.vpack`, `pto.vsunpack`, `pto.vzunpack`, `pto.vselr` |
 | 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Fused ops, special functions, UB-to-UB, sorting | ~12 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vci`, `pto.vtranspose`, `pto.vsort32`, `pto.vmrgsort`, etc. |
+| 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Scalar constants, scalar/index arithmetic, compares, casts, and selects used around PTO ops | ~12 | `arith.constant`, `arith.addi`, `arith.subi`, `arith.muli`, `arith.cmpi`, `arith.select`, `arith.index_cast`, `arith.index_castui`, `arith.andi`, `arith.xori`, `arith.remui`, `arith.ceildivsi` |
+| 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
 ---
 
@@ -491,6 +552,18 @@ This section provides a categorized overview of all VPTO instructions. Detailed 
 | Intra-core Sync | 1 | `pto.set_flag`, `pto.wait_flag` |
 | Inter-core Sync | 1 | `pto.set_cross_core`, `pto.wait_flag_dev` |
 | Memory Barrier | 1 | `pto.mem_bar` |
+
+### Scalar & Control Operations
+
+| Operation | Group | Description |
+|-----------|-------|-------------|
+| Scalar / Index Constants | 14 | `arith.constant` |
+| Scalar Compare & Select | 14 | `arith.cmpi`, `arith.select` |
+| Scalar / Index Arithmetic | 14 | `arith.addi`, `arith.subi`, `arith.muli`, `arith.remui`, `arith.ceildivsi` |
+| Casts Between Index and Integer | 14 | `arith.index_cast`, `arith.index_castui` |
+| Counted Loops | 15 | `scf.for` |
+| Conditional Regions | 15 | `scf.if`, `scf.yield` |
+| Break-like Structured Loops | 15 | `scf.while`, `scf.condition`, `scf.yield` |
 
 ---
 


### PR DESCRIPTION
## Summary
- reorganize the VPTO element type section in `docs/vpto-spec.md`
- document shared `arith` and `scf` dialect support in the main VPTO spec
- add ISA reference pages for shared `arith` and `scf` ops under `docs/isa/`
- clarify that VPTO supports the full scalar `arith` surface rather than only index-heavy usage patterns
- remove CCE mapping-oriented wording from the spec section and treat shared dialects as part of PTO-ISA

## Validation
- not run (documentation-only change)
