### PR TITLE
docs(isa): restore §3 + §6–§9 layout after PR #21 (latency preserved)

### DIFF
--- a/docs/isa/03-vector-load-store.md
+++ b/docs/isa/03-vector-load-store.md
@@ -141,17 +141,20 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics |
-|------|-------------|-------------|
-| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` |
-| `BRC_B8/B16/B32` | Broadcast single element | `dst[i] = UB[base]` for all i |
-| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` |
-| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` |
-| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` |
-| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte |
-| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element |
-| `DINTLV_B32` | Deinterleave 32-bit | Even elements only |
-| `BLK` | Block load | Blocked access pattern |
+| Mode | Description | C Semantics | Latency |
+|------|-------------|-------------|---------------------|
+| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` | **9** cycles |
+| `BRC_B32` | Broadcast single element | `dst[i] = UB[base]` for all i | **9** cycles |
+| `BRC_B8`, `BRC_B16` | Broadcast first lane element | Same idea at B8/B16 width | **9** cycles |
+| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` | **9** cycles |
+| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` | **9** cycles |
+| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` | **9** cycles |
+| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte | **9** cycles |
+| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element | **9** cycles |
+| `DINTLV_B32` | Deinterleave 32-bit | Even elements only | **9** cycles |
+| `DINTLV_B16`, `DINTLV_B8` | Deinterleave 16-bit / 8-bit | Pair lanes from interleaved UB | **9** cycles |
+| `BDINTLV` | Block deinterleave | (see PTO headers for exact tiling) | **9** cycles |
+| `BLK` | Block load | Blocked / tiled access pattern (see PTO headers) | **9** cycles (`dist:BRC_BLK` on `RV_VLD`) |
 
 **Example — Contiguous load:**
 ```mlir
@@ -178,6 +181,7 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
   This op is the required leading operation for a `pto.vldus` stream using the
   same alignment state. The source address itself need not be 32-byte aligned;
   hardware truncates it to the aligned block boundary for the priming load.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -196,6 +200,7 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
   A matching `pto.vldas` MUST appear before the first dependent `pto.vldus`
   stream in the same vector loop. Both the alignment state and the base address
   advance across the stream, and the PTO micro Instruction representation exposes those updates as SSA results.
+- **Latency:** **9** cycles.
 
 **Unaligned load pattern:**
 ```mlir
@@ -219,6 +224,7 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 - **constraints and limitations:**
   This family is only legal for interleave/deinterleave style distributions.
   The two outputs form an ordered pair, and that pairing MUST be preserved.
+- **Latency:** **`DINTLV_B32` → 9** cycles on `RV_VLDI`. **`DINTLV_B16` / `DINTLV_B8` → 9** cycles on `RV_VLDI`. **`BDINTLV` → 9** cycles on `RV_VLDI`.
 
 **Distribution modes:** `DINTLV_B8`, `DINTLV_B16`, `DINTLV_B32`, `BDINTLV`
 
