### PR TITLE
add SCF dialect deps for PTO bindings

### DIFF
--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(_pto PRIVATE
   MLIRCAPIIR
   MLIRSupport
   MLIRArithDialect
+  MLIRSCFDialect
   MLIRDestinationStyleOpInterface
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces

--- a/lib/PTO/IR/CMakeLists.txt
+++ b/lib/PTO/IR/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_dialect_library(PTOIR
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSCFDialect
   MLIRControlFlowInterfaces
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces


### PR DESCRIPTION
## Summary
- add MLIRSCFDialect to PTO Python binding link deps
- add MLIRSCFDialect to PTOIR public link deps

## Test plan
- [ ] build PTO Python bindings
- [ ] build PTOIR target

🤖 Generated with [Claude Code](https://claude.com/claude-code)