### PR TITLE
Docs: ISA vector load/store latency (03) and verification split

### DIFF
--- a/docs/isa/03-vector-load-store.md
+++ b/docs/isa/03-vector-load-store.md
@@ -5,20 +5,104 @@
 
 Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Vector stores move data from `vreg` back to UB. All vector compute operates only on `vreg` — UB is the staging area between DMA and compute.
 
-## Common Operand Model
+---
 
-- `%source` / `%dest` is the base address operand in SSA form. The base pointer
-  MUST address the Vector tile buffer / UB space.
-- `%offset` is the displacement operand in SSA form. The exact encoding is
-  instruction-specific, but the effective address and any post-update behavior
-  MUST match the selected instruction form.
-- `%mask` is the predicate operand for predicated memory families. For memory
-  families,
-  inactive lanes or inactive blocks MUST NOT issue memory requests unless the
-  instruction explicitly documents a different behavior.
-- `%result` is the destination vector register value in SSA form.
-- `!pto.align` is the SSA carrier for alignment-buffer state used by unaligned
-  load/store families. The PTO micro Instruction representation makes that state explicit rather than implicit.
+## Latency and throughput (A5)
+
+**Cycle-accurate simulator (CA model)** issue→retire timings for vector-side instructions behind this chapter. Values are **simulator** results, **not** guaranteed for silicon.
+
+**SOC:** Tables below are from **Ascend910_9599** CA sim (the pto-isa ST default when **Ascend950PR_9599** is not selected).
+
+**Log `dist:` tokens:** PTO load/store modes lower to **`RV_VLD` / `RV_VLDI` / `RV_VST` / `RV_VSTI`** with a **`dist:`** field on the vector pipes (`RVECLD` / `RVECST`). Some simulator logs typo contiguous load as `dist:NORAML`; treat as **`NORMAL`**.
+
+### Reference op latencies (A5 mnemonics)
+
+| A5 mnemonic | Mode / note | Typical issue→retire (cycles) |
+|-------------|-------------|------------------------------|
+| `RV_VLD` | `dist:NORMAL` / `NORAML` | **9** |
+| `RV_VLDI` | `dist:DINTLV_B32` (dual vreg) | **9** |
+| `RV_VST` / `RV_VSTI` | `dist:NORM_B32` | **9** |
+| `RV_VGATHER2` | `Dtype: B32` | **27–28** |
+| `RV_VGATHERB` | indexed byte gather | **~21** |
+| `RV_VSCATTER` | `Dtype: B16` | **~17** |
+| `RV_VADD` | F32 between UB-backed ops | **7** |
+
+### `dist:` tokens (issue→retire)
+
+Most **`dist:`** tokens are **9** issue→retire cycles. **`INTLV_*`** on **`RV_VSTI`** are **12** cycles.
+
+| `dist:` (as in log) | RV op | issue→retire (cycles) |
+|---------------------|-------|----------------------|
+| `DINTLV_B32` | `RV_VLDI` | **9** |
+| `DINTLV_B16` | `RV_VLDI` | **9** |
+| `DINTLV_B8` | `RV_VLDI` | **9** |
+| `BRC_B32` | `RV_VLD` | **9** |
+| `BRC_B8` | `RV_VLD` | **9** |
+| `BRC_B16` | `RV_VLD` | **9** |
+| `BRC_BLK` | `RV_VLD` | **9** |
+| `INTLV_B32` | `RV_VSTI` | **12** |
+| `INTLV_B16` | `RV_VSTI` | **12** |
+| `INTLV_B8` | `RV_VSTI` | **12** |
+| `UNPK_B8` | `RV_VLD` | **9** |
+| `UNPK_B16` | `RV_VLD` | **9** |
+| `UNPK_B32` | `RV_VLD` | **9** |
+| `NORM_B32` | `RV_VSTI` | **9** |
+| `NORM_B16` | `RV_VSTI` | **9** |
+| `NORM_B8` | `RV_VSTI` | **9** |
+| `PK_B32` | `RV_VSTI` | **9** |
+| `PK_B16` | `RV_VSTI` | **9** |
+| `NORMAL` / `NORAML` | `RV_VLD` | **9** |
+
+**Note:** PTO intrinsic **`BLK`** matches the **`BRC_BLK`** `dist:` string on **`RV_VLD`** in simulator logs (block-replicate path; not a plain contiguous copy in the usual tiling use).
+
+**Issue (vector load/store):** `pto.vlds` (**`RV_VLD`**) is **dual-issue capable**: two independent `pto.vlds` can issue **in the same cycle**. **Alternatively**, the hardware can issue **one** `pto.vlds` **and** **one** `pto.vsts` together (**1+1**) in the same cycle. Each cycle is **either** dual **`vlds`** **or** **`vlds` + `vsts` (1+1)**—those two issue modes are mutually exclusive. Sustained throughput still depends on RAW hazards and loop structure.
+
+**Throughput (simulator, pattern-dependent):**
+
+- **`RV_VLD` / `pto.vlds`:** Dual-issue **or** half of a **1+1** with `vsts`, per the rule above.
+- **`RV_VST` / `pto.vsts`:** In a **1+1** cycle, pairs with one `vlds`; otherwise typically **one** store per cycle in tight loops.
+- **`RV_VGATHER2`:** Much lower than contiguous `RV_VLD` (on the order of **~0.1** ops/cycle in steady-state alongside 27–28-cycle latency).
+
+### PTO `dist` summary (loads)
+
+| PTO `dist` (load) | Latency |
+|-------------------|-------------------|
+| `NORM` | **9** cycles |
+| `UNPK_B8`, `UNPK_B16`, `UNPK_B32` | **9** cycles |
+| `DINTLV_B32` | **9** cycles (`RV_VLDI`) |
+| `DINTLV_B16`, `DINTLV_B8` | **9** cycles (same `RV_VLDI` + `dist:DINTLV_*` path as `DINTLV_B32`) |
+| `BRC_B32` | **9** cycles |
+| `BRC_B8`, `BRC_B16` | **9** cycles (`RV_VLD`) |
+| `BLK` | **9** cycles as **`dist:BRC_BLK`** on `RV_VLD` |
+| `BDINTLV` | **9** cycles |
+| `US_*`, `DS_*`, `SPLT*` | **9** cycles |
+
+### PTO `dist` summary (stores)
+
+| PTO `dist` (store) | Latency |
+|--------------------|-------------------|
+| `NORM_B8`, `NORM_B16`, `NORM_B32` | **9** cycles (`RV_VSTI`) |
+| `PK_B16`, `PK_B32` | **9** cycles |
+| `INTLV_B32` (`pto.vstx2`) | **12** cycles |
+| `INTLV_B16`, `INTLV_B8` | **12** cycles (same interleave store path as `INTLV_B32`) |
+| `MRG4CHN_B8`, `MRG2CHN_*` | **9** cycles |
+
+### Gather, scatter, and special addressing
+
+| PTO op | A5-level | Latency |
+|--------|----------|-------------------|
+| `pto.vgather2` | `RV_VGATHER2` | **27–28** cycles (pattern-dependent) |
+| `pto.vgatherb` | `RV_VGATHERB` | **~21** cycles issue→retire |
+| `pto.vgather2_bc` | (broadcast gather) | **27–28** cycles (same as **`pto.vgather2`**) |
+| `pto.vscatter` | `RV_VSCATTER` | **~17** cycles for **`Dtype: B16`** |
+
+### Strided loads/stores, unaligned ops, alignment state
+
+Ops such as **`pto.vldas`**, **`pto.vldus`**, **`pto.vsld`**, **`pto.vsldb`**, **`pto.vsst`**, **`pto.vsstb`**, **`pto.vsta`**, **`pto.vstas`**, **`pto.vstar`**, **`pto.vstu`**, **`pto.vstus`**, **`pto.vstur`**: **9** cycles (same vector load/store pipe family as contiguous `RV_VLD` / `RV_VST` unless listed otherwise above).
+
+### Dual-issue vs DMA
+
+DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD`/`RV_VST`. **MTE2** `MOV_*` latency is not the same as vector `RV_VLD` latency (see `02-dma-copy.md` for GM↔UB movement).
 
 ---
 
@@ -28,31 +112,23 @@ Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Ve
 
 - **syntax:** `%result = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>`
 - **semantics:** Vector load with distribution mode.
-- **inputs:**
-  `%source` is the UB base address, `%offset` is the load displacement, and
-  `DIST` selects the distribution mode.
-- **outputs:**
-  `%result` is the loaded vector register value.
-- **constraints and limitations:**
-  The effective address MUST satisfy the alignment rule of the selected
-  distribution mode. `NORM` reads one full vector footprint. Broadcast,
-  upsample, downsample, unpack, split-channel, and deinterleave modes change
-  how memory bytes are mapped into destination lanes, but they do not change the
-  fact that the source is UB memory.
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics |
-|------|-------------|-------------|
-| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` |
-| `BRC_B8/B16/B32` | Broadcast single element | `dst[i] = UB[base]` for all i |
-| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` |
-| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` |
-| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` |
-| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte |
-| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element |
-| `DINTLV_B32` | Deinterleave 32-bit | Even elements only |
-| `BLK` | Block load | Blocked access pattern |
+| Mode | Description | C Semantics | Latency |
+|------|-------------|-------------|---------------------|
+| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` | **9** cycles |
+| `BRC_B32` | Broadcast single element | `dst[i] = UB[base]` for all i | **9** cycles |
+| `BRC_B8`, `BRC_B16` | Broadcast first lane element | Same idea at B8/B16 width | **9** cycles |
+| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` | **9** cycles |
+| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` | **9** cycles |
+| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` | **9** cycles |
+| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte | **9** cycles |
+| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element | **9** cycles |
+| `DINTLV_B32` | Deinterleave 32-bit | Even elements only | **9** cycles |
+| `DINTLV_B16`, `DINTLV_B8` | Deinterleave 16-bit / 8-bit | Pair lanes from interleaved UB | **9** cycles |
+| `BDINTLV` | Block deinterleave | (see PTO headers for exact tiling) | **9** cycles |
+| `BLK` | Block load | Blocked / tiled access pattern (see PTO headers) | **9** cycles (`dist:BRC_BLK` on `RV_VLD`) |
 
 **Example — Contiguous load:**
 ```mlir