@@ -251,6 +257,7 @@ for (int i = 0; i < 64; i++) {
 - **constraints and limitations:**
   This is a deprecated compatibility family. The selected stride token
   determines which sub-elements are read from each source block.
+- **Latency:** **9** cycles.
 
 **Stride modes:** `STRIDE_S3_B16`, `STRIDE_S4_B64`, `STRIDE_S8_B32`, `STRIDE_S2_B64`
 
@@ -269,6 +276,7 @@ for (int i = 0; i < 64; i++) {
   `%offset` is not a plain byte displacement; it encodes the block stride and
   repeat pattern. If a block is masked off, the corresponding destination block
   is zeroed and MUST NOT raise an address overflow exception for that block.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -287,6 +295,7 @@ for (int i = 0; i < 64; i++) {
   Only the first `%active_lanes` indices participate. The index element width
   and interpretation MUST match the selected gather form, and each effective
   address must satisfy that form's alignment rules.
+- **Latency:** **27–28** cycles per `RV_VGATHER2`; throughput much lower than contiguous `RV_VLD` (see **Latency and throughput (A5)** at the start of this chapter).
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -308,6 +317,7 @@ for (int i = 0; i < active_lanes; i++)
   This is a block gather, not a byte-per-lane gather. `%source` MUST be 32-byte
   aligned, each participating offset MUST describe a 32-byte-aligned block, and
   inactive blocks are zero-filled.
+- **Latency:** **~21** cycles issue→retire.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -329,6 +339,7 @@ for (int i = 0; i < active_lanes; i++)
   This is a backward-compatible family. Masked-off lanes do not participate in
   address coalescing and do not trigger address overflow exceptions; their
   destination lanes are zero-filled.
+- **Latency:** **27–28** cycles (same as **`pto.vgather2`**).
 
 ---
 
@@ -352,12 +363,12 @@ for (int i = 0; i < active_lanes; i++)
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics |
-|------|-------------|-------------|
-| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` |
-| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` |
-| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes |
-| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes |
+| Mode | Description | C Semantics | Latency |
+|------|-------------|-------------|---------------------|
+| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` | **9** cycles |
+| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` | **9** cycles |
+| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes | **9** cycles |
+| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes | **9** cycles |
 
 **Example — Contiguous store:**
 ```mlir
@@ -382,6 +393,7 @@ pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.p
   This family is only legal for interleave distributions. The two source
   vectors form an ordered pair, and the interleave semantics of that pair MUST
   be preserved.
+- **Latency:** **`INTLV_B32` / `INTLV_B16` / `INTLV_B8` → 12** cycles on `RV_VSTI`.
 
 **Distribution modes:** `INTLV_B8`, `INTLV_B16`, `INTLV_B32`
 
@@ -409,6 +421,7 @@ for (int i = 0; i < 64; i++) {
 - **constraints and limitations:**
   This is a deprecated compatibility family. The stride token, not the vector
   lane number alone, determines which destination elements are written.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -424,6 +437,7 @@ for (int i = 0; i < 64; i++) {
 - **constraints and limitations:**
   `%offset` is a control word, not a plain byte displacement. This is a
   deprecated compatibility family kept for surface coverage.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -444,6 +458,7 @@ for (int i = 0; i < 64; i++) {
   must use a supported integer element type and layout for this family.
   Each computed address MUST be element-aligned. If two or more indices alias,
   only one write is guaranteed and the winning lane is implementation-defined.
+- **Latency:** **~17** cycles for **`Dtype: B16`**.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -467,6 +482,7 @@ for (int i = 0; i < active_lanes; i++)
   The flush address MUST match the post-updated address expected by the
   preceding unaligned-store stream. After the flush, the corresponding store
   alignment state is consumed.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -481,6 +497,7 @@ for (int i = 0; i < active_lanes; i++)
 - **constraints and limitations:**
   This family uses the same buffered-tail semantics as `pto.vsta` but keeps the
   scalar-offset form explicit.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -495,6 +512,7 @@ for (int i = 0; i < active_lanes; i++)
 - **constraints and limitations:**
   The implicit update state consumed by this flush MUST correspond to the same
   store stream that produced `%value`.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -512,6 +530,7 @@ for (int i = 0; i < active_lanes; i++)
   This op models a stateful unaligned-store sequence in SSA form. A final
   `pto.vsta` / `pto.vstas` / `pto.vstar` is still required to flush the trailing
   buffered bytes.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -526,6 +545,7 @@ for (int i = 0; i < active_lanes; i++)
 - **constraints and limitations:**
   The same final flush requirement and state-threading constraints as
   `pto.vstu` apply.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -540,26 +560,7 @@ for (int i = 0; i < active_lanes; i++)
 - **constraints and limitations:**
   This op updates only the residual alignment state. A matching flush op is
   still required to emit the trailing bytes.
-
-- **syntax:** `pto.vstas %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, i32`
-- **semantics:** Flush alignment state with scalar offset.
-
----
-
-### `pto.vstar`
-
-- **syntax:** `pto.vstar %value, %dest : !pto.align, !pto.ptr<T, ub>`
-- **semantics:** Flush remaining alignment state.
-- **inputs:**
-  `%value` is the pending alignment/buffer state that still needs to be emitted,
-  and `%dest` is the UB destination base pointer.
-- **outputs:**
-  No SSA result. The effect is a memory-side flush that writes the remaining
-  buffered bytes to memory.
-- **constraints and limitations:**
-  This op terminates an unaligned-store sequence. It MUST be paired with a
-  compatible prior state-producing store sequence so that the pending tail state
-  is well-defined.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -582,6 +583,7 @@ These ops make reference-updated state explicit as SSA results.
   The alignment state MUST be threaded in program order. A terminating flush
   form such as `pto.vstar`/`pto.vstas` is still required to commit the buffered
   tail bytes.
+- **Latency:** **9** cycles.
 
 **Mode tokens:** `POST_UPDATE`, `NO_POST_UPDATE`
 
@@ -602,6 +604,7 @@ These ops make reference-updated state explicit as SSA results.
   This is the scalar-offset stateful form of the unaligned store family. The
   scalar offset width and update mode MUST match the selected form, and a later
   flush op is still required.
+- **Latency:** **9** cycles.
 
 ---
 
@@ -618,3 +621,4 @@ These ops make reference-updated state explicit as SSA results.
   This form exposes only the evolving state; it does not by itself guarantee
   that all buffered bytes have reached memory. A compatible final flush is still
   required unless the surrounding sequence is known to be complete.
+- **Latency:** **9** cycles.

--- a/docs/isa/03-vector-load-store.md
+++ b/docs/isa/03-vector-load-store.md
@@ -5,6 +5,21 @@
 
 Vector loads move data from Unified Buffer (UB) to vector registers (`vreg`). Vector stores move data from `vreg` back to UB. All vector compute operates only on `vreg` — UB is the staging area between DMA and compute.
 
+## Common Operand Model
+
+- `%source` / `%dest` is the base address operand in SSA form. The base pointer
+  MUST address the Vector tile buffer / UB space.
+- `%offset` is the displacement operand in SSA form. The exact encoding is
+  instruction-specific, but the effective address and any post-update behavior
+  MUST match the selected instruction form.
+- `%mask` is the predicate operand for predicated memory families. For memory
+  families,
+  inactive lanes or inactive blocks MUST NOT issue memory requests unless the
+  instruction explicitly documents a different behavior.
+- `%result` is the destination vector register value in SSA form.
+- `!pto.align` is the SSA carrier for alignment-buffer state used by unaligned
+  load/store families. The PTO micro Instruction representation makes that state explicit rather than implicit.
+
 ---
 
 ## Latency and throughput (A5)
@@ -112,23 +127,31 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 
 - **syntax:** `%result = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>`
 - **semantics:** Vector load with distribution mode.
+- **inputs:**
+  `%source` is the UB base address, `%offset` is the load displacement, and
+  `DIST` selects the distribution mode.
+- **outputs:**
+  `%result` is the loaded vector register value.
+- **constraints and limitations:**
+  The effective address MUST satisfy the alignment rule of the selected
+  distribution mode. `NORM` reads one full vector footprint. Broadcast,
+  upsample, downsample, unpack, split-channel, and deinterleave modes change
+  how memory bytes are mapped into destination lanes, but they do not change the
+  fact that the source is UB memory.
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics | Latency |
-|------|-------------|-------------|---------------------|
-| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` | **9** cycles |
-| `BRC_B32` | Broadcast single element | `dst[i] = UB[base]` for all i | **9** cycles |
-| `BRC_B8`, `BRC_B16` | Broadcast first lane element | Same idea at B8/B16 width | **9** cycles |
-| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` | **9** cycles |
-| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` | **9** cycles |
-| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` | **9** cycles |
-| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte | **9** cycles |
-| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element | **9** cycles |
-| `DINTLV_B32` | Deinterleave 32-bit | Even elements only | **9** cycles |
-| `DINTLV_B16`, `DINTLV_B8` | Deinterleave 16-bit / 8-bit | Pair lanes from interleaved UB | **9** cycles |
-| `BDINTLV` | Block deinterleave | (see PTO headers for exact tiling) | **9** cycles |
-| `BLK` | Block load | Blocked / tiled access pattern (see PTO headers) | **9** cycles (`dist:BRC_BLK` on `RV_VLD`) |
+| Mode | Description | C Semantics |
+|------|-------------|-------------|
+| `NORM` | Contiguous 256B load | `dst[i] = UB[base + i * sizeof(T)]` |
+| `BRC_B8/B16/B32` | Broadcast single element | `dst[i] = UB[base]` for all i |
+| `US_B8/B16` | Upsample (duplicate each element) | `dst[2*i] = dst[2*i+1] = UB[base + i]` |
+| `DS_B8/B16` | Downsample (every 2nd element) | `dst[i] = UB[base + 2*i]` |
+| `UNPK_B8/B16/B32` | Unpack (zero-extend to wider type) | `dst_i32[i] = (uint32_t)UB_i16[base + 2*i]` |
+| `SPLT4CHN_B8` | Split 4-channel (RGBA → R plane) | Extract every 4th byte |
+| `SPLT2CHN_B8/B16` | Split 2-channel | Extract every 2nd element |
+| `DINTLV_B32` | Deinterleave 32-bit | Even elements only |
+| `BLK` | Block load | Blocked access pattern |
 
 **Example — Contiguous load:**
 ```mlir
@@ -146,7 +169,15 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 
 - **syntax:** `%result = pto.vldas %source : !pto.ptr<T, ub> -> !pto.align`
 - **semantics:** Prime alignment buffer for subsequent unaligned load.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%source` is the UB address whose surrounding aligned block seeds the load
+  alignment state.
+- **outputs:**
+  `%result` is the initialized load-alignment state.
+- **constraints and limitations:**
+  This op is the required leading operation for a `pto.vldus` stream using the
+  same alignment state. The source address itself need not be 32-byte aligned;
+  hardware truncates it to the aligned block boundary for the priming load.
 
 ---
 
@@ -154,7 +185,17 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 
 - **syntax:** `%result, %align_out, %base_out = pto.vldus %source, %align : !pto.ptr<T, ub>, !pto.align -> !pto.vreg<NxT>, !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Unaligned load using primed align state.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%source` is the current UB address and `%align` is the incoming load
+  alignment state primed by `pto.vldas` or a prior `pto.vldus`.
+- **outputs:**
+  `%result` is the assembled vector value, `%align_out` is the updated alignment
+  state, and `%base_out` is the post-update base pointer state exposed in SSA
+  form.
+- **constraints and limitations:**
+  A matching `pto.vldas` MUST appear before the first dependent `pto.vldus`
+  stream in the same vector loop. Both the alignment state and the base address
+  advance across the stream, and the PTO micro Instruction representation exposes those updates as SSA results.
 
 **Unaligned load pattern:**
 ```mlir
@@ -170,7 +211,14 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 
 - **syntax:** `%low, %high = pto.vldx2 %source[%offset], "DIST" : !pto.ptr<T, ub>, index -> !pto.vreg<NxT>, !pto.vreg<NxT>`
 - **semantics:** Dual load with deinterleave (AoS → SoA conversion).
-- **Latency:** **`DINTLV_B32` → 9** cycles on `RV_VLDI`. **`DINTLV_B16` / `DINTLV_B8` → 9** cycles on `RV_VLDI`. **`BDINTLV` → 9** cycles on `RV_VLDI`.
+- **inputs:**
+  `%source` is the UB base pointer, `%offset` is the displacement, and `DIST`
+  selects a dual-load/deinterleave layout.
+- **outputs:**
+  `%low` and `%high` are the two destination vectors.
+- **constraints and limitations:**
+  This family is only legal for interleave/deinterleave style distributions.
+  The two outputs form an ordered pair, and that pairing MUST be preserved.
 
 **Distribution modes:** `DINTLV_B8`, `DINTLV_B16`, `DINTLV_B32`, `BDINTLV`
 
@@ -195,7 +243,14 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `%result = pto.vsld %source[%offset], "STRIDE" : !pto.ptr<T, ub> -> !pto.vreg<NxT>`
 - **semantics:** Strided load with fixed stride pattern.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%source` is the UB base pointer and `%offset` is the displacement encoded
+  with the selected fixed stride mode.
+- **outputs:**
+  `%result` is the loaded vector.
+- **constraints and limitations:**
+  This is a deprecated compatibility family. The selected stride token
+  determines which sub-elements are read from each source block.
 
 **Stride modes:** `STRIDE_S3_B16`, `STRIDE_S4_B64`, `STRIDE_S8_B32`, `STRIDE_S2_B64`
 
@@ -203,9 +258,17 @@ for (int i = 0; i < 64; i++) {
 
 ### `pto.vsldb`
 
-- **syntax:** `%result = pto.vsldb %source, %offset, %mask : !pto.ptr<T, ub>, i32, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsldb %source, %offset, %mask : !pto.ptr<T, ub>, i32, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Block-strided load for 2D tile access.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%source` is the UB base pointer, `%offset` is the packed stride/control word,
+  and `%mask` controls which blocks participate.
+- **outputs:**
+  `%result` is the loaded vector.
+- **constraints and limitations:**
+  `%offset` is not a plain byte displacement; it encodes the block stride and
+  repeat pattern. If a block is masked off, the corresponding destination block
+  is zeroed and MUST NOT raise an address overflow exception for that block.
 
 ---
 
@@ -215,7 +278,15 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `%result = pto.vgather2 %source, %offsets, %active_lanes : !pto.ptr<T, ub>, !pto.vreg<NxI>, index -> !pto.vreg<NxT>`
 - **semantics:** Indexed gather from UB.
-- **Latency:** **27–28** cycles per `RV_VGATHER2`; throughput much lower than contiguous `RV_VLD` (see **Latency and throughput (A5)** at the start of this chapter).
+- **inputs:**
+  `%source` is the UB base pointer, `%offsets` provides per-lane element
+  offsets, and `%active_lanes` bounds how many lanes participate.
+- **outputs:**
+  `%result` is the gathered vector.
+- **constraints and limitations:**
+  Only the first `%active_lanes` indices participate. The index element width
+  and interpretation MUST match the selected gather form, and each effective
+  address must satisfy that form's alignment rules.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -228,7 +299,15 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `%result = pto.vgatherb %source, %offsets, %active_lanes : !pto.ptr<T, ub>, !pto.vreg<NxI>, index -> !pto.vreg<NxT>`
 - **semantics:** Byte-granularity indexed gather from UB.
-- **Latency:** **~21** cycles issue→retire.
+- **inputs:**
+  `%source` is the UB base pointer, `%offsets` contains per-block byte offsets,
+  and `%active_lanes` bounds the number of active gathered blocks.
+- **outputs:**
+  `%result` is the gathered vector.
+- **constraints and limitations:**
+  This is a block gather, not a byte-per-lane gather. `%source` MUST be 32-byte
+  aligned, each participating offset MUST describe a 32-byte-aligned block, and
+  inactive blocks are zero-filled.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -239,9 +318,17 @@ for (int i = 0; i < active_lanes; i++)
 
 ### `pto.vgather2_bc`
 
-- **syntax:** `%result = pto.vgather2_bc %source, %offsets, %mask : !pto.ptr<T, ub>, !pto.vreg<NxI>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vgather2_bc %source, %offsets, %mask : !pto.ptr<T, ub>, !pto.vreg<NxI>, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Gather with broadcast, conditioned by mask.
-- **Latency:** **27–28** cycles (same as **`pto.vgather2`**).
+- **inputs:**
+  `%source` is the UB base pointer, `%offsets` contains gather indices, and
+  `%mask` gates which lanes participate.
+- **outputs:**
+  `%result` is the gathered vector.
+- **constraints and limitations:**
+  This is a backward-compatible family. Masked-off lanes do not participate in
+  address coalescing and do not trigger address overflow exceptions; their
+  destination lanes are zero-filled.
 
 ---
 
@@ -249,21 +336,32 @@ for (int i = 0; i < active_lanes; i++)
 
 ### `pto.vsts`
 
-- **syntax:** `pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask<G>`
+- **syntax:** `pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask`
 - **semantics:** Vector store with distribution mode.
+- **inputs:**
+  `%value` is the source vector, `%dest` is the UB base pointer, `%offset` is
+  the displacement, `%mask` selects the active lanes or sub-elements, and
+  `DIST` selects the store distribution.
+- **outputs:**
+  This op has no SSA result; it writes to UB memory.
+- **constraints and limitations:**
+  The effective destination address MUST satisfy the alignment rule of the
+  selected store mode. Narrowing/packing modes may only preserve a subset of the
+  source bits. Merge-channel modes reinterpret the source vector as channel
+  planes and interleave them on store.
 
 **Distribution modes:**
 
-| Mode | Description | C Semantics | Latency |
-|------|-------------|-------------|---------------------|
-| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` | **9** cycles |
-| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` | **9** cycles |
-| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes | **9** cycles |
-| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes | **9** cycles |
+| Mode | Description | C Semantics |
+|------|-------------|-------------|
+| `NORM_B8/B16/B32` | Contiguous store | `UB[base + i] = src[i]` |
+| `PK_B16/B32` | Pack/narrowing store | `UB_i16[base + 2*i] = truncate_16(src_i32[i])` |
+| `MRG4CHN_B8` | Merge 4 channels (R,G,B,A → RGBA) | Interleave 4 planes |
+| `MRG2CHN_B8/B16` | Merge 2 channels | Interleave 2 planes |
 
 **Example — Contiguous store:**
 ```mlir
-pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<G>
+pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask
 ```
 
 ---
@@ -272,9 +370,18 @@ pto.vsts %v, %ub[%offset], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.p
 
 ### `pto.vstx2`
 
-- **syntax:** `pto.vstx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.ptr<T, ub>, index, !pto.mask<G>`
+- **syntax:** `pto.vstx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.ptr<T, ub>, index, !pto.mask`
 - **semantics:** Dual interleaved store (SoA → AoS conversion).
-- **Latency:** **`INTLV_B32` / `INTLV_B16` / `INTLV_B8` → 12** cycles on `RV_VSTI`.
+- **inputs:**
+  `%low` and `%high` are the two source vectors, `%dest` is the UB base pointer,
+  `%offset` is the displacement, `DIST` selects the interleave layout, and
+  `%mask` gates the participating elements.
+- **outputs:**
+  This op has no SSA result; it writes an interleaved stream to UB.
+- **constraints and limitations:**
+  This family is only legal for interleave distributions. The two source
+  vectors form an ordered pair, and the interleave semantics of that pair MUST
+  be preserved.
 
 **Distribution modes:** `INTLV_B8`, `INTLV_B16`, `INTLV_B32`
 
@@ -294,15 +401,29 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `pto.vsst %value, %dest[%offset], "STRIDE" : !pto.vreg<NxT>, !pto.ptr<T, ub>`
 - **semantics:** Strided store with fixed stride pattern.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%value` is the source vector, `%dest` is the UB base pointer, and `%offset`
+  / `STRIDE` select the fixed strided layout.
+- **outputs:**
+  This op writes UB memory and returns no SSA value.
+- **constraints and limitations:**
+  This is a deprecated compatibility family. The stride token, not the vector
+  lane number alone, determines which destination elements are written.
 
 ---
 
 ### `pto.vsstb`
 
-- **syntax:** `pto.vsstb %value, %dest, %offset, %mask : !pto.vreg<NxT>, !pto.ptr<T, ub>, i32, !pto.mask<G>`
+- **syntax:** `pto.vsstb %value, %dest, %offset, %mask : !pto.vreg<NxT>, !pto.ptr<T, ub>, i32, !pto.mask`
 - **semantics:** Block-strided store for 2D tile access.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%value` is the source vector, `%dest` is the UB base pointer, `%offset` is
+  the packed stride/control word, and `%mask` controls block participation.
+- **outputs:**
+  This op writes UB memory and returns no SSA value.
+- **constraints and limitations:**
+  `%offset` is a control word, not a plain byte displacement. This is a
+  deprecated compatibility family kept for surface coverage.
 
 ---
 
@@ -312,7 +433,17 @@ for (int i = 0; i < 64; i++) {
 
 - **syntax:** `pto.vscatter %value, %dest, %offsets, %active_lanes : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.vreg<NxI>, index`
 - **semantics:** Indexed scatter to UB.
-- **Latency:** **~17** cycles for **`Dtype: B16`**.
+- **inputs:**
+  `%value` is the source vector, `%dest` is the UB base pointer, `%offsets`
+  provides per-lane or per-block indices, and `%active_lanes` bounds the active
+  requests.
+- **outputs:**
+  This op writes UB memory and returns no SSA value.
+- **constraints and limitations:**
+  Only `b8`, `b16`, and `b32` element sizes are supported. The index vector
+  must use a supported integer element type and layout for this family.
+  Each computed address MUST be element-aligned. If two or more indices alias,
+  only one write is guaranteed and the winning lane is implementation-defined.
 
 ```c
 for (int i = 0; i < active_lanes; i++)
@@ -327,15 +458,91 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `pto.vsta %value, %dest[%offset] : !pto.align, !pto.ptr<T, ub>, index`
 - **semantics:** Flush alignment state to memory.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%value` is the pending store-alignment state, `%dest` is the UB base pointer,
+  and `%offset` is the flush displacement.
+- **outputs:**
+  This op writes buffered tail bytes to UB and returns no SSA value.
+- **constraints and limitations:**
+  The flush address MUST match the post-updated address expected by the
+  preceding unaligned-store stream. After the flush, the corresponding store
+  alignment state is consumed.
 
 ---
 
 ### `pto.vstas`
+- **syntax:** `pto.vstas %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, i32`
+- **semantics:** Scalar-register-offset form of alignment-state flush.
+- **inputs:**
+  `%value` is the pending store-alignment state, `%dest` is the UB base
+  pointer, and `%offset` is the scalar-register style displacement.
+- **outputs:**
+  This op writes buffered tail bytes to UB and returns no SSA value.
+- **constraints and limitations:**
+  This family uses the same buffered-tail semantics as `pto.vsta` but keeps the
+  scalar-offset form explicit.
+
+---
+
+### `pto.vstar`
+- **syntax:** `pto.vstar %value, %dest : !pto.align, !pto.ptr<T, ub>`
+- **semantics:** Flush alignment state using the register-update form.
+- **inputs:**
+  `%value` is the pending store-alignment state and `%dest` is the UB base
+  pointer.
+- **outputs:**
+  This op writes buffered tail bytes to UB and returns no SSA value.
+- **constraints and limitations:**
+  The implicit update state consumed by this flush MUST correspond to the same
+  store stream that produced `%value`.
+
+---
+
+### `pto.vstu`
+- **syntax:** `%align_out, %base_out = pto.vstu %align_in, %base_in, %value, %dest, %mode : !pto.align, !pto.ptr<T, ub>, !pto.vreg<NxT>, !pto.ptr<T, ub>, index -> !pto.align, !pto.ptr<T, ub>`
+- **semantics:** Unaligned store with explicit threaded alignment/base state.
+- **inputs:**
+  `%align_in` is the incoming store-alignment state, `%base_in` is the current
+  stream base, `%value` is the vector to store, `%dest` is the UB base pointer,
+  and `%mode` selects the post-update behavior.
+- **outputs:**
+  `%align_out` is the updated buffered-tail state and `%base_out` is the
+  post-update base pointer state.
+- **constraints and limitations:**
+  This op models a stateful unaligned-store sequence in SSA form. A final
+  `pto.vsta` / `pto.vstas` / `pto.vstar` is still required to flush the trailing
+  buffered bytes.
+
+---
+
+### `pto.vstus`
+- **syntax:** `%align_out, %base_out = pto.vstus %align_in, %base_in, %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, !pto.vreg<NxT>, !pto.ptr<T, ub>, i32 -> !pto.align, !pto.ptr<T, ub>`
+- **semantics:** Scalar-offset unaligned store with threaded state.
+- **inputs:**
+  Same roles as `pto.vstu`, but `%offset` is provided explicitly as the scalar
+  displacement.
+- **outputs:**
+  Updated alignment state and base state.
+- **constraints and limitations:**
+  The same final flush requirement and state-threading constraints as
+  `pto.vstu` apply.
+
+---
+
+### `pto.vstur`
+- **syntax:** `%align_out = pto.vstur %align_in, %value, %dest : !pto.align, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align`
+- **semantics:** Register-update unaligned store form.
+- **inputs:**
+  `%align_in` is the incoming store-alignment state, `%value` is the vector to
+  store, and `%dest` is the UB base pointer.
+- **outputs:**
+  `%align_out` is the updated buffered-tail state.
+- **constraints and limitations:**
+  This op updates only the residual alignment state. A matching flush op is
+  still required to emit the trailing bytes.
 
 - **syntax:** `pto.vstas %value, %dest, %offset : !pto.align, !pto.ptr<T, ub>, i32`
 - **semantics:** Flush alignment state with scalar offset.
-- **Latency:** **9** cycles.
 
 ---
 
@@ -343,7 +550,16 @@ for (int i = 0; i < active_lanes; i++)
 
 - **syntax:** `pto.vstar %value, %dest : !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Flush remaining alignment state.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%value` is the pending alignment/buffer state that still needs to be emitted,
+  and `%dest` is the UB destination base pointer.
+- **outputs:**
+  No SSA result. The effect is a memory-side flush that writes the remaining
+  buffered bytes to memory.
+- **constraints and limitations:**
+  This op terminates an unaligned-store sequence. It MUST be paired with a
+  compatible prior state-producing store sequence so that the pending tail state
+  is well-defined.
 
 ---
 
@@ -355,7 +571,17 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out, %offset_out = pto.vstu %align_in, %offset_in, %value, %base, "MODE" : !pto.align, index, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align, index`
 - **semantics:** Unaligned store with align + offset state update.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%align_in` is the incoming store-alignment state, `%offset_in` is the current
+  logical byte/element displacement, `%value` is the vector being stored, and
+  `%base` is the UB base pointer.
+- **outputs:**
+  `%align_out` is the updated alignment/tail state and `%offset_out` is the
+  next offset after applying the selected post-update rule.
+- **constraints and limitations:**
+  The alignment state MUST be threaded in program order. A terminating flush
+  form such as `pto.vstar`/`pto.vstas` is still required to commit the buffered
+  tail bytes.
 
 **Mode tokens:** `POST_UPDATE`, `NO_POST_UPDATE`
 
@@ -365,7 +591,17 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out, %base_out = pto.vstus %align_in, %offset, %value, %base, "MODE" : !pto.align, i32, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align, !pto.ptr<T, ub>`
 - **semantics:** Unaligned store with scalar offset and state update.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%align_in` is the incoming store-alignment state, `%offset` is the scalar
+  displacement, `%value` is the vector being stored, and `%base` is the UB base
+  pointer.
+- **outputs:**
+  `%align_out` is the updated buffered-tail state and `%base_out` is the next
+  base pointer when the lowering chooses a post-update form.
+- **constraints and limitations:**
+  This is the scalar-offset stateful form of the unaligned store family. The
+  scalar offset width and update mode MUST match the selected form, and a later
+  flush op is still required.
 
 ---
 
@@ -373,4 +609,12 @@ These ops make reference-updated state explicit as SSA results.
 
 - **syntax:** `%align_out = pto.vstur %align_in, %value, %base, "MODE" : !pto.align, !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.align`
 - **semantics:** Unaligned store with residual flush and state update.
-- **Latency:** **9** cycles.
+- **inputs:**
+  `%align_in` is the incoming store-alignment state, `%value` is the vector to
+  store, and `%base` is the UB base pointer.
+- **outputs:**
+  `%align_out` is the updated residual state after the current partial store.
+- **constraints and limitations:**
+  This form exposes only the evolving state; it does not by itself guarantee
+  that all buffered bytes have reached memory. A compatible final flush is still
+  required unless the surrounding sequence is known to be complete.

--- a/docs/isa/06-unary-vector-ops.md
+++ b/docs/isa/06-unary-vector-ops.md
@@ -5,6 +5,15 @@
 
 Element-wise operations that take one vector input and produce one vector output.
 
+## Common Operand Model
+
+- `%input` is the source vector register value.
+- `%mask` is the predicate operand. For this family, inactive lanes follow the
+  predication behavior of the selected instruction form: zeroing forms
+  zero-fill inactive lanes, while merging forms preserve the destination value.
+- `%result` is the destination vector register value. Unless stated otherwise,
+  `%result` has the same lane count and element type as `%input`.
+
 ## CA latency (A5, Ascend910_9599 CA)
 
 Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** values use **aclFloat16** in traces where measured. **bf16:** no simple-tile ST coverage on this surface; treat as **—**.
@@ -22,22 +31,13 @@ Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** values u
 | `pto.vnot` | `RV_VNOT` | — | int-only paths | — |
 | `pto.vmov` | `RV_VLD` proxy | **9** | **9** | — |
 
-## Common Operand Model
-
-- `%input` is the source vector register value.
-- `%mask` is the predicate operand. For this family, inactive lanes follow the
-  predication behavior of the selected instruction form: zeroing forms
-  zero-fill inactive lanes, while merging forms preserve the destination value.
-- `%result` is the destination vector register value. Unless stated otherwise,
-  `%result` has the same lane count and element type as `%input`.
-
 ---
 
 ## Arithmetic
 
 ### `pto.vabs`
 
-- **syntax:** `%result = pto.vabs %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vabs %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, f32
 
 ```c
@@ -56,7 +56,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vneg`
 
-- **syntax:** `%result = pto.vneg %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vneg %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, f32
 
 ```c
@@ -74,7 +74,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vexp`
 
-- **syntax:** `%result = pto.vexp %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vexp %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -90,7 +90,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vln`
 
-- **syntax:** `%result = pto.vln %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vln %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -108,7 +108,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsqrt`
 
-- **syntax:** `%result = pto.vsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -125,7 +125,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrsqrt`
 
-- **syntax:** `%result = pto.vrsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrsqrt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -143,7 +143,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrec`
 
-- **syntax:** `%result = pto.vrec %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrec %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -163,7 +163,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vrelu`
 
-- **syntax:** `%result = pto.vrelu %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vrelu %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 
 ```c
@@ -182,7 +182,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vnot`
 
-- **syntax:** `%result = pto.vnot %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vnot %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -198,7 +198,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vbcnt`
 
-- **syntax:** `%result = pto.vbcnt %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vbcnt %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -215,7 +215,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vcls`
 
-- **syntax:** `%result = pto.vcls %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vcls %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -234,7 +234,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmov`
 
-- **syntax:** `%result = pto.vmov %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmov %input, %mask : !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **semantics:** Vector register copy.
 
 ```c
@@ -253,12 +253,12 @@ for (int i = 0; i < N; i++)
 
 ```mlir
 // Softmax numerator: exp(x - max)
-%sub = pto.vsub %x, %max_broadcast, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
-%exp = pto.vexp %sub, %mask : !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%sub = pto.vsub %x, %max_broadcast, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+%exp = pto.vexp %sub, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Reciprocal for division
-%sum_rcp = pto.vrec %sum, %mask : !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%sum_rcp = pto.vrec %sum, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // ReLU activation
-%activated = pto.vrelu %linear_out, %mask : !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%activated = pto.vrelu %linear_out, %mask : !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 ```

--- a/docs/isa/07-binary-vector-ops.md
+++ b/docs/isa/07-binary-vector-ops.md
@@ -5,6 +5,15 @@
 
 Element-wise operations that take two vector inputs and produce one vector output.
 
+## Common Operand Model
+
+- `%lhs` and `%rhs` are the two source vector register values.
+- `%mask` is the predicate operand `Pg` that gates which lanes participate.
+- `%result` is the destination vector register value. Unless explicitly noted,
+  it has the same lane count and element type as the inputs.
+- Unless explicitly documented otherwise, `%lhs`, `%rhs`, and `%result` MUST
+  have matching vector shapes and element types.
+
 ## CA latency (A5, Ascend910_9599 CA)
 
 Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **aclFloat16** in measured traces. **bf16:** — (no dedicated vec tile ST on this surface).
@@ -16,22 +25,13 @@ Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **a
 | `pto.vmul` | `RV_VMUL` | **8** | **8** | — |
 | `pto.vdiv` | `RV_VDIV` | **17** | **22** | — |
 
-## Common Operand Model
-
-- `%lhs` and `%rhs` are the two source vector register values.
-- `%mask` is the predicate operand `Pg` that gates which lanes participate.
-- `%result` is the destination vector register value. Unless explicitly noted,
-  it has the same lane count and element type as the inputs.
-- Unless explicitly documented otherwise, `%lhs`, `%rhs`, and `%result` MUST
-  have matching vector shapes and element types.
-
 ---
 
 ## Arithmetic
 
 ### `pto.vadd`
 
-- **syntax:** `%result = pto.vadd %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vadd %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i64, f16, bf16, f32
 
 ```c
@@ -48,7 +48,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsub`
 
-- **syntax:** `%result = pto.vsub %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsub %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i64, f16, bf16, f32
 
 ```c
@@ -65,7 +65,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmul`
 
-- **syntax:** `%result = pto.vmul %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmul %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i16-i32, f16, bf16, f32 (**NOT** i8/u8)
 
 ```c
@@ -83,7 +83,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vdiv`
 
-- **syntax:** `%result = pto.vdiv %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vdiv %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32 only (no integer division)
 
 ```c
@@ -102,7 +102,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmax`
 
-- **syntax:** `%result = pto.vmax %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmax %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, bf16, f32
 
 ```c
@@ -118,7 +118,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmin`
 
-- **syntax:** `%result = pto.vmin %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmin %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** i8-i32, f16, bf16, f32
 
 ```c
@@ -136,7 +136,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vand`
 
-- **syntax:** `%result = pto.vand %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vand %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -152,7 +152,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vor`
 
-- **syntax:** `%result = pto.vor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -168,7 +168,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vxor`
 
-- **syntax:** `%result = pto.vxor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vxor %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -186,7 +186,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshl`
 
-- **syntax:** `%result = pto.vshl %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshl %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -205,7 +205,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshr`
 
-- **syntax:** `%result = pto.vshr %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshr %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>`
 - **A5 types:** all integer types
 
 ```c
@@ -225,7 +225,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vaddc`
 
-- **syntax:** `%result, %carry = pto.vaddc %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.mask<G>`
+- **syntax:** `%result, %carry = pto.vaddc %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>, !pto.mask`
 - **semantics:** Add with carry output.
 
 ```c
@@ -248,7 +248,7 @@ for (int i = 0; i < N; i++) {
 
 ### `pto.vsubc`
 
-- **syntax:** `%result, %borrow = pto.vsubc %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.mask<G>`
+- **syntax:** `%result, %borrow = pto.vsubc %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask -> !pto.vreg<NxT>, !pto.mask`
 - **semantics:** Subtract with borrow output.
 
 ```c
@@ -272,15 +272,15 @@ for (int i = 0; i < N; i++) {
 
 ```mlir
 // Vector addition
-%sum = pto.vadd %a, %b, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%sum = pto.vadd %a, %b, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Element-wise multiply
-%prod = pto.vmul %x, %y, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%prod = pto.vmul %x, %y, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Clamp to range [min, max]
-%clamped_low = pto.vmax %input, %min_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
-%clamped = pto.vmin %clamped_low, %max_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<G> -> !pto.vreg<64xf32>
+%clamped_low = pto.vmax %input, %min_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
+%clamped = pto.vmin %clamped_low, %max_vec, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask -> !pto.vreg<64xf32>
 
 // Bit manipulation
-%masked = pto.vand %data, %bitmask, %mask : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<G> -> !pto.vreg<64xi32>
+%masked = pto.vand %data, %bitmask, %mask : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask -> !pto.vreg<64xi32>
 ```

--- a/docs/isa/08-vec-scalar-ops.md
+++ b/docs/isa/08-vec-scalar-ops.md
@@ -5,15 +5,6 @@
 
 Operations that combine a vector with a scalar value, applying the scalar to every lane.
 
-## CA latency (A5, Ascend910_9599 CA)
-
-Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **aclFloat16** in measured traces. **bf16:** —.
-
-| PTO op | RV (CA) | fp32 | fp16 | bf16 |
-|--------|---------|------|------|------|
-| `pto.vadds` | `RV_VADDS` | **7** | **7** | — |
-| `pto.vmuls` | `RV_VMULS` | **8** | **8** | — |
-
 ## Common Operand Model
 
 - `%input` is the source vector register value.
@@ -23,13 +14,22 @@ Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **a
 - For 32-bit scalar forms, the scalar source MUST satisfy the backend's legal
   scalar-source constraints for this family.
 
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). **fp16** uses **aclFloat16** in measured traces. **bf16:** —.
+
+| PTO op | RV (CA) | fp32 | fp16 | bf16 |
+|--------|---------|------|------|------|
+| `pto.vadds` | `RV_VADDS` | **7** | **7** | — |
+| `pto.vmuls` | `RV_VMULS` | **8** | **8** | — |
+
 ---
 
 ## Arithmetic
 
 ### `pto.vadds`
 
-- **syntax:** `%result = pto.vadds %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vadds %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -47,7 +47,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vsubs`
 
-- **syntax:** `%result = pto.vsubs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vsubs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -63,7 +63,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmuls`
 
-- **syntax:** `%result = pto.vmuls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmuls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -79,7 +79,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmaxs`
 
-- **syntax:** `%result = pto.vmaxs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmaxs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -94,7 +94,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vmins`
 
-- **syntax:** `%result = pto.vmins %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vmins %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -111,7 +111,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vands`
 
-- **syntax:** `%result = pto.vands %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vands %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -126,7 +126,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vors`
 
-- **syntax:** `%result = pto.vors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -141,7 +141,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vxors`
 
-- **syntax:** `%result = pto.vxors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vxors %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -158,7 +158,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshls`
 
-- **syntax:** `%result = pto.vshls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshls %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -175,7 +175,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshrs`
 
-- **syntax:** `%result = pto.vshrs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshrs %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -191,7 +191,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vlrelu`
 
-- **syntax:** `%result = pto.vlrelu %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vlrelu %input, %scalar, %mask : !pto.vreg<NxT>, T, !pto.mask -> !pto.vreg<NxT>`
 
 ```c
 for (int i = 0; i < N; i++)
@@ -210,7 +210,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vaddcs`
 
-- **syntax:** `%result, %carry = pto.vaddcs %lhs, %rhs, %carry_in, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.mask<G>`
+- **syntax:** `%result, %carry = pto.vaddcs %lhs, %rhs, %carry_in, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask, !pto.mask -> !pto.vreg<NxT>, !pto.mask`
 - **semantics:** Add with carry-in and carry-out.
 
 ```c
@@ -233,7 +233,7 @@ for (int i = 0; i < N; i++) {
 
 ### `pto.vsubcs`
 
-- **syntax:** `%result, %borrow = pto.vsubcs %lhs, %rhs, %borrow_in, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.mask<G>`
+- **syntax:** `%result, %borrow = pto.vsubcs %lhs, %rhs, %borrow_in, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask, !pto.mask -> !pto.vreg<NxT>, !pto.mask`
 - **semantics:** Subtract with borrow-in and borrow-out.
 
 ```c
@@ -256,15 +256,15 @@ for (int i = 0; i < N; i++) {
 
 ```mlir
 // Add bias to all elements
-%biased = pto.vadds %activation, %bias_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
+%biased = pto.vadds %activation, %bias_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Scale by constant
-%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
+%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Clamp to [0, 255] for uint8 quantization
-%clamped_low = pto.vmaxs %input, %c0, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
-%clamped = pto.vmins %clamped_low, %c255, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
+%clamped_low = pto.vmaxs %input, %c0, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
+%clamped = pto.vmins %clamped_low, %c255, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 
 // Shift right by fixed amount
-%shifted = pto.vshrs %data, %c4, %mask : !pto.vreg<64xi32>, i32, !pto.mask<G> -> !pto.vreg<64xi32>
+%shifted = pto.vshrs %data, %c4, %mask : !pto.vreg<64xi32>, i32, !pto.mask -> !pto.vreg<64xi32>
 ```

--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -5,15 +5,6 @@
 
 Operations that convert between data types (float/int, narrowing/widening).
 
-## CA latency (A5, Ascend910_9599 CA)
-
-Cycle-accurate simulator **popped→retire** latency (cycles). Only representative traces below; other `pto.vcvt` conversion pairs depend on the RV lowering in the trace.
-
-| PTO op | RV (CA) | Note | Latency |
-|--------|---------|------|---------|
-| `pto.vcvt` | `RV_VCVT_F2F` | f32→f16 | **7** |
-| `pto.vci` | — | no vector `RV_*` in sampled `veccore0` trace | — |
-
 ## Common Operand Model
 
 - `%input` is the source vector register value.
@@ -22,6 +13,15 @@ Cycle-accurate simulator **popped→retire** latency (cycles). Only representati
   selection in attribute form.
 - The single `pto.vcvt` surface covers float-int, float-float, int-float, and
   int-int conversion families.
+
+## CA latency (A5, Ascend910_9599 CA)
+
+Cycle-accurate simulator **popped→retire** latency (cycles). Only representative traces below; other `pto.vcvt` conversion pairs depend on the RV lowering in the trace.
+
+| PTO op | RV (CA) | Note | Latency |
+|--------|---------|------|---------|
+| `pto.vcvt` | `RV_VCVT_F2F` | f32→f16 | **7** |
+| `pto.vci` | — | no vector `RV_*` in sampled `veccore0` trace | — |
 
 ---
 
@@ -120,7 +120,7 @@ For conversions that change width (e.g., f32→f16), use even/odd parts and comb
     : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
 %odd  = pto.vcvt %in1 {round_mode = "ROUND_R", sat = "RS_ENABLE", part = "PART_ODD"}
     : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-%result = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+%result = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask -> !pto.vreg<128xf16>
 ```
 
 ---
@@ -159,7 +159,7 @@ for (int i = 0; i < N; i++)
 
 ```mlir
 // Quantization: f32 → i8 with saturation
-%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+%scaled = pto.vmuls %input, %scale, %mask : !pto.vreg<64xf32>, f32, !pto.mask -> !pto.vreg<64xf32>
 %quantized = pto.vcvt %scaled {round_mode = "ROUND_R", sat = "RS_ENABLE"}
     : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
 // Then narrow i32 → i8 via pack ops


### PR DESCRIPTION
## Summary

Follow-up to **#21** (merged at `cee0cf5`): that commit added **§3** load/store latency and **§6–§9** CA tables but **dropped** the **`## Common Operand Model`** chapter intro and much of the per-op **inputs / outputs / constraints** text in **`03-vector-load-store.md`**. On **§6–§9**, **CA latency** was placed **above** **Common Operand Model**.

This PR restores the full **`03`** spec (merged from the pre-latency tree + the latency/throughput block) and reorders **§6–§9** so **Common Operand Model → CA latency → op sections**. No new files; **only** these five ISA chapters change.

## Files

- `docs/isa/03-vector-load-store.md`
- `docs/isa/06-unary-vector-ops.md` … `09-conversion-ops.md`

## Note

Unary op syntax lines on `feature-vpto-backend` had a stray `!pto.mask<G>` fragment; this PR aligns them to `!pto.mask` as in the restored source.

## Validation

Documentation-only.
