### PR TITLE
Refresh VPTO ISA docs for current operand syntax

### DIFF
--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -135,8 +135,9 @@ pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 
 scf.for %dummy = %c0 to %c1 step %c1 {
   %v   = pto.vlds %ub_ptr[%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-  %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-  pto.vsts %abs, %ub_out[%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+  %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
+  %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+  pto.vsts %abs, %ub_out[%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 } {llvm.loop.aivector_scope}
 
 // Vector signals: "UB output is ready for MTE3"
@@ -160,34 +161,35 @@ Instead of naming events, each pipeline declares when it **acquires** (`get_buf`
 ```mlir
 // ─── Stage 1: MTE2 loads data into UB ───
 // MTE2 acquires ub_ptr — blocks if Vector hasn't released it from a prior iteration
-pto.get_buf %bufid_ub_ptr, "PIPE_MTE2"
+pto.get_buf "PIPE_MTE2", %bufid_ub_ptr, %mode : i64, i64
 pto.copy_gm_to_ubuf %gm_ptr, %ub_ptr, ...
 // MTE2 done writing ub_ptr — release it so Vector can consume
-pto.rls_buf %bufid_ub_ptr, "PIPE_MTE2"
+pto.rls_buf "PIPE_MTE2", %bufid_ub_ptr, %mode : i64, i64
 
 // ─── Stage 2: Vector computation ───
 // Vector acquires ub_ptr (input) — blocks until MTE2 releases it (RAW: MTE2 write → V read)
-pto.get_buf %bufid_ub_ptr, "PIPE_V"
+pto.get_buf "PIPE_V", %bufid_ub_ptr, %mode : i64, i64
 // Vector acquires ub_out (output) — blocks until MTE3 releases it from a prior iteration (WAR: MTE3 read → V write)
-pto.get_buf %bufid_ub_out, "PIPE_V"
+pto.get_buf "PIPE_V", %bufid_ub_out, %mode : i64, i64
 
 scf.for %dummy = %c0 to %c1 step %c1 {
+  %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
   %v   = pto.vlds %ub_ptr[%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-  %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-  pto.vsts %abs, %ub_out[%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+  %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+  pto.vsts %abs, %ub_out[%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 } {llvm.loop.aivector_scope}
 
 // Vector done reading ub_ptr — release so MTE2 can reuse it in next iteration
-pto.rls_buf %bufid_ub_ptr, "PIPE_V"
+pto.rls_buf "PIPE_V", %bufid_ub_ptr, %mode : i64, i64
 // Vector done writing ub_out — release so MTE3 can consume
-pto.rls_buf %bufid_ub_out, "PIPE_V"
+pto.rls_buf "PIPE_V", %bufid_ub_out, %mode : i64, i64
 
 // ─── Stage 3: MTE3 stores result to GM ───
 // MTE3 acquires ub_out — blocks until Vector releases it (RAW: V write → MTE3 read)
-pto.get_buf %bufid_ub_out, "PIPE_MTE3"
+pto.get_buf "PIPE_MTE3", %bufid_ub_out, %mode : i64, i64
 pto.copy_ubuf_to_gm %ub_out, %gm_out, ...
 // MTE3 done reading ub_out — release so Vector can reuse it in next iteration
-pto.rls_buf %bufid_ub_out, "PIPE_MTE3"
+pto.rls_buf "PIPE_MTE3", %bufid_ub_out, %mode : i64, i64
 ```
 
 **Key property:** No event IDs needed. Dependencies are implicit from program order of `get_buf`/`rls_buf` on the same buffer ID. This becomes much more convenient in multi-iteration loops (see Example 3).
@@ -249,8 +251,9 @@ scf.for %i = %c0 to %N step %c1 {
   pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{pp}"]
   scf.for %dummy = %c0 to %c1 step %c1 {
     %v   = pto.vlds %ub_in[%pp][%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-    %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-    pto.vsts %abs, %ub_out[%pp][%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
+    %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+    pto.vsts %abs, %ub_out[%pp][%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
   } {llvm.loop.aivector_scope}
   // WAR: tell MTE2 "done reading buf_in[i%2]"
   pto.set_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_{pp}"]
@@ -300,8 +303,9 @@ scf.for %i = %c0 to %N step %c1 {
   pto.get_buf %bufid_out[%pp], "PIPE_V"
   scf.for %dummy = %c0 to %c1 step %c1 {
     %v   = pto.vlds %ub_buf[%pp][%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-    %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-    pto.vsts %abs, %ub_out[%pp][%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
+    %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+    pto.vsts %abs, %ub_out[%pp][%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
   } {llvm.loop.aivector_scope}
   // Release buf[i%2] — MTE2 can reuse in iteration i+2 (WAR resolved)
   pto.rls_buf %bufid_buf[%pp], "PIPE_V"

--- a/docs/isa/02-dma-copy.md
+++ b/docs/isa/02-dma-copy.md
@@ -137,10 +137,11 @@ set_loop1_stride_ubtoout(gm_dst_stride << 21 | ub_src_stride);
 
 - **syntax:**
 ```mlir
-pto.copy_gm_to_ubuf %gm_src, %ub_dst, %sid, %n_burst, %len_burst,
-    %left_padding, %right_padding, %l2_cache_ctl, %gm_src_stride, %ub_dst_stride
-    {layout = "LAYOUT", data_select_bit = true|false, ub_pad = true|false}
-    : !pto.ptr<T, gm>, !pto.ptr<T, ub>, i64 x8
+pto.copy_gm_to_ubuf %gm_src, %ub_dst, %valid_rows, %valid_cols,
+    %sid, %n_burst, %len_burst, %left_padding, %right_padding,
+    %data_select_bit, %l2_cache_ctl, %gm_src_stride, %ub_dst_stride
+    : !pto.ptr<T, gm>, !pto.ptr<T, ub>, i64, i64, i64, i64, i64,
+      i64, i64, i1, i64, i64, i64
 ```
 - **semantics:** DMA transfer from Global Memory (`!pto.ptr<T, gm>`) to Unified Buffer (`!pto.ptr<T, ub>`).
 
@@ -150,22 +151,17 @@ pto.copy_gm_to_ubuf %gm_src, %ub_dst, %sid, %n_burst, %len_burst,
 |-----------|-------------|
 | `%gm_src` | GM source pointer (`!pto.ptr<T, gm>`) |
 | `%ub_dst` | UB destination pointer (`!pto.ptr<T, ub>`, 32B-aligned) |
+| `%valid_rows` | Valid row count |
+| `%valid_cols` | Valid column count |
 | `%sid` | Stream ID (usually 0) |
 | `%n_burst` | Number of burst rows (innermost loop count) |
 | `%len_burst` | Contiguous bytes transferred per burst row |
 | `%left_padding` | Left padding count (bytes) |
 | `%right_padding` | Right padding count (bytes) |
+| `%data_select_bit` | Padding / data-select control bit (`i1`) |
 | `%l2_cache_ctl` | L2 cache allocate control (TBD — controls whether DMA allocates in L2 cache) |
 | `%gm_src_stride` | GM source stride: start-to-start distance between consecutive burst rows (bytes) |
 | `%ub_dst_stride` | UB destination stride: start-to-start distance between consecutive burst rows (bytes, 32B-aligned) |
-
-**Attributes:**
-
-| Attribute | Values | Description |
-|-----------|--------|-------------|
-| `layout` | `"nd"` | Data layout |
-| `data_select_bit` | `true`/`false` | Enable padding fill |
-| `ub_pad` | `true`/`false` | Enable UB padding |
 
 ---
 
@@ -173,10 +169,9 @@ pto.copy_gm_to_ubuf %gm_src, %ub_dst, %sid, %n_burst, %len_burst,
 
 - **syntax:**
 ```mlir
-pto.copy_ubuf_to_gm %ub_src, %gm_dst, %sid, %n_burst, %len_burst,
-    %reserved, %gm_dst_stride, %ub_src_stride
-    {layout = "LAYOUT"}
-    : !pto.ptr<T, ub>, !pto.ptr<T, gm>, i64 x6
+pto.copy_ubuf_to_gm %ub_src, %gm_dst, %valid_rows, %valid_cols,
+    %sid, %n_burst, %len_burst, %reserved, %gm_dst_stride, %ub_src_stride
+    : !pto.ptr<T, ub>, !pto.ptr<T, gm>, i64, i64, i64, i64, i64, i64, i64, i64
 ```
 - **semantics:** DMA transfer from Unified Buffer (`!pto.ptr<T, ub>`) to Global Memory (`!pto.ptr<T, gm>`). MTE3 reads only `len_burst` bytes from each UB row (de-padding).
 
@@ -186,6 +181,8 @@ pto.copy_ubuf_to_gm %ub_src, %gm_dst, %sid, %n_burst, %len_burst,
 |-----------|-------------|
 | `%ub_src` | UB source pointer (`!pto.ptr<T, ub>`, 32B-aligned) |
 | `%gm_dst` | GM destination pointer (`!pto.ptr<T, gm>`) |
+| `%valid_rows` | Valid row count |
+| `%valid_cols` | Valid column count |
 | `%sid` | Stream ID (usually 0) |
 | `%n_burst` | Number of burst rows |
 | `%len_burst` | Contiguous bytes transferred per burst row |

--- a/docs/isa/03-vector-load-store.md
+++ b/docs/isa/03-vector-load-store.md
@@ -42,20 +42,20 @@ Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Ve
 
 ### `pto.vldas`
 
-- **syntax:** `%result = pto.vldas %source[%offset] : !pto.ptr<T, ub> -> !pto.align`
+- **syntax:** `%result = pto.vldas %source : !pto.ptr<T, ub> -> !pto.align`
 - **semantics:** Prime alignment buffer for subsequent unaligned load.
 
 ---
 
 ### `pto.vldus`
 
-- **syntax:** `%result = pto.vldus %align, %source[%offset] : !pto.align, !pto.ptr<T, ub> -> !pto.vreg<NxT>`
+- **syntax:** `%result, %align_out, %base_out = pto.vldus %source, %align : !pto.ptr<T, ub>, !pto.align -> !pto.vreg<NxT>, !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Unaligned load using primed align state.
 
 **Unaligned load pattern:**
 ```mlir
-%align = pto.vldas %ub[%c0] : !pto.ptr<f32, ub> -> !pto.align
-%vec = pto.vldus %align, %ub[%c64] : !pto.align, !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+%align = pto.vldas %ub : !pto.ptr<f32, ub> -> !pto.align
+%vec, %align2, %ub2 = pto.vldus %ub, %align : !pto.ptr<f32, ub>, !pto.align -> !pto.vreg<64xf32>, !pto.align, !pto.ptr<f32, ub>
 ```
 
 ---
@@ -139,7 +139,7 @@ for (int i = 0; i < active_lanes; i++)
 
 ### `pto.vsts`
 
-- **syntax:** `pto.vsts %value, %dest[%offset] {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>`
+- **syntax:** `pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask`
 - **semantics:** Vector store with distribution mode.
 
 **Distribution modes:**
@@ -153,15 +153,8 @@ for (int i = 0; i < active_lanes; i++)
 
 **Example — Contiguous store:**
 ```mlir
-pto.vsts %v, %ub[%offset] {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 ```
-
----
-
-### `pto.vsts_pred`
-
-- **syntax:** `pto.vsts_pred %value, %dest[%offset], %active_lanes {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, index`
-- **semantics:** Predicated vector store.
 
 ---
 
@@ -246,7 +239,7 @@ These ops make reference-updated state explicit as SSA results.
 - **syntax:** `%align_out, %offset_out = pto.vstu %align_in, %offset_in, %value, %base, "MODE" : !pto.align, index, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align, index`
 - **semantics:** Unaligned store with align + offset state update.
 
-**Mode tokens:** `POST_UPDATE`, `NO_POST_UPDATE`
+**Mode tokens:** `π_UPDATE`, `NO_POST_UPDATE`
 
 ---
 

--- a/docs/isa/04-predicate-load-store.md
+++ b/docs/isa/04-predicate-load-store.md
@@ -9,67 +9,67 @@ Predicate registers (`!pto.mask`) are 256-bit registers that enable per-lane con
 
 ## Predicate Loads
 
-### `pto.vplds`
+### `pto.plds`
 
-- **syntax:** `%result = pto.vplds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.mask`
+- **syntax:** `%result = pto.plds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.mask`
 - **semantics:** Load predicate register with scalar offset.
 
 **Distribution modes:** `NORM`, `US`, `DS`
 
 **Example:**
 ```mlir
-%mask = pto.vplds %ub[%c0] {dist = "NORM"} : !pto.ptr<T, ub> -> !pto.mask
+%mask = pto.plds %ub[%c0] {dist = "NORM"} : !pto.ptr<T, ub> -> !pto.mask
 ```
 
 ---
 
-### `pto.vpld`
+### `pto.pld`
 
-- **syntax:** `%result = pto.vpld %source[%offset], "DIST" : !pto.ptr<T, ub>, index -> !pto.mask`
+- **syntax:** `%result = pto.pld %source[%offset], "DIST" : !pto.ptr<T, ub>, index -> !pto.mask`
 - **semantics:** Load predicate register with areg offset.
 
 ---
 
-### `pto.vpldi`
+### `pto.pldi`
 
-- **syntax:** `%result = pto.vpldi %source, %offset, "DIST" : !pto.ptr<T, ub>, i32 -> !pto.mask`
+- **syntax:** `%result = pto.pldi %source, %offset, "DIST" : !pto.ptr<T, ub>, i32 -> !pto.mask`
 - **semantics:** Load predicate register with immediate offset.
 
 ---
 
 ## Predicate Stores
 
-### `pto.vpsts`
+### `pto.psts`
 
-- **syntax:** `pto.vpsts %value, %dest[%offset] : !pto.mask, !pto.ptr<T, ub>`
+- **syntax:** `pto.psts %value, %dest[%offset] : !pto.mask, !pto.ptr<T, ub>`
 - **semantics:** Store predicate register with scalar offset.
 
 **Example:**
 ```mlir
-pto.vpsts %mask, %ub[%c0] : !pto.mask, !pto.ptr<T, ub>
+pto.psts %mask, %ub[%c0] : !pto.mask, !pto.ptr<T, ub>
 ```
 
 ---
 
-### `pto.vpst`
+### `pto.pst`
 
-- **syntax:** `pto.vpst %value, %dest[%offset], "DIST" : !pto.mask, !pto.ptr<T, ub>, index`
+- **syntax:** `pto.pst %value, %dest[%offset], "DIST" : !pto.mask, !pto.ptr<T, ub>, index`
 - **semantics:** Store predicate register with areg offset.
 
 **Distribution modes:** `NORM`, `PK`
 
 ---
 
-### `pto.vpsti`
+### `pto.psti`
 
-- **syntax:** `pto.vpsti %value, %dest, %offset, "DIST" : !pto.mask, !pto.ptr<T, ub>, i32`
+- **syntax:** `pto.psti %value, %dest, %offset, "DIST" : !pto.mask, !pto.ptr<T, ub>, i32`
 - **semantics:** Store predicate register with immediate offset.
 
 ---
 
-### `pto.vpstu`
+### `pto.pstu`
 
-- **syntax:** `%align_out, %base_out = pto.vpstu %align_in, %value, %base : !pto.align, !pto.mask, !pto.ptr<T, ub> -> !pto.align, !pto.ptr<T, ub>`
+- **syntax:** `%align_out, %base_out = pto.pstu %align_in, %value, %base : !pto.align, !pto.mask, !pto.ptr<T, ub> -> !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Predicate unaligned store with align state update.
 
 ---
@@ -81,12 +81,12 @@ pto.vpsts %mask, %ub[%c0] : !pto.mask, !pto.ptr<T, ub>
 %mask = pto.vcmp %v0, %v1, %seed, "lt" : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.mask
 
 // Store mask to UB for later use
-pto.vpsts %mask, %ub_mask[%c0] : !pto.mask, !pto.ptr<T, ub>
+pto.psts %mask, %ub_mask[%c0] : !pto.mask, !pto.ptr<T, ub>
 
 // ... later in another kernel ...
 
 // Load mask from UB
-%saved_mask = pto.vplds %ub_mask[%c0] {dist = "NORM"} : !pto.ptr<T, ub> -> !pto.mask
+%saved_mask = pto.plds %ub_mask[%c0] {dist = "NORM"} : !pto.ptr<T, ub> -> !pto.mask
 
 // Use for predicated select
 %result = pto.vsel %v_true, %v_false, %saved_mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>

--- a/docs/isa/05-materialization-predicate.md
+++ b/docs/isa/05-materialization-predicate.md
@@ -28,7 +28,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vdup`
 
-- **syntax:** `%result = pto.vdup %input {position = "POSITION", mode = "MODE"} : T|!pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vdup %input {position = "POSITION"} : T|!pto.vreg<NxT> -> !pto.vreg<NxT>`
 - **semantics:** Duplicate scalar or vector element to all lanes.
 
 ```c
@@ -38,23 +38,11 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vdupi`
-
-- **syntax:** `%result = pto.vdupi %imm : i32 -> !pto.vreg<NxT>`
-- **semantics:** Broadcast immediate constant to all lanes.
-
-```c
-for (int i = 0; i < N; i++)
-    dst[i] = (T)imm;
-```
-
----
-
 ## Predicate Generation
 
-### `pto.vpset_b8` / `pto.vpset_b16` / `pto.vpset_b32`
+### `pto.pset_b8` / `pto.pset_b16` / `pto.pset_b32`
 
-- **syntax:** `%result = pto.vpset_b32 "PAT_*" : !pto.mask`
+- **syntax:** `%result = pto.pset_b32 "PAT_*" : !pto.mask`
 - **semantics:** Generate predicate from pattern.
 
 **Patterns:**
@@ -70,19 +58,19 @@ for (int i = 0; i < N; i++)
 
 **Example — All 64 f32 lanes active:**
 ```mlir
-%all_active = pto.vpset_b32 "PAT_ALL" : !pto.mask
+%all_active = pto.pset_b32 "PAT_ALL" : !pto.mask
 ```
 
 **Example — First 16 lanes active:**
 ```mlir
-%first_16 = pto.vpset_b32 "PAT_VL16" : !pto.mask
+%first_16 = pto.pset_b32 "PAT_VL16" : !pto.mask
 ```
 
 ---
 
-### `pto.vpge_b8` / `pto.vpge_b16` / `pto.vpge_b32`
+### `pto.pge_b8` / `pto.pge_b16` / `pto.pge_b32`
 
-- **syntax:** `%result = pto.vpge_b32 "PAT_*" : !pto.mask`
+- **syntax:** `%result = pto.pge_b32 "PAT_*" : !pto.mask`
 - **semantics:** Generate tail mask — first N lanes active.
 
 ```c
@@ -92,34 +80,41 @@ for (int i = 0; i < TOTAL_LANES; i++)
 
 **Example — Tail mask for remainder loop:**
 ```mlir
-%tail_mask = pto.vpge_b32 "PAT_VL8" : !pto.mask
+%tail_mask = pto.pge_b32 "PAT_VL8" : !pto.mask
+
+---
+
+### `pto.plt_b8` / `pto.plt_b16` / `pto.plt_b32`
+
+- **syntax:** `%mask, %scalar_out = pto.plt_b32 %scalar : i32 -> !pto.mask, i32`
+- **semantics:** Generate predicate state together with updated scalar state.
 ```
 
 ---
 
 ## Predicate Pack/Unpack
 
-### `pto.vppack`
+### `pto.ppack`
 
-- **syntax:** `%result = pto.vppack %input, "PART" : !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.ppack %input, "PART" : !pto.mask -> !pto.mask`
 - **semantics:** Narrowing pack of predicate register.
 
 **Part tokens:** `LOWER`, `HIGHER`
 
 ---
 
-### `pto.vpunpack`
+### `pto.punpack`
 
-- **syntax:** `%result = pto.vpunpack %input, "PART" : !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.punpack %input, "PART" : !pto.mask -> !pto.mask`
 - **semantics:** Widening unpack of predicate register.
 
 ---
 
 ## Predicate Logical Ops
 
-### `pto.vpand`
+### `pto.pand`
 
-- **syntax:** `%result = pto.vpand %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.pand %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
 - **semantics:** Predicate bitwise AND.
 
 ```c
@@ -129,9 +124,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vpor`
+### `pto.por`
 
-- **syntax:** `%result = pto.vpor %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.por %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
 - **semantics:** Predicate bitwise OR.
 
 ```c
@@ -141,9 +136,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vpxor`
+### `pto.pxor`
 
-- **syntax:** `%result = pto.vpxor %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.pxor %src0, %src1, %mask : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
 - **semantics:** Predicate bitwise XOR.
 
 ```c
@@ -153,9 +148,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vpnot`
+### `pto.pnot`
 
-- **syntax:** `%result = pto.vpnot %input, %mask : !pto.mask, !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.pnot %input, %mask : !pto.mask, !pto.mask -> !pto.mask`
 - **semantics:** Predicate bitwise NOT.
 
 ```c
@@ -165,9 +160,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vpsel`
+### `pto.psel`
 
-- **syntax:** `%result = pto.vpsel %src0, %src1, %sel : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
+- **syntax:** `%result = pto.psel %src0, %src1, %sel : !pto.mask, !pto.mask, !pto.mask -> !pto.mask`
 - **semantics:** Predicate select (mux).
 
 ```c
@@ -179,10 +174,10 @@ for (int i = 0; i < N; i++)
 
 ## Predicate Movement
 
-### `pto.vpmov`
+### `pto.ppack`
 
-- **syntax:** `%result = pto.vpmov %src, %mask : !pto.mask, !pto.mask -> !pto.mask`
-- **semantics:** Predicate move (copy under mask).
+- **syntax:** `%result = pto.ppack %input, "PART" : !pto.mask -> !pto.mask`
+- **semantics:** Narrowing pack of predicate register.
 
 ```c
 for (int i = 0; i < N; i++)
@@ -191,24 +186,24 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vpintlv`
+### `pto.punpack`
 
-- **syntax:** `%low, %high = pto.vpintlv %src0, %src1 : !pto.mask, !pto.mask -> !pto.mask, !pto.mask`
-- **semantics:** Predicate interleave.
+- **syntax:** `%result = pto.punpack %input, "PART" : !pto.mask -> !pto.mask`
+- **semantics:** Widening unpack of predicate register.
 
 ---
 
-### `pto.vpdintlv`
+### `pto.pdintlv_b8`
 
-- **syntax:** `%low, %high = pto.vpdintlv %src0, %src1 : !pto.mask, !pto.mask -> !pto.mask, !pto.mask`
+- **syntax:** `%low, %high = pto.pdintlv_b8 %src0, %src1 : !pto.mask, !pto.mask -> !pto.mask, !pto.mask`
 - **semantics:** Predicate deinterleave.
 
 ---
 
-### `pto.vpslide`
+### `pto.pintlv_b16`
 
-- **syntax:** `%result = pto.vpslide %src0, %src1, %amt : !pto.mask, !pto.mask, i16 -> !pto.mask`
-- **semantics:** Predicate slide/shift.
+- **syntax:** `%low, %high = pto.pintlv_b16 %src0, %src1 : !pto.mask, !pto.mask -> !pto.mask, !pto.mask`
+- **semantics:** Predicate interleave.
 
 ---
 
@@ -216,16 +211,16 @@ for (int i = 0; i < N; i++)
 
 ```mlir
 // Generate all-active mask for f32 (64 lanes)
-%all = pto.vpset_b32 "PAT_ALL" : !pto.mask
+%all = pto.pset_b32 "PAT_ALL" : !pto.mask
 
 // Generate tail mask for remainder (last 12 elements)
-%tail = pto.vpge_b32 "PAT_VL12" : !pto.mask
+%tail = pto.pge_b32 "PAT_VL12" : !pto.mask
 
 // Compare and generate mask
 %cmp_mask = pto.vcmp %a, %b, %all, "lt" : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.mask
 
 // Combine masks: only process tail elements that passed comparison
-%combined = pto.vpand %cmp_mask, %tail, %all : !pto.mask, !pto.mask, !pto.mask -> !pto.mask
+%combined = pto.pand %cmp_mask, %tail, %all : !pto.mask, !pto.mask, !pto.mask -> !pto.mask
 
 // Use for predicated operation
 %result = pto.vsel %true_vals, %false_vals, %combined : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>

--- a/docs/isa/06-unary-vector-ops.md
+++ b/docs/isa/06-unary-vector-ops.md
@@ -11,7 +11,7 @@ Element-wise operations that take one vector input and produce one vector output
 
 ### `pto.vabs`
 
-- **syntax:** `%result = pto.vabs %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vabs %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, f32
 
 ```c
@@ -23,7 +23,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vneg`
 
-- **syntax:** `%result = pto.vneg %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vneg %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, f32
 
 ```c
@@ -37,7 +37,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vexp`
 
-- **syntax:** `%result = pto.vexp %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vexp %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -49,7 +49,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vln`
 
-- **syntax:** `%result = pto.vln %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vln %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -61,7 +61,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsqrt`
 
-- **syntax:** `%result = pto.vsqrt %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -73,7 +73,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrsqrt`
 
-- **syntax:** `%result = pto.vrsqrt %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -85,7 +85,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrec`
 
-- **syntax:** `%result = pto.vrec %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrec %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -99,7 +99,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrelu`
 
-- **syntax:** `%result = pto.vrelu %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrelu %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -113,7 +113,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vnot`
 
-- **syntax:** `%result = pto.vnot %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vnot %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -125,7 +125,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vbcnt`
 
-- **syntax:** `%result = pto.vbcnt %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vbcnt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -137,7 +137,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vcls`
 
-- **syntax:** `%result = pto.vcls %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcls %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -151,7 +151,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmov`
 
-- **syntax:** `%result = pto.vmov %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmov %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Vector register copy.
 
 ```c
@@ -165,12 +165,12 @@ for (int i = 0; i < N; i++)
 
 ```mlir
 // Softmax numerator: exp(x - max)
-%sub = pto.vsub %x, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-%exp = pto.vexp %sub : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%sub = pto.vsub %x, %max_broadcast, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+%exp = pto.vexp %sub, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Reciprocal for division
-%sum_rcp = pto.vrec %sum : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%sum_rcp = pto.vrec %sum, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // ReLU activation
-%activated = pto.vrelu %linear_out : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%activated = pto.vrelu %linear_out, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 ```

--- a/docs/isa/07-binary-vector-ops.md
+++ b/docs/isa/07-binary-vector-ops.md
@@ -11,7 +11,7 @@ Element-wise operations that take two vector inputs and produce one vector outpu
 
 ### `pto.vadd`
 
-- **syntax:** `%result = pto.vadd %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vadd %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i64, f16, bf16, f32
 
 ```c
@@ -23,7 +23,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsub`
 
-- **syntax:** `%result = pto.vsub %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsub %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i64, f16, bf16, f32
 
 ```c
@@ -35,7 +35,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmul`
 
-- **syntax:** `%result = pto.vmul %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmul %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, bf16, f32 (**NOT** i8/u8)
 
 ```c
@@ -47,7 +47,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vdiv`
 
-- **syntax:** `%result = pto.vdiv %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vdiv %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32 only (no integer division)
 
 ```c
@@ -59,7 +59,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmax`
 
-- **syntax:** `%result = pto.vmax %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmax %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, bf16, f32
 
 ```c
@@ -71,7 +71,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmin`
 
-- **syntax:** `%result = pto.vmin %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmin %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, bf16, f32
 
 ```c
@@ -85,7 +85,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vand`
 
-- **syntax:** `%result = pto.vand %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vand %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -97,7 +97,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vor`
 
-- **syntax:** `%result = pto.vor %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -109,7 +109,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vxor`
 
-- **syntax:** `%result = pto.vxor %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vxor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -123,7 +123,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshl`
 
-- **syntax:** `%result = pto.vshl %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshl %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -135,7 +135,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshr`
 
-- **syntax:** `%result = pto.vshr %lhs, %rhs : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshr %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -180,15 +180,15 @@ for (int i = 0; i < N; i++) {
 
 ```mlir
 // Vector addition
-%sum = pto.vadd %a, %b : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%sum = pto.vadd %a, %b, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Element-wise multiply
-%prod = pto.vmul %x, %y : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%prod = pto.vmul %x, %y, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Clamp to range [min, max]
-%clamped_low = pto.vmax %input, %min_vec : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-%clamped = pto.vmin %clamped_low, %max_vec : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%clamped_low = pto.vmax %input, %min_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+%clamped = pto.vmin %clamped_low, %max_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Bit manipulation
-%masked = pto.vand %data, %bitmask : !pto.vreg<64xi32>, !pto.vreg<64xi32> -> !pto.vreg<64xi32>
+%masked = pto.vand %data, %bitmask, %mask : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask -> !pto.vreg<64xi32>
 ```

--- a/docs/isa/08-vec-scalar-ops.md
+++ b/docs/isa/08-vec-scalar-ops.md
@@ -11,7 +11,7 @@ Operations that combine a vector with a scalar value, applying the scalar to eve
 
 ### `pto.vadds`
 
-- **syntax:** `%result = pto.vadds %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vadds %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -22,7 +22,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsubs`
 
-- **syntax:** `%result = pto.vsubs %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsubs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -33,7 +33,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmuls`
 
-- **syntax:** `%result = pto.vmuls %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmuls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -44,7 +44,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmaxs`
 
-- **syntax:** `%result = pto.vmaxs %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmaxs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -55,7 +55,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmins`
 
-- **syntax:** `%result = pto.vmins %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmins %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -68,7 +68,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vands`
 
-- **syntax:** `%result = pto.vands %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vands %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -79,7 +79,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vors`
 
-- **syntax:** `%result = pto.vors %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -90,7 +90,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vxors`
 
-- **syntax:** `%result = pto.vxors %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vxors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -103,7 +103,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshls`
 
-- **syntax:** `%result = pto.vshls %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -114,11 +114,22 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshrs`
 
-- **syntax:** `%result = pto.vshrs %input, %scalar : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshrs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
     dst[i] = src[i] >> scalar;
+```
+
+---
+
+### `pto.vlrelu`
+
+- **syntax:** `%result = pto.vlrelu %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
+
+```c
+for (int i = 0; i < N; i++)
+    dst[i] = (src[i] >= 0) ? src[i] : scalar * src[i];
 ```
 
 ---
@@ -158,15 +169,15 @@ for (int i = 0; i < N; i++) {
 
 ```mlir
 // Add bias to all elements
-%biased = pto.vadds %activation, %bias_scalar : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%biased = pto.vadds %activation, %bias_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Scale by constant
-%scaled = pto.vmuls %input, %scale : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Clamp to [0, 255] for uint8 quantization
-%clamped_low = pto.vmaxs %input, %c0 : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
-%clamped = pto.vmins %clamped_low, %c255 : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%clamped_low = pto.vmaxs %input, %c0, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
+%clamped = pto.vmins %clamped_low, %c255, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Shift right by fixed amount
-%shifted = pto.vshrs %data, %c4 : !pto.vreg<64xi32>, i32 -> !pto.vreg<64xi32>
+%shifted = pto.vshrs %data, %c4, %mask : !pto.vreg<64xi32>, i32, !pto.mask -> !pto.vreg<64xi32>
 ```

--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -7,6 +7,13 @@ Operations that convert between data types (float/int, narrowing/widening).
 
 ---
 
+## `pto.vci`
+
+- **syntax:** `%result = pto.vci %index {order = "ORDER"} : integer -> !pto.vreg<NxT>`
+- **semantics:** Generate a lane-index vector from a scalar seed/index value.
+
+---
+
 ## `pto.vcvt`
 
 - **syntax:** `%result = pto.vcvt %input {round_mode = "ROUND_MODE", sat = "SAT_MODE", part = "PART_MODE"} : !pto.vreg<NxT0> -> !pto.vreg<MxT1>`
@@ -78,7 +85,7 @@ For conversions that change width (e.g., f32→f16), use even/odd parts and comb
     : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
 %odd  = pto.vcvt %in1 {round_mode = "ROUND_R", sat = "RS_ENABLE", part = "PART_ODD"}
     : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-%result = pto.vor %even, %odd : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>
+%result = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask -> !pto.vreg<128xf16>
 ```
 
 ---
@@ -107,7 +114,7 @@ for (int i = 0; i < N; i++)
 
 ```mlir
 // Quantization: f32 → i8 with saturation
-%scaled = pto.vmuls %input, %scale : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 %quantized = pto.vcvt %scaled {round_mode = "ROUND_R", sat = "RS_ENABLE"}
     : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
 // Then narrow i32 → i8 via pack ops

--- a/docs/isa/10-reduction-ops.md
+++ b/docs/isa/10-reduction-ops.md
@@ -11,7 +11,7 @@ Operations that reduce a vector to a scalar or per-group result.
 
 ### `pto.vcadd`
 
-- **syntax:** `%result = pto.vcadd %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcadd %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i64, f16, f32
 - **semantics:** Sum all elements. Result in lane 0, others zeroed.
 
@@ -28,7 +28,7 @@ for (int i = 1; i < N; i++)
 
 ### `pto.vcmax`
 
-- **syntax:** `%result = pto.vcmax %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcmax %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, f32
 - **semantics:** Find max element with argmax. Result value + index in lane 0.
 
@@ -44,7 +44,7 @@ dst_idx[0] = idx;
 
 ### `pto.vcmin`
 
-- **syntax:** `%result = pto.vcmin %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcmin %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, f32
 - **semantics:** Find min element with argmin. Result value + index in lane 0.
 
@@ -70,7 +70,7 @@ VLane 4: [32..39] VLane 5: [40..47] VLane 6: [48..55] VLane 7: [56..63]
 
 ### `pto.vcgadd`
 
-- **syntax:** `%result = pto.vcgadd %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcgadd %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, f32
 - **semantics:** Sum within each VLane. 8 results at indices 0, 8, 16, 24, 32, 40, 48, 56 (for f32).
 
@@ -91,7 +91,7 @@ for (int g = 0; g < 8; g++) {
 
 ### `pto.vcgmax`
 
-- **syntax:** `%result = pto.vcgmax %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcgmax %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, f32
 - **semantics:** Max within each VLane.
 
@@ -111,7 +111,7 @@ for (int g = 0; g < 8; g++) {
 
 ### `pto.vcgmin`
 
-- **syntax:** `%result = pto.vcgmin %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcgmin %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, f32
 - **semantics:** Min within each VLane.
 
@@ -133,7 +133,7 @@ for (int g = 0; g < 8; g++) {
 
 ### `pto.vcpadd`
 
-- **syntax:** `%result = pto.vcpadd %input : !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcpadd %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** Inclusive prefix sum (scan).
 
@@ -155,18 +155,18 @@ for (int i = 1; i < N; i++)
 
 ```mlir
 // Softmax: find max for numerical stability
-%max_vec = pto.vcmax %logits : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%max_vec = pto.vcmax %logits, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 // max is in lane 0, broadcast it
 %max_broadcast = pto.vlds %ub_tmp[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // Row-wise sum using vcgadd (for 8-row tile)
-%row_sums = pto.vcgadd %tile : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%row_sums = pto.vcgadd %tile, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 // Results at indices 0, 8, 16, 24, 32, 40, 48, 56
 
 // Full vector sum for normalization
-%total = pto.vcadd %values : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%total = pto.vcadd %values, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 // total[0] contains the sum
 
 // Prefix sum for cumulative distribution
-%cdf = pto.vcpadd %pdf : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%cdf = pto.vcpadd %pdf, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 ```

--- a/docs/isa/11-compare-select.md
+++ b/docs/isa/11-compare-select.md
@@ -33,7 +33,7 @@ for (int i = 0; i < N; i++)
 
 **Example:**
 ```mlir
-%all_active = pto.vpset_b32 "PAT_ALL" : !pto.mask
+%all_active = pto.pset_b32 "PAT_ALL" : !pto.mask
 %lt_mask = pto.vcmp %a, %b, %all_active, "lt" : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.mask
 // lt_mask[i] = 1 if a[i] < b[i]
 ```
@@ -83,7 +83,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vselr`
 
-- **syntax:** `%result = pto.vselr %src0, %src1 : !pto.vreg<NxT>, !pto.vreg<NxI> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vselr %src0, %src1 : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
 - **semantics:** Select with reversed mask semantics.
 
 ```c
@@ -93,11 +93,18 @@ for (int i = 0; i < N; i++)
 
 ---
 
+### `pto.vselrv2`
+
+- **syntax:** `%result = pto.vselrv2 %src0, %src1 : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **semantics:** Variant select form with the same current two-vector operand shape.
+
+---
+
 ## Typical Usage
 
 ```mlir
 // Clamp negative values to zero (manual ReLU)
-%all = pto.vpset_b32 "PAT_ALL" : !pto.mask
+%all = pto.pset_b32 "PAT_ALL" : !pto.mask
 %zero = pto.vbr %c0_f32 : f32 -> !pto.vreg<64xf32>
 %neg_mask = pto.vcmps %input, %c0_f32, %all, "lt" : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.mask
 %clamped = pto.vsel %zero, %input, %neg_mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
@@ -119,7 +126,7 @@ for (int i = 0; i < N; i++)
 // Softmax safe exp: exp(x - max) where x < max returns exp of negative
 // but we want to clamp to avoid underflow
 
-%all = pto.vpset_b32 "PAT_ALL" : !pto.mask
+%all = pto.pset_b32 "PAT_ALL" : !pto.mask
 
 // 1. Compare against threshold
 %too_small = pto.vcmps %x_minus_max, %min_exp_arg, %all, "lt"
@@ -130,5 +137,5 @@ for (int i = 0; i < N; i++)
     : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // 3. Safe exp
-%exp_result = pto.vexp %clamped : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp_result = pto.vexp %clamped, %all : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 ```

--- a/docs/isa/12-data-rearrangement.md
+++ b/docs/isa/12-data-rearrangement.md
@@ -184,10 +184,22 @@ for (int i = 0; i < N/2; i++)
 // Sliding window sum
 %prev_window = pto.vslide %curr, %prev, %c1
     : !pto.vreg<64xf32>, !pto.vreg<64xf32>, i16 -> !pto.vreg<64xf32>
-%window_sum = pto.vadd %curr, %prev_window
-    : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%window_sum = pto.vadd %curr, %prev_window, %all
+    : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Type narrowing via pack
 %packed_i16 = pto.vpack %wide0_i32, %wide1_i32, %c0
     : !pto.vreg<64xi32>, !pto.vreg<64xi32>, index -> !pto.vreg<128xi16>
 ```
+
+---
+
+## V2 Interleave Forms
+
+### `pto.vintlvv2`
+
+- **syntax:** `%result = pto.vintlvv2 %lhs, %rhs, "PART" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+
+### `pto.vdintlvv2`
+
+- **syntax:** `%result = pto.vdintlvv2 %lhs, %rhs, "PART" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`

--- a/docs/isa/13-dsa-sfu-ops.md
+++ b/docs/isa/13-dsa-sfu-ops.md
@@ -11,7 +11,7 @@ Fused operations, special functions, and UB-to-UB operations that leverage hardw
 
 ### `pto.vlrelu`
 
-- **syntax:** `%result = pto.vlrelu %input, %alpha : !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vlrelu %input, %alpha, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** Leaky ReLU with scalar alpha.
 
@@ -141,18 +141,14 @@ for (int i = 0; i < 64; i++) {
 
 ### `pto.vmula`
 
-- **syntax:** `%result = pto.vmula %acc, %lhs, %rhs, %mask {mode = "MODE"} : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
-- **semantics:** Multiply-accumulate with mode control.
+- **syntax:** `%result = pto.vmula %acc, %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
+- **semantics:** Multiply-accumulate.
 
 ```c
 for (int i = 0; i < N; i++)
     if (mask[i])
         dst[i] = acc[i] + lhs[i] * rhs[i];
-    else if (mode == MODE_ZEROING)
-        dst[i] = 0;
 ```
-
-**Mode tokens:** `MODE_ZEROING`, `MODE_MERGING`, `MODE_UNKNOWN`
 
 ---
 
@@ -199,6 +195,16 @@ for (int i = 0; i < N; i++)
 
 ---
 
+## Current Implementation Surface Summary
+
+- `pto.vmull %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>, !pto.vreg<NxT>`
+- `pto.vmula %acc, %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
+- `pto.vci %index {order = "ORDER"} : integer -> !pto.vreg<NxT>`
+- `pto.vbitsort %dest, %src, %indices, %repeat_times : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, index`
+- `pto.vmrgsort4 %dest, %src0, %src1, %src2, %src3, %count, %config : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, i64, i64`
+
+---
+
 ## Typical Usage
 
 ```mlir
@@ -207,7 +213,7 @@ for (int i = 0; i < N; i++)
 %exp_stable = pto.vexpdiff %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // Leaky ReLU activation
-%activated = pto.vlrelu %linear_out, %alpha_scalar : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%activated = pto.vlrelu %linear_out, %alpha_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Fused residual add + ReLU
 %residual = pto.vaddrelu %conv_out, %skip_connection : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>

--- a/docs/isa/15-shared-scf.md
+++ b/docs/isa/15-shared-scf.md
@@ -40,9 +40,10 @@ Ops such as `scf.execute_region`, `scf.forall`, or `scf.index_switch` are not pa
 ```mlir
 scf.for %i = %c0 to %c4 step %c1 {
   %offset = arith.muli %i, %c32 : index
+  %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
   %v = pto.vlds %ub[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-  %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-  pto.vsts %abs, %ub_out[%offset] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+  %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+  pto.vsts %abs, %ub_out[%offset], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 }
 ```
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -3,7 +3,7 @@
 > **Status:** DRAFT for review
 > **Base:** [vpto-spec.md](https://github.com/mouliangyu/PTOAS/blob/feature-vpto-backend/docs/vpto-spec.md) (2026-03-20)
 > **Additions from:** [a5_intrinsic_ir.md](../a5_intrinsic/a5_intrinsic_ir.md) v3.2 (2026-03-21)
-> **Updated:** 2026-03-24
+> **Updated:** 2026-03-27
 
 ---
 
@@ -166,9 +166,10 @@ The execution model follows non-blocking fork semantics:
 
 ```mlir
 scf.for %dummy = %c0 to %c1 step %c1 {
+  %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
   %v = pto.vlds %ub[%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-  %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-  pto.vsts %abs, %ub_out[%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+  %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+  pto.vsts %abs, %ub_out[%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 } {llvm.loop.aivector_scope}
 ```
 
@@ -178,18 +179,19 @@ scf.for %dummy = %c0 to %c1 step %c1 {
 pto.set_loop2_stride_outtoub %c4096_i64, %c4096_i64 : i64, i64
 pto.set_loop1_stride_outtoub %c4096_i64, %c4096_i64 : i64, i64
 pto.set_loop_size_outtoub %c1_i64, %c1_i64 : i64, i64
-pto.copy_gm_to_ubuf %7, %2, %3, %3, %c0_i64, %c32_i64, %4, %c0_i64, %c0_i64, %c0_i64, %c128_i64, %c128_i64
-    {data_select_bit = false, layout = "nd", ub_pad = false}
-    : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64
+pto.copy_gm_to_ubuf %7, %2, %3, %3, %c0_i64, %c32_i64, %4, %c0_i64, %c0_i64,
+    %false, %c0_i64, %c128_i64, %c128_i64
+    : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i1, i64, i64, i64
 
 pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 
 scf.for %dummy = %c0 to %c1 step %c1 {
   scf.for %lane = %c0 to %9 step %c64 {
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask
     %v = pto.vlds %2[%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-    %abs = pto.vabs %v : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-    pto.vsts %abs, %8[%lane] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+    %abs = pto.vabs %v, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+    pto.vsts %abs, %8[%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
   }
 } {llvm.loop.aivector_scope}
 
@@ -199,7 +201,6 @@ pto.set_loop_size_ubtoout %c1_i64, %c1_i64 : i64, i64
 pto.set_loop1_stride_ubtoout %c4096_i64, %c4096_i64 : i64, i64
 pto.set_loop2_stride_ubtoout %c4096_i64, %c4096_i64 : i64, i64
 pto.copy_ubuf_to_gm %8, %14, %3, %3, %c0_i64, %c32_i64, %4, %c0_i64, %c128_i64, %c128_i64
-    {layout = "nd"}
     : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64, i64, i64
 ```
 
@@ -254,7 +255,7 @@ VPTO memory operands use `!pto.ptr<element-type, space>`. This specification mod
 Typical pointer construction and pointer arithmetic follow the same `!pto.ptr<..., space>` form:
 
 ```mlir
-%0 = pto.castptr %c0 : i64 to !pto.ptr<f32, ub>
+%0 = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
 %1 = pto.addptr %0, %c1024 : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
 ```
 
@@ -278,7 +279,7 @@ Typical examples:
 
 #### `pto.castptr`
 
-- **syntax:** `%result = pto.castptr %addr : i64 to !pto.ptr<T, space>`
+- **syntax:** `%result = pto.castptr %addr : i64 -> !pto.ptr<T, space>`
 - **semantics:** Reinterpret a scalar address value as a typed PTO pointer in the target memory space.
 
 ```c
@@ -303,13 +304,13 @@ result = ptr + offset;  // offset counted in elements, not bytes
 The following lowered-style fragment shows how typed PTO pointers flow through pointer construction, pointer arithmetic, structured control flow, and PTO memory ops:
 
 ```mlir
-%0 = pto.castptr %c0 : i64 to !pto.ptr<f32, ub>
+%0 = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
 %1 = pto.addptr %0, %c1024 : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
 scf.for %arg2 = %c0 to %c1 step %c1 {
   %16 = scf.for %arg3 = %c0 to %11 step %c64 iter_args(%arg4 = %12) -> (i32) {
     %mask, %scalar_out = pto.plt_b32 %arg4 : i32 -> !pto.mask, i32
     %17 = pto.vlds %1[%arg3] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-    %18 = pto.vabs %17, %mask {mode = "MODE_ZEROING"} : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+    %18 = pto.vabs %17, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
     pto.vsts %18, %10[%arg3], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
     scf.yield %scalar_out : i32
   }
@@ -344,9 +345,8 @@ dst[i] = mask[i] ? op(src0[i], src1[i]) : 0    // ZEROING mode
 
 ```mlir
 // Predicated add: inactive lanes produce zero
-%mask = pto.vpset_b32 "PAT_VL32" : !pto.mask   // first 32 lanes active
-%result = pto.vadd %a, %b, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
-// result[0..31] = a[0..31] + b[0..31], result[32..63] = 0
+%mask = pto.pset_b32 "PAT_VL32" : !pto.mask   // first 32 lanes active
+%result = pto.vcmp %a, %b, %mask, "lt" : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.mask
 ```
 
 ```mlir
@@ -360,8 +360,8 @@ dst[i] = mask[i] ? op(src0[i], src1[i]) : 0    // ZEROING mode
 `!pto.align` models the A5 vector-align carrier state. It is not payload data.
 
 ```mlir
-%align = pto.vldas %ub[%c0] : !pto.ptr<f32, ub> -> !pto.align
-%vec = pto.vldus %align, %ub[%c64] : !pto.align, !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+%align = pto.vldas %ub : !pto.ptr<f32, ub> -> !pto.align
+%vec, %align_out, %base_out = pto.vldus %ub, %align : !pto.ptr<f32, ub>, !pto.align -> !pto.vreg<64xf32>, !pto.align, !pto.ptr<f32, ub>
 ```
 
 ---
@@ -431,8 +431,8 @@ pto.vstx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vreg
 **Predicate construction:**
 
 ```mlir
-%mask = pto.vpset_b32 "PAT_ALL" : !pto.mask
-%mask = pto.vpge_b32 "PAT_VL16" : !pto.mask
+%mask = pto.pset_b32 "PAT_ALL" : !pto.mask
+%tail = pto.pge_b32 "PAT_VL16" : !pto.mask
 ```
 
 **Sync operations:**
@@ -440,13 +440,12 @@ pto.vstx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vreg
 ```mlir
 pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
-pto.mem_bar "VV_ALL"
 ```
 
 **Pointer construction and arithmetic:**
 
 ```mlir
-%ptr = pto.castptr %addr : i64 to !pto.ptr<T, SPACE>
+%ptr = pto.castptr %addr : i64 -> !pto.ptr<T, SPACE>
 %ptr2 = pto.addptr %ptr, %offset : !pto.ptr<T, SPACE> -> !pto.ptr<T, SPACE>
 ```
 
@@ -562,7 +561,6 @@ for (int g = 0; g < 8; g++) {
 | `"SAT_MODE"` | Saturation: `RS_ENABLE \| RS_DISABLE` |
 | `"PART_MODE"` | Half selector: `PART_EVEN \| PART_ODD` |
 | `"PAT_*"` | Predicate pattern literal |
-| `"MODE"` | Mode selector: `MODE_ZEROING \| MODE_MERGING` |
 | `T` | Element type (f32, f16, bf16, i32, i16, i8, etc.) |
 | `N` | Lane count (`N * bitwidth(T) = 2048`) |
 
@@ -579,19 +577,19 @@ This section provides a categorized overview of all VPTO instructions plus the s
 
 | # | Group | Description | Count | Details |
 |---|-------|-------------|-------|---------|
-| 1 | [Pipeline Sync](isa/01-pipeline-sync.md) | Intra-core pipeline synchronization (MTE↔Vector) and inter-core coordination | 10 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf`, `pto.mem_bar`, `pto.set_cross_core`, `pto.wait_flag_dev`, `pto.set_intra_block`, `pto.wait_intra_block` |
+| 1 | [Pipeline Sync](isa/01-pipeline-sync.md) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
 | 2 | [DMA Copy Programming](isa/02-dma-copy.md) | DMA configuration and transfer between GM↔UB | 9 | `pto.set_loop*_stride_*`, `pto.set_loop_size_*`, `pto.copy_gm_to_ubuf`, `pto.copy_ubuf_to_ubuf`, `pto.copy_ubuf_to_gm` |
 | 3 | [Vector Load/Store](isa/03-vector-load-store.md) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldx2`, `pto.vgather2`, `pto.vsts`, `pto.vstx2`, `pto.vscatter`, etc. |
-| 4 | [Predicate Load/Store](isa/04-predicate-load-store.md) | UB↔mask register movement | 7 | `pto.vplds`, `pto.vpld`, `pto.vpldi`, `pto.vpsts`, `pto.vpst`, `pto.vpsti`, `pto.vpstu` |
-| 5 | [Materialization & Predicate Ops](isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~20 | `pto.vbr`, `pto.vdup`, `pto.vpset_b*`, `pto.vpge_b*`, `pto.vpand`, `pto.vpor`, `pto.vpnot`, `pto.vpsel`, etc. |
-| 6 | [Unary Vector Ops](isa/06-unary-vector-ops.md) | Single-input element-wise operations | 12 | `pto.vabs`, `pto.vneg`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrsqrt`, `pto.vrec`, `pto.vrelu`, `pto.vnot`, `pto.vbcnt`, `pto.vcls`, `pto.vmov` |
+| 4 | [Predicate Load/Store](isa/04-predicate-load-store.md) | UB↔mask register movement | 7 | `pto.plds`, `pto.pld`, `pto.pldi`, `pto.psts`, `pto.pst`, `pto.psti`, `pto.pstu` |
+| 5 | [Materialization & Predicate Ops](isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
+| 6 | [Unary Vector Ops](isa/06-unary-vector-ops.md) | Single-input element-wise operations | 9 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrec`, `pto.vrelu`, `pto.vnot`, `pto.vbcnt`, `pto.vcls` |
 | 7 | [Binary Vector Ops](isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
-| 8 | [Vec-Scalar Ops](isa/08-vec-scalar-ops.md) | Vector-scalar operations | 12 | `pto.vadds`, `pto.vsubs`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vands`, `pto.vors`, `pto.vxors`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
+| 8 | [Vec-Scalar Ops](isa/08-vec-scalar-ops.md) | Vector-scalar operations | 8 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
 | 9 | [Conversion Ops](isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 2 | `pto.vcvt`, `pto.vtrc` |
-| 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector and per-VLane reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
-| 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` |
-| 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 11 | `pto.vintlv`, `pto.vdintlv`, `pto.vslide`, `pto.vshift`, `pto.vsqz`, `pto.vusqz`, `pto.vperm`, `pto.vpack`, `pto.vsunpack`, `pto.vzunpack`, `pto.vselr` |
-| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Fused ops, special functions, UB-to-UB, sorting | ~12 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vci`, `pto.vtranspose`, `pto.vsort32`, `pto.vmrgsort`, etc. |
+| 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector reductions | 3 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin` |
+| 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 5 | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr`, `pto.vselrv2` |
+| 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 4 | `pto.vintlv`, `pto.vdintlv`, `pto.vintlvv2`, `pto.vdintlvv2` |
+| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 5 | `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
@@ -619,7 +617,7 @@ This section provides a categorized overview of all VPTO instructions plus the s
 | Element-wise Arithmetic | 6, 7 | `pto.vadd`, `pto.vmul`, `pto.vabs`, etc. |
 | Scalar Operations | 8 | `pto.vadds`, `pto.vmuls`, etc. |
 | Transcendental | 6 | `pto.vexp`, `pto.vln`, `pto.vsqrt`, etc. |
-| Reduction | 10 | `pto.vcadd`, `pto.vcmax`, `pto.vcgadd`, etc. |
+| Reduction | 10 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin` |
 | Comparison | 11 | `pto.vcmp`, `pto.vcmps` |
 | Selection | 11 | `pto.vsel`, `pto.vselr` |
 
@@ -629,16 +627,14 @@ This section provides a categorized overview of all VPTO instructions plus the s
 |-----------|-------|-------------|
 | Type Conversion | 9 | `pto.vcvt` |
 | Interleave/Deinterleave | 12 | `pto.vintlv`, `pto.vdintlv` |
-| Compress/Expand | 12 | `pto.vsqz`, `pto.vusqz` |
-| Pack/Unpack | 12 | `pto.vpack`, `pto.vsunpack`, `pto.vzunpack` |
+| Interleave/Deinterleave | 12 | `pto.vintlv`, `pto.vdintlv`, `pto.vintlvv2`, `pto.vdintlvv2` |
 
 ### Synchronization
 
 | Operation | Group | Description |
 |-----------|-------|-------------|
 | Intra-core Sync | 1 | `pto.set_flag`, `pto.wait_flag` |
-| Inter-core Sync | 1 | `pto.set_cross_core`, `pto.wait_flag_dev` |
-| Memory Barrier | 1 | `pto.mem_bar` |
+| Pipeline Buffer Sync | 1 | `pto.get_buf`, `pto.rls_buf` |
 
 ### Scalar & Control Operations
 
@@ -678,30 +674,30 @@ Group 14 covers the full scalar `arith` surface. The rows below list common VPTO
 
 ```mlir
 // 1. Find max
-%max_vec = pto.vcmax %logits : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-pto.vsts %max_vec, %ub_tmp[%c0] {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+%max_vec = pto.vcmax %logits, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+pto.vsts %max_vec, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 %max_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 2. exp(x - max) using fused op
 %exp = pto.vexpdiff %logits, %max_bc : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // 3. Sum
-%sum = pto.vcadd %exp : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
-pto.vsts %sum, %ub_tmp[%c0] {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+%sum = pto.vcadd %exp, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+pto.vsts %sum, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 %sum_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 4. Divide
-%softmax = pto.vdiv %exp, %sum_bc : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%softmax = pto.vdiv %exp, %sum_bc, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 ```
 
 ### ReLU Variants
 
 ```mlir
 // Standard ReLU
-%relu = pto.vrelu %input : !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%relu = pto.vrelu %input, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Leaky ReLU (scalar alpha)
-%lrelu = pto.vlrelu %input, %alpha : !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+%lrelu = pto.vlrelu %input, %alpha, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Parametric ReLU (per-element alpha)
 %prelu = pto.vprelu %input, %alpha_vec : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
@@ -767,8 +763,8 @@ pto.vstx2 %x, %y, %ub_xy[%offset], "INTLV_B32", %all_mask : !pto.vreg<64xf32>, !
 | 4 | Sec 4: Loads — BRC/US/DS/SPLT dist modes | **ADDED** with C semantics | a5_intrinsic_ir.md |
 | 5 | Sec 5: vbr | Kept from vpto-spec.md | vpto-spec.md |
 | 6 | Sec 5: vdupi | **ADDED** | a5_intrinsic_ir.md |
-| 7 | Sec 5: vpand, vpor, vpxor, vpmov | **ADDED** | a5_intrinsic_ir.md |
-| 8 | Sec 5: vpintlv, vpdintlv, vpslide | **ADDED** | a5_intrinsic_ir.md |
+| 7 | Sec 5: pand, por, pxor, ppack/punpack | **ADDED** | a5_intrinsic_ir.md |
+| 8 | Sec 5: pintlv/pdintlv-style predicate movement | **ADDED** | a5_intrinsic_ir.md |
 | 9 | Sec 6: vneg, vrsqrt | **ADDED** | a5_intrinsic_ir.md |
 | 10 | Sec 6: vcgadd, vcgmax, vcgmin | **ADDED** per-VLane reductions | a5_intrinsic_ir.md |
 | 11 | Sec 6: vcpadd | **ADDED** prefix sum | a5_intrinsic_ir.md |
@@ -782,7 +778,7 @@ pto.vstx2 %x, %y, %ub_xy[%offset], "INTLV_B32", %all_mask : !pto.vreg<64xf32>, !
 | 2 | Sec 8: vsubs, vands, vors, vxors | **ADDED** | a5_intrinsic_ir.md |
 | 3 | Sec 9: vselrv2 | **REMOVED** (not A5) | — |
 | 4 | Sec 9: vprelu | **ADDED** parametric ReLU | a5_intrinsic_ir.md |
-| 5 | Sec 10: vintlvv2, vdintlvv2, vpdintlv_b8, vpintlv_b16 | **REMOVED** (not A5) | — |
+| 5 | Sec 10: vintlvv2, vdintlvv2, pdintlv_b8, pintlv_b16 | **REMOVED** (not A5) | — |
 | 6 | Sec 10: vslide, vshift, vsqz, vusqz | **ADDED** data movement | a5_intrinsic_ir.md |
 | 7 | Sec 10: vperm (was vgather reg) | **ADDED** in-register permute | a5_intrinsic_ir.md |
 | 8 | Sec 10: vtranspose | **ADDED** | a5_intrinsic_ir.md |
@@ -820,7 +816,7 @@ pto.vstx2 %x, %y, %ub_xy[%offset], "INTLV_B32", %all_mask : !pto.vreg<64xf32>, !
 
 1. **pto.vmov:** May not need a dedicated op if MLIR copy semantics suffice. Confirm if needed.
 2. **pto.vdupi:** Is this distinct from `pto.vdup` with an immediate operand, or can `pto.vdup` handle both?
-3. **Predicate ops (vpand/vpor/vpxor/vpmov/vpintlv/vpdintlv/vpslide):** These need MLIR op definitions and verifier rules. Confirm priority.
+3. **Predicate ops (pand/por/pxor and predicate movement forms):** These need MLIR op definitions and verifier rules. Confirm priority.
 
 ### Part 3B
 


### PR DESCRIPTION
- align docs/vpto-spec.md and docs/isa/* with current operand syntax and examples without rewriting the overall document style
- unify explicit %mask forms across unary, binary, vec-scalar, reduction, and DSA/SFU docs
- remove interface-level mode descriptions that are no longer kept in docs, including unary, reduction, vmula, and vdup entries
- rename old predicate vp* spellings to current p* spellings and update related examples and overview tables
- remove unused draft-only entries such as pto.vdupi and pto.vsts_pred, plus outdated overview and appendix references
- clean up DMA docs by dropping old layout/ub_pad attribute-style descriptions and documenting data_select_bit in the current parameter-style form
- refresh appendix, discussion, and cross-reference text to remove stale interface remnants

No tests run; documentation-only change.