@@ -70,15 +146,7 @@ Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Ve
 
 - **syntax:** `%result = pto.vldas %source : !pto.ptr<T, ub> -> !pto.align`
 - **semantics:** Prime alignment buffer for subsequent unaligned load.
-- **inputs:**
-  `%source` is the UB address whose surrounding aligned block seeds the load
-  alignment state.
-- **outputs:**
-  `%result` is the initialized load-alignment state.
-- **constraints and limitations:**
-  This op is the required leading operation for a `pto.vldus` stream using the
-  same alignment state. The source address itself need not be 32-byte aligned;
-  hardware truncates it to the aligned block boundary for the priming load.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -86,17 +154,7 @@ Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Ve
 
 - **syntax:** `%result, %align_out, %base_out = pto.vldus %source, %align : !pto.ptr<T, ub>, !pto.align -> !pto.vreg<NxT>, !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Unaligned load using primed align state.
-- **inputs:**
-  `%source` is the current UB address and `%align` is the incoming load
-  alignment state primed by `pto.vldas` or a prior `pto.vldus`.
-- **outputs:**
-  `%result` is the assembled vector value, `%align_out` is the updated alignment
-  state, and `%base_out` is the post-update base pointer state exposed in SSA
-  form.
-- **constraints and limitations:**
-  A matching `pto.vldas` MUST appear before the first dependent `pto.vldus`
-  stream in the same vector loop. Both the alignment state and the base address
-  advance across the stream, and the PTO micro Instruction representation exposes those updates as SSA results.
+- **Latency:** **9** cycles.
 
 **Unaligned load pattern:**
 ```mlir
