### PR TITLE
Fix VPTO control-flow type mismatch after VPTO op rewriting

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -463,6 +463,22 @@ static bool hasPtoPtrType(TypeRange types) {
   return llvm::any_of(types, [](Type type) { return isa<pto::PtrType>(type); });
 }
 
+static bool hasVPTOControlFlowCarrierType(Type type) {
+  if (isa<pto::VRegType, pto::MaskType, pto::AlignType>(type))
+    return true;
+  if (auto fnType = dyn_cast<FunctionType>(type)) {
+    return llvm::any_of(fnType.getInputs(), hasVPTOControlFlowCarrierType) ||
+           llvm::any_of(fnType.getResults(), hasVPTOControlFlowCarrierType);
+  }
+  return false;
+}
+
+static bool hasVPTOControlFlowCarrierType(TypeRange types) {
+  return llvm::any_of(types, [](Type type) {
+    return hasVPTOControlFlowCarrierType(type);
+  });
+}
+
 static bool hasPtoMemRefMemorySpace(Type type) {
   if (auto memRefType = dyn_cast<MemRefType>(type))
     return isa<pto::AddressSpaceAttr>(memRefType.getMemorySpace());
@@ -948,6 +964,113 @@ static LogicalResult normalizePtoPtrsToLLVM(ModuleOp module, llvm::raw_ostream &
     castOp.getResult(0).replaceAllUsesWith(castOp.getOperand(0));
     castOp.erase();
   }
+
+  return success();
+}
+
+static LogicalResult normalizeVPTOControlFlowTypes(ModuleOp module,
+                                                   llvm::raw_ostream &diagOS) {
+  MLIRContext *context = module.getContext();
+  TypeConverter typeConverter;
+  typeConverter.addConversion([](Type type) { return type; });
+  typeConverter.addConversion([&](pto::VRegType type) -> Type {
+    return VectorType::get({type.getElementCount()}, type.getElementType());
+  });
+  typeConverter.addConversion(
+      [&](pto::MaskType) -> Type { return VectorType::get({256}, IntegerType::get(context, 1)); });
+  typeConverter.addConversion(
+      [&](pto::AlignType) -> Type { return VectorType::get({32}, IntegerType::get(context, 8)); });
+
+  auto materializeCast = [](OpBuilder &builder, Type resultType,
+                            ValueRange inputs, Location loc) -> Value {
+    if (inputs.size() != 1)
+      return {};
+    return builder
+        .create<UnrealizedConversionCastOp>(loc, TypeRange{resultType}, inputs)
+        .getResult(0);
+  };
+  typeConverter.addSourceMaterialization(materializeCast);
+  typeConverter.addTargetMaterialization(materializeCast);
+  typeConverter.addArgumentMaterialization(materializeCast);
+
+  ConversionTarget target(*context);
+  target.addLegalOp<ModuleOp>();
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+    return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+           typeConverter.isLegal(&op.getBody());
+  });
+  target.addDynamicallyLegalOp<func::CallOp>(
+      [&](func::CallOp op) { return typeConverter.isLegal(op); });
+  target.addDynamicallyLegalOp<func::ReturnOp>(
+      [&](func::ReturnOp op) { return typeConverter.isLegal(op); });
+  target.addDynamicallyLegalOp<cf::BranchOp, cf::CondBranchOp>(
+      [&](Operation *op) {
+        return isLegalForBranchOpInterfaceTypeConversionPattern(op,
+                                                                typeConverter);
+      });
+  target.markUnknownOpDynamicallyLegal([&](Operation *op) {
+    return typeConverter.isLegal(op->getOperandTypes()) &&
+           typeConverter.isLegal(op->getResultTypes());
+  });
+
+  RewritePatternSet patterns(context);
+  scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter, patterns,
+                                                       target);
+  populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
+                                                                 typeConverter);
+  populateCallOpTypeConversionPattern(patterns, typeConverter);
+  populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
+  populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+    diagOS << "VPTO LLVM emission failed: VPTO control-flow type normalization "
+              "failed\n";
+    return failure();
+  }
+
+  SmallVector<UnrealizedConversionCastOp> castsToFold;
+  module.walk([&](UnrealizedConversionCastOp castOp) {
+    if (castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+      return;
+    if (!hasVPTOControlFlowCarrierType(castOp->getOperandTypes()) &&
+        !hasVPTOControlFlowCarrierType(castOp->getResultTypes()))
+      return;
+    Type convertedResultType = typeConverter.convertType(castOp.getResult(0).getType());
+    if (convertedResultType && convertedResultType == castOp.getOperand(0).getType())
+      castsToFold.push_back(castOp);
+  });
+  for (UnrealizedConversionCastOp castOp : castsToFold) {
+    castOp.getResult(0).replaceAllUsesWith(castOp.getOperand(0));
+    castOp.erase();
+  }
+
+  WalkResult leftover = module.walk([&](Operation *op) {
+    if (hasVPTOControlFlowCarrierType(op->getOperandTypes()) ||
+        hasVPTOControlFlowCarrierType(op->getResultTypes())) {
+      diagOS << "VPTO LLVM emission failed: residual VPTO carrier type on op "
+             << op->getName().getStringRef() << "\n";
+      op->print(diagOS);
+      diagOS << "\n";
+      return WalkResult::interrupt();
+    }
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        for (BlockArgument arg : block.getArguments()) {
+          if (!hasVPTOControlFlowCarrierType(arg.getType()))
+            continue;
+          diagOS << "VPTO LLVM emission failed: residual VPTO carrier type on "
+                    "block argument "
+                 << arg << " in op " << op->getName().getStringRef() << "\n";
+          op->print(diagOS);
+          diagOS << "\n";
+          return WalkResult::interrupt();
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+  if (leftover.wasInterrupted())
+    return failure();
 
   return success();
 }
@@ -2717,6 +2840,8 @@ buildLLVMModuleFromPreparedVPTO(ModuleOp module, llvm::LLVMContext &llvmContext,
     diagOS << "VPTO LLVM emission failed: VPTO-to-call rewriting failed\n";
     return nullptr;
   }
+  if (failed(normalizeVPTOControlFlowTypes(*cloned, diagOS)))
+    return nullptr;
   normalizeFuncSignaturesForOfficialLLVMLowering(*cloned);
 
   PassManager pm(cloned->getContext());

--- a/test/dsl/expand_tile_op_tilelang_tadds.pto
+++ b/test/dsl/expand_tile_op_tilelang_tadds.pto
@@ -1,0 +1,41 @@
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test ExpandTileOp expansion for pto.tadds in the VPTO pipeline.
+//
+// IMPORTANT: Do NOT use --enable-tile-op-expand for ops with scalar operands.
+// TADDS has a scalar operand (f32), so it uses the PTOToVPTO lowering path.
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --vpto-emit-hivm-llvm --print-ir-after-all %s -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK-LABEL: // -----// IR Dump After ExpandTileOp (pto-expand-tile-op) //----- //
+// CHECK: func.func @TADDS()
+// CHECK-NOT: pto.tadds ins
+// CHECK: call @__pto_tilelang_tadds
+// CHECK: func.func private @__pto_tilelang_tadds
+// CHECK: attributes {pto.tilelang.instance}
+// CHECK: pto.vecscope
+// CHECK: pto.vlds
+// CHECK: pto.vadds
+// CHECK: pto.vsts
+
+module {
+  func.func @TADDS() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scalar = arith.constant 1.0 : f32
+
+    pto.tadds ins(%a, %scalar : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                              blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                          f32)
+              outs(%tile_buf : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- add VPTO control-flow type normalization after  in 
- convert carrier types used by SCF/CFG structures (, , ) to legal builtin/vector types
- keep structural type conversion aligned for / region args, iter args, and yields before official LLVM lowering

## Root Cause
 rewrote PTO ops to  and converted result types early, but control-flow structural op types (especially loop-carried values in ) were not converted in lockstep, causing verifier failures like:
for is a shell keyword.

## Validation
- ninja: Entering directory `build'
[1/3] Building CXX object lib/PTO/Transforms/CMakeFiles/obj.PTOTransforms.dir/VPTOLLVMEmitter.cpp.o
In file included from /home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Interfaces/MemorySlotInterfaces.h:14,
                 from /home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h:19,
                 from /home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h:17,
                 from /home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h:18,
                 from /home/zhangzhendong/ptoas-workspace/PTOAS/include/PTO/IR/PTO.h:22,
                 from /home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:11:
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::memref::ReinterpretCastOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:521:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
In file included from /home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Conversion/LLVMCommon/TypeConverter.h:19,
                 from /home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:17:
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::memref::ReinterpretCastOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::memref::SubViewOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:541:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::memref::SubViewOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::UnrealizedConversionCastOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:560:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::UnrealizedConversionCastOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::pto::AddPtrOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:688:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::pto::AddPtrOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::pto::CastPtrOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:712:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::pto::CastPtrOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::pto::LoadScalarOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:770:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::pto::LoadScalarOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h: In instantiation of ‘class mlir::OpConversionPattern<mlir::pto::StoreScalarOp>’:
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:797:0:   required from here
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/IR/PatternMatch.h:255:16: warning: ‘virtual void mlir::RewritePattern::rewrite(mlir::Operation*, mlir::PatternRewriter&) const’ was hidden [-Woverloaded-virtual=]
  255 |   virtual void rewrite(Operation *op, PatternRewriter &rewriter) const;
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/llvm-project/mlir/include/mlir/Transforms/DialectConversion.h:552:16: note:   by ‘mlir::OpConversionPattern<mlir::pto::StoreScalarOp>::rewrite’
  552 |   virtual void rewrite(SourceOp op, OpAdaptor adaptor,
      |                ^~~~~~~
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:2685: warning: ‘llvm::LogicalResult mlir::pto::{anonymous}::rewriteFunctionsToEmitCStyleABI(llvm::Module&, const llvm::StringMap<FunctionABISpec>&, llvm::raw_ostream&)’ defined but not used [-Wunused-function]
 2685 | static LogicalResult rewriteFunctionsToEmitCStyleABI(
      | 
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:1168: warning: ‘mlir::Value mlir::pto::{anonymous}::buildAllTrueMask(mlir::OpBuilder&, mlir::Location)’ defined but not used [-Wunused-function]
 1168 | static Value buildAllTrueMask(OpBuilder &builder, Location loc) {
      | 
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:304: warning: ‘llvm::StringMap<mlir::pto::{anonymous}::FunctionABISpec> mlir::pto::{anonymous}::collectFunctionABISpecs(mlir::ModuleOp)’ defined but not used [-Wunused-function]
  304 | static llvm::StringMap<FunctionABISpec> collectFunctionABISpecs(ModuleOp module) {
      | 
/home/zhangzhendong/ptoas-workspace/PTOAS/lib/PTO/Transforms/VPTOLLVMEmitter.cpp:172: warning: ‘mlir::Type mlir::pto::{anonymous}::getSignlessIntegerTypeWithSameWidth(mlir::Type, mlir::Builder&)’ defined but not used [-Wunused-function]
  172 | static Type getSignlessIntegerTypeWithSameWidth(Type type, Builder &builder) {
      | 
[2/3] Linking CXX static library lib/PTO/Transforms/libPTOTransforms.a
[3/3] Linking CXX executable tools/ptoas/ptoas
- 
- -- Testing: 2 tests, 2 workers --
Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90.. 

Testing Time: 0.25s

Total Discovered Tests: 2
  Passed: 2 (100.00%)