@@ -112,14 +170,7 @@ Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Ve
 
 - **syntax:** `%low, %high = pto.vldx2 %source[%offset], "DIST" : !pto.ptr<T, ub>, index -> !pto.vreg<NxT>, !pto.vreg<NxT>`
 - **semantics:** Dual load with deinterleave (AoS → SoA conversion).
-- **inputs:**
-  `%source` is the UB base pointer, `%offset` is the displacement, and `DIST`
-  selects a dual-load/deinterleave layout.
-- **outputs:**
-  `%low` and `%high` are the two destination vectors.
-- **constraints and limitations:**
-  This family is only legal for interleave/deinterleave style distributions.
-  The two outputs form an ordered pair, and that pairing MUST be preserved.
+- **Latency:** **`DINTLV_B32` → 9** cycles on `RV_VLDI`. **`DINTLV_B16` / `DINTLV_B8` → 9** cycles on `RV_VLDI`. **`BDINTLV` → 9** cycles on `RV_VLDI`.
 
 **Distribution modes:** `DINTLV_B8`, `DINTLV_B16`, `DINTLV_B32`, `BDINTLV`
 
@@ -144,14 +195,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `%result = pto.vsld %source[%offset], "STRIDE" : !pto.ptr<T, ub> -> !pto.vreg<NxT>`
 - **semantics:** Strided load with fixed stride pattern.
-- **inputs:**
-  `%source` is the UB base pointer and `%offset` is the displacement encoded
-  with the selected fixed stride mode.
-- **outputs:**
-  `%result` is the loaded vector.
-- **constraints and limitations:**
-  This is a deprecated compatibility family. The selected stride token
-  determines which sub-elements are read from each source block.
+- **Latency:** **9** cycles.
 
 **Stride modes:** `STRIDE_S3_B16`, `STRIDE_S4_B64`, `STRIDE_S8_B32`, `STRIDE_S2_B64`
 
@@ -161,15 +205,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `%result = pto.vsldb %source, %offset, %mask : !pto.ptr<T, ub>, i32, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Block-strided load for 2D tile access.
-- **inputs:**
-  `%source` is the UB base pointer, `%offset` is the packed stride/control word,
-  and `%mask` controls which blocks participate.
-- **outputs:**
-  `%result` is the loaded vector.
-- **constraints and limitations:**
-  `%offset` is not a plain byte displacement; it encodes the block stride and
-  repeat pattern. If a block is masked off, the corresponding destination block
-  is zeroed and MUST NOT raise an address overflow exception for that block.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -179,15 +215,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `%result = pto.vgather2 %source, %offsets, %active_lanes : !pto.ptr<T, ub>, !pto.vreg<NxI>, index -> !pto.vreg<NxT>`
 - **semantics:** Indexed gather from UB.
-- **inputs:**
-  `%source` is the UB base pointer, `%offsets` provides per-lane element
-  offsets, and `%active_lanes` bounds how many lanes participate.
-- **outputs:**
-  `%result` is the gathered vector.
-- **constraints and limitations:**
-  Only the first `%active_lanes` indices participate. The index element width
-  and interpretation MUST match the selected gather form, and each effective
-  address must satisfy that form's alignment rules.
+- **Latency:** **27–28** cycles per `RV_VGATHER2`; throughput much lower than contiguous `RV_VLD` (see **Latency and throughput (A5)** at the start of this chapter).
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -200,15 +228,7 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `%result = pto.vgatherb %source, %offsets, %active_lanes : !pto.ptr<T, ub>, !pto.vreg<NxI>, index -> !pto.vreg<NxT>`
 - **semantics:** Byte-granularity indexed gather from UB.
-- **inputs:**
-  `%source` is the UB base pointer, `%offsets` contains per-block byte offsets,
-  and `%active_lanes` bounds the number of active gathered blocks.
-- **outputs:**
-  `%result` is the gathered vector.
-- **constraints and limitations:**
-  This is a block gather, not a byte-per-lane gather. `%source` MUST be 32-byte
-  aligned, each participating offset MUST describe a 32-byte-aligned block, and
-  inactive blocks are zero-filled.
+- **Latency:** **~21** cycles issue→retire.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -221,15 +241,7 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `%result = pto.vgather2_bc %source, %offsets, %mask : !pto.ptr<T, ub>, !pto.vreg<NxI>, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Gather with broadcast, conditioned by mask.
-- **inputs:**
-  `%source` is the UB base pointer, `%offsets` contains gather indices, and
-  `%mask` gates which lanes participate.
-- **outputs:**
-  `%result` is the gathered vector.
-- **constraints and limitations:**
-  This is a backward-compatible family. Masked-off lanes do not participate in
-  address coalescing and do not trigger address overflow exceptions; their
-  destination lanes are zero-filled.
+- **Latency:** **27–28** cycles (same as **`pto.vgather2`**).
 
 ---
 
@@ -239,26 +251,15 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask`
 - **semantics:** Vector store with distribution mode.
-- **inputs:**
-  `%value` is the source vector, `%dest` is the UB base pointer, `%offset` is
-  the displacement, `%mask` selects the active lanes or sub-elements, and
-  `DIST` selects the store distribution.
-- **outputs:**
-  This op has no SSA result; it writes to UB memory.
-- **constraints and limitations:**
-  The effective destination address MUST satisfy the alignment rule of the
-  selected store mode. Narrowing/packing modes may only preserve a subset of the
-  source bits. Merge-channel modes reinterpret the source vector as channel
-  planes and interleave them on store.
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics |
-|------|-------------|-------------|
-| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` |
-| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` |
-| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes |
-| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes |
+| Mode | Description | C Semantics | Latency |
+|------|-------------|-------------|---------------------|
+| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` | **9** cycles |
+| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` | **9** cycles |
+| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes | **9** cycles |
+| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes | **9** cycles |
 
 **Example — Contiguous store:**
 ```mlir
@@ -273,16 +274,7 @@ pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.p
 
 - **syntax:** `pto.vstx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.ptr<T, ub>, index, !pto.mask`
 - **semantics:** Dual interleaved store (SoA → AoS conversion).
-- **inputs:**
-  `%low` and `%high` are the two source vectors, `%dest` is the UB base pointer,
-  `%offset` is the displacement, `DIST` selects the interleave layout, and
-  `%mask` gates the participating elements.
-- **outputs:**
-  This op has no SSA result; it writes an interleaved stream to UB.
-- **constraints and limitations:**
-  This family is only legal for interleave distributions. The two source
-  vectors form an ordered pair, and the interleave semantics of that pair MUST
-  be preserved.
+- **Latency:** **`INTLV_B32` / `INTLV_B16` / `INTLV_B8` → 12** cycles on `RV_VSTI`.
 
 **Distribution modes:** `INTLV_B8`, `INTLV_B16`, `INTLV_B32`
 
@@ -302,14 +294,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `pto.vsst %value, %dest[%offset], "STRIDE" : !pto.vreg<NxT>, !pto.ptr<T, ub>`
 - **semantics:** Strided store with fixed stride pattern.
-- **inputs:**
-  `%value` is the source vector, `%dest` is the UB base pointer, and `%offset`
-  / `STRIDE` select the fixed strided layout.
-- **outputs:**
-  This op writes UB memory and returns no SSA value.
-- **constraints and limitations:**
-  This is a deprecated compatibility family. The stride token, not the vector
-  lane number alone, determines which destination elements are written.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -317,14 +302,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `pto.vsstb %value, %dest, %offset, %mask : !pto.vreg<NxT>, !pto.ptr<T, ub>, i32, !pto.mask`
 - **semantics:** Block-strided store for 2D tile access.
-- **inputs:**
-  `%value` is the source vector, `%dest` is the UB base pointer, `%offset` is
-  the packed stride/control word, and `%mask` controls block participation.
-- **outputs:**
-  This op writes UB memory and returns no SSA value.
-- **constraints and limitations:**
-  `%offset` is a control word, not a plain byte displacement. This is a
-  deprecated compatibility family kept for surface coverage.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -334,17 +312,7 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `pto.vscatter %value, %dest, %offsets, %active_lanes : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.vreg<NxI>, index`
 - **semantics:** Indexed scatter to UB.
-- **inputs:**
-  `%value` is the source vector, `%dest` is the UB base pointer, `%offsets`
-  provides per-lane or per-block indices, and `%active_lanes` bounds the active
-  requests.
-- **outputs:**
-  This op writes UB memory and returns no SSA value.
-- **constraints and limitations:**
-  Only `b8`, `b16`, and `b32` element sizes are supported. The index vector
-  must use a supported integer element type and layout for this family.
-  Each computed address MUST be element-aligned. If two or more indices alias,
-  only one write is guaranteed and the winning lane is implementation-defined.
+- **Latency:** **~17** cycles for **`Dtype: B16`**.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -359,91 +327,15 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `pto.vsta %value, %dest[%offset] : !pto.align, !pto.ptr<T, ub>, index`
 - **semantics:** Flush alignment state to memory.
-- **inputs:**
-  `%value` is the pending store-alignment state, `%dest` is the UB base pointer,
-  and `%offset` is the flush displacement.
-- **outputs:**
-  This op writes buffered tail bytes to UB and returns no SSA value.
-- **constraints and limitations:**
-  The flush address MUST match the post-updated address expected by the
-  preceding unaligned-store stream. After the flush, the corresponding store
-  alignment state is consumed.
+- **Latency:** **9** cycles.
 
 ---
 
 ### `pto.vstas`
-- **syntax:** `pto.vstas %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, i32`
-- **semantics:** Scalar-register-offset form of alignment-state flush.
-- **inputs:**
-  `%value` is the pending store-alignment state, `%dest` is the UB base
-  pointer, and `%offset` is the scalar-register style displacement.
-- **outputs:**
-  This op writes buffered tail bytes to UB and returns no SSA value.
-- **constraints and limitations:**
-  This family uses the same buffered-tail semantics as `pto.vsta` but keeps the
-  scalar-offset form explicit.
-
----
-
-### `pto.vstar`
-- **syntax:** `pto.vstar %value, %dest : !pto.align, !pto.ptr<T, ub>`
-- **semantics:** Flush alignment state using the register-update form.
-- **inputs:**
-  `%value` is the pending store-alignment state and `%dest` is the UB base
-  pointer.
-- **outputs:**
-  This op writes buffered tail bytes to UB and returns no SSA value.
-- **constraints and limitations:**
-  The implicit update state consumed by this flush MUST correspond to the same
-  store stream that produced `%value`.
-
----
-
-### `pto.vstu`
-- **syntax:** `%align_out, %base_out = pto.vstu %align_in, %base_in, %value, %dest, %mode : !pto.align, !pto.ptr<T, ub>, !pto.vreg<NxT>, !pto.ptr<T, ub>, index -> !pto.align, !pto.ptr<T, ub>`
-- **semantics:** Unaligned store with explicit threaded alignment/base state.
-- **inputs:**
-  `%align_in` is the incoming store-alignment state, `%base_in` is the current
-  stream base, `%value` is the vector to store, `%dest` is the UB base pointer,
-  and `%mode` selects the post-update behavior.
-- **outputs:**
-  `%align_out` is the updated buffered-tail state and `%base_out` is the
-  post-update base pointer state.
-- **constraints and limitations:**
-  This op models a stateful unaligned-store sequence in SSA form. A final
-  `pto.vsta` / `pto.vstas` / `pto.vstar` is still required to flush the trailing
-  buffered bytes.
-
----
-
-### `pto.vstus`
-- **syntax:** `%align_out, %base_out = pto.vstus %align_in, %base_in, %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, !pto.vreg<NxT>, !pto.ptr<T, ub>, i32 -> !pto.align, !pto.ptr<T, ub>`
-- **semantics:** Scalar-offset unaligned store with threaded state.
-- **inputs:**
-  Same roles as `pto.vstu`, but `%offset` is provided explicitly as the scalar
-  displacement.
-- **outputs:**
-  Updated alignment state and base state.
-- **constraints and limitations:**
-  The same final flush requirement and state-threading constraints as
-  `pto.vstu` apply.
-
----
-
-### `pto.vstur`
-- **syntax:** `%align_out = pto.vstur %align_in, %value, %dest : !pto.align, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align`
-- **semantics:** Register-update unaligned store form.
-- **inputs:**
-  `%align_in` is the incoming store-alignment state, `%value` is the vector to
-  store, and `%dest` is the UB base pointer.
-- **outputs:**
-  `%align_out` is the updated buffered-tail state.
-- **constraints and limitations:**
-  This op updates only the residual alignment state. A matching flush op is
-  still required to emit the trailing bytes.
 
 - **syntax:** `pto.vstas %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, i32`
 - **semantics:** Flush alignment state with scalar offset.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -451,16 +343,7 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `pto.vstar %value, %dest : !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Flush remaining alignment state.
-- **inputs:**
-  `%value` is the pending alignment/buffer state that still needs to be emitted,
-  and `%dest` is the UB destination base pointer.
-- **outputs:**
-  No SSA result. The effect is a memory-side flush that writes the remaining
-  buffered bytes to memory.
-- **constraints and limitations:**
-  This op terminates an unaligned-store sequence. It MUST be paired with a
-  compatible prior state-producing store sequence so that the pending tail state
-  is well-defined.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -472,17 +355,7 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out, %offset_out = pto.vstu %align_in, %offset_in, %value, %base, "MODE" : !pto.align, index, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align, index`
 - **semantics:** Unaligned store with align + offset state update.
-- **inputs:**
-  `%align_in` is the incoming store-alignment state, `%offset_in` is the current
-  logical byte/element displacement, `%value` is the vector being stored, and
-  `%base` is the UB base pointer.
-- **outputs:**
-  `%align_out` is the updated alignment/tail state and `%offset_out` is the
-  next offset after applying the selected post-update rule.
-- **constraints and limitations:**
-  The alignment state MUST be threaded in program order. A terminating flush
-  form such as `pto.vstar`/`pto.vstas` is still required to commit the buffered
-  tail bytes.
+- **Latency:** **9** cycles.
 
 **Mode tokens:** `POST_UPDATE`, `NO_POST_UPDATE`
 
@@ -492,17 +365,7 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out, %base_out = pto.vstus %align_in, %offset, %value, %base, "MODE" : !pto.align, i32, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Unaligned store with scalar offset and state update.
-- **inputs:**
-  `%align_in` is the incoming store-alignment state, `%offset` is the scalar
-  displacement, `%value` is the vector being stored, and `%base` is the UB base
-  pointer.
-- **outputs:**
-  `%align_out` is the updated buffered-tail state and `%base_out` is the next
-  base pointer when the lowering chooses a post-update form.
-- **constraints and limitations:**
-  This is the scalar-offset stateful form of the unaligned store family. The
-  scalar offset width and update mode MUST match the selected form, and a later
-  flush op is still required.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -510,12 +373,4 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out = pto.vstur %align_in, %value, %base, "MODE" : !pto.align, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align`
 - **semantics:** Unaligned store with residual flush and state update.
-- **inputs:**
-  `%align_in` is the incoming store-alignment state, `%value` is the vector to
-  store, and `%base` is the UB base pointer.
-- **outputs:**
-  `%align_out` is the updated residual state after the current partial store.
-- **constraints and limitations:**
-  This form exposes only the evolving state; it does not by itself guarantee
-  that all buffered bytes have reached memory. A compatible final flush is still
-  required unless the surrounding sequence is known to be complete.
+- **Latency:** **9** cycles.

--- a/docs/isa/06-unary-vector-ops.md
+++ b/docs/isa/06-unary-vector-ops.md
@@ -5,6 +5,23 @@
 
 Element-wise operations that take one vector input and produce one vector output.
 
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** values use **aclFloat16** in traces where measured. **bf16:** no simple-tile ST coverage on this surface; treat as **—**.
+
+| PTO op | RV (CA) | fp32 | fp16 | bf16 |
+|--------|---------|------|------|------|
+| `pto.vabs` | `RV_VABS_FP` | **5** | **5** | — |
+| `pto.vneg` | `RV_VMULS` | **8** | **8** | — |
+| `pto.vexp` | `RV_VEXP` | **16** | **21** | — |
+| `pto.vln` | `RV_VLN` | **18** | **23** | — |
+| `pto.vsqrt` | `RV_VSQRT` | **17** | **22** | — |
+| `pto.vrsqrt` | `RV_VSQRT` / `RV_VDIV` | **17** / **17** | **22** / **22** | — |
+| `pto.vrec` | `RV_VDIV` | **17** | **22** | — |
+| `pto.vrelu` | `RV_VRELU` | **5** | **5** | — |
+| `pto.vnot` | `RV_VNOT` | — | int-only paths | — |
+| `pto.vmov` | `RV_VLD` proxy | **9** | **9** | — |
+
 ## Common Operand Model
 
 - `%input` is the source vector register value.

--- a/docs/isa/07-binary-vector-ops.md
+++ b/docs/isa/07-binary-vector-ops.md
@@ -5,6 +5,17 @@
 
 Element-wise operations that take two vector inputs and produce one vector output.
 
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **aclFloat16** in measured traces. **bf16:** — (no dedicated vec tile ST on this surface).
+
+| PTO op | RV (CA) | fp32 | fp16 | bf16 |
+|--------|---------|------|------|------|
+| `pto.vadd` | `RV_VADD` | **7** | **7** | — |
+| `pto.vsub` | `RV_VSUB` | **7** | **7** | — |
+| `pto.vmul` | `RV_VMUL` | **8** | **8** | — |
+| `pto.vdiv` | `RV_VDIV` | **17** | **22** | — |
+
 ## Common Operand Model
 
 - `%lhs` and `%rhs` are the two source vector register values.

--- a/docs/isa/08-vec-scalar-ops.md
+++ b/docs/isa/08-vec-scalar-ops.md
@@ -5,6 +5,15 @@
 
 Operations that combine a vector with a scalar value, applying the scalar to every lane.
 
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **aclFloat16** in measured traces. **bf16:** —.
+
+| PTO op | RV (CA) | fp32 | fp16 | bf16 |
+|--------|---------|------|------|------|
+| `pto.vadds` | `RV_VADDS` | **7** | **7** | — |
+| `pto.vmuls` | `RV_VMULS` | **8** | **8** | — |
+
 ## Common Operand Model
 
 - `%input` is the source vector register value.

--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -5,6 +5,15 @@
 
 Operations that convert between data types (float/int, narrowing/widening).
 
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). Only representative traces below; other `pto.vcvt` conversion pairs depend on the RV lowering in the trace.
+
+| PTO op | RV (CA) | Note | Latency |
+|--------|---------|------|---------|
+| `pto.vcvt` | `RV_VCVT_F2F` | f32→f16 | **7** |
+| `pto.vci` | — | no vector `RV_*` in sampled `veccore0` trace | — |
+
 ## Common Operand Model
 
 - `%input` is the source vector register value.


### PR DESCRIPTION
## Summary

This PR updates `docs/isa/03-vector-load-store.md` with:

- **Latency and throughput (A5)** — simulator issue→retire tables for `dist:` tokens, reference RV op latencies, PTO `dist` summaries, gather/scatter notes, and **issue rules** (`pto.vlds` dual-issue **or** `vlds`+`vsts` 1+1 per cycle, mutually exclusive).
- Per-op **Latency** bullets throughout; wording uses **Latency** (not "CA latency") and drops testcase-only provenance per spec style.

## Verification split

- New `docs/isa/verification.md` — how to reproduce timings from simulator logs and pto-isa ST builds (points back to the spec for numbers).
- New `docs/isa/scripts/` — `camodel_dist_latency.py`, `run_one_st_camodel.sh`, `run_03_vector_load_store_traces.sh`, and `camodel_parse_latencies.py` as referenced from verification.

## Validation

- Documentation-only change; no build or test commands required for merge readiness.

Base branch: `feature-vpto-backend` (repo default integration branch).

Made with [Cursor](https://cursor.com)