### PR TITLE
Support function-call lowering and floating-point literal forms in TileLang DSL

### DIFF
--- a/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
+++ b/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
@@ -35,12 +35,20 @@ static bool isInstanceFunc(func::FuncOp fn) {
   return fn->hasAttr(kOpLibAttrInstVariantId);
 }
 
-static bool isTilelangFunc(func::FuncOp fn) {
-  return fn->hasAttr("pto.tilelang.instance");
+static bool isTilelangInlineProcFunc(func::FuncOp fn) {
+  return fn->hasAttr("pto.tilelang.inline_proc");
+}
+
+static bool isTilelangTemplateFunc(func::FuncOp fn) {
+  return fn->hasAttr("pto.tilelang.instance") && fn.isPrivate();
 }
 
 static bool isInlineableLibFunc(func::FuncOp fn) {
-  return isInstanceFunc(fn) || isTilelangFunc(fn);
+  // Keep OP-Lib behavior unchanged while force-inlining TileLang helpers
+  // (inline_proc + private template helper).
+  if (isInstanceFunc(fn) || isTilelangInlineProcFunc(fn))
+    return true;
+  return isTilelangTemplateFunc(fn);
 }
 
 static Value maybeUnwrapCastToExpected(Value operand, Type expectedType) {
@@ -116,14 +124,17 @@ static void eraseDeadBridgeCasts(func::FuncOp func) {
 }
 
 static LogicalResult inlineCall(func::CallOp call, func::FuncOp callee) {
-  if (call.getNumResults() != 0)
-    return call.emitOpError("OP-Lib inline expects call without results");
   if (callee.isExternal())
     return call.emitOpError("callee must have a body before inlining");
 
   Block &entry = callee.getBody().front();
   if (entry.getNumArguments() != call.getNumOperands())
     return call.emitOpError("callee argument count mismatch during inlining");
+  auto returnOp = dyn_cast<func::ReturnOp>(entry.getTerminator());
+  if (!returnOp)
+    return call.emitOpError("callee must terminate with func.return");
+  if (returnOp.getNumOperands() != call.getNumResults())
+    return call.emitOpError("callee return/result arity mismatch during inlining");
 
   OpBuilder builder(call);
   IRMapping mapping;
@@ -136,6 +147,14 @@ static LogicalResult inlineCall(func::CallOp call, func::FuncOp callee) {
     for (auto [oldRes, newRes] :
          llvm::zip(op.getResults(), newOp->getResults()))
       mapping.map(oldRes, newRes);
+  }
+
+  for (auto [callResult, returnOperand] :
+       llvm::zip(call.getResults(), returnOp.getOperands())) {
+    Value mapped = mapping.lookupOrNull(returnOperand);
+    if (!mapped)
+      mapped = returnOperand;
+    callResult.replaceAllUsesWith(mapped);
   }
 
   call.erase();
@@ -156,7 +175,7 @@ struct PTOInlineLibCallPass
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {
       if (func.isExternal())
         continue;
-      if (isInlineableLibFunc(func))
+      if (isInstanceFunc(func))
         continue;
       if (func.empty())
         continue;
@@ -209,6 +228,14 @@ struct PTOInlineLibCallPass
         OpBuilder builder(call);
         auto newCall = builder.create<func::CallOp>(call.getLoc(), callee,
                                                     concreteOperands);
+        if (call.getNumResults() != newCall.getNumResults()) {
+          call.emitOpError("call result arity mismatch during inline staging");
+          signalPassFailure();
+          return;
+        }
+        for (auto [oldResult, newResult] :
+             llvm::zip(call.getResults(), newCall.getResults()))
+          oldResult.replaceAllUsesWith(newResult);
         call.erase();
 
         if (failed(inlineCall(newCall, callee))) {

--- a/test/basic/inline_libcall_filter_tilelang_scope.pto
+++ b/test/basic/inline_libcall_filter_tilelang_scope.pto
@@ -1,0 +1,38 @@
+// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: i32) {
+    %v0 = func.call @__tl_inline_add1_i32(%arg0) : (i32) -> i32
+    %v1 = func.call @__tilelang_template_passthrough_i32(%v0) : (i32) -> i32
+    %v2 = func.call @__regular_passthrough_i32(%v1) : (i32) -> i32
+    return
+  }
+
+  func.func private @__tl_inline_add1_i32(%x: i32) -> i32 attributes { pto.tilelang.inline_proc } {
+    %c1 = arith.constant 1 : i32
+    %y = arith.addi %x, %c1 : i32
+    return %y : i32
+  }
+
+  // This is intentionally NOT an inline_proc helper. The inline pass should
+  // still inline it because template helper inlining is enabled in VPTO
+  // mainline regardless of --enable-tile-op-expand.
+  func.func private @__tilelang_template_passthrough_i32(%x: i32) -> i32 attributes { pto.tilelang.instance } {
+    return %x : i32
+  }
+
+  // Regular private helper without TileLang/OP-Lib attrs must not be inlined
+  // by pto-inline-libcall.
+  func.func private @__regular_passthrough_i32(%x: i32) -> i32 {
+    return %x : i32
+  }
+}
+
+// CHECK-LABEL: func.func @kernel
+// CHECK: arith.constant 1 : i32
+// CHECK-NOT: func.call @__tl_inline_add1_i32
+// CHECK-NOT: call @__tilelang_template_passthrough_i32
+// CHECK: call @__regular_passthrough_i32
+// CHECK-NOT: func.func private @__tilelang_template_passthrough_i32
+// CHECK: func.func private @__regular_passthrough_i32
+// CHECK-NOT: func.func private @__tl_inline_add1_i32

--- a/test/basic/inline_libcall_result_rewrite.pto
+++ b/test/basic/inline_libcall_result_rewrite.pto
@@ -1,0 +1,36 @@
+// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%x: i32) {
+    %a, %b = func.call @__tl_inline_pair_i32(%x) : (i32) -> (i32, i32)
+    %sum = arith.addi %a, %b : i32
+    func.call @__tl_inline_sink_i32(%sum) : (i32) -> ()
+    return
+  }
+
+  func.func private @__tl_inline_pair_i32(%arg0: i32) -> (i32, i32) attributes { pto.tilelang.inline_proc } {
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %v1 = arith.addi %arg0, %c1 : i32
+    %v2 = arith.addi %arg0, %c2 : i32
+    return %v1, %v2 : i32, i32
+  }
+
+  func.func private @__tl_inline_sink_i32(%arg0: i32) attributes { pto.tilelang.inline_proc } {
+    %c0 = arith.constant 0 : i32
+    %_ = arith.addi %arg0, %c0 : i32
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @kernel(
+// CHECK: %[[C1:.+]] = arith.constant 1 : i32
+// CHECK: %[[C2:.+]] = arith.constant 2 : i32
+// CHECK: %[[V1:.+]] = arith.addi %{{[^,]+}}, %[[C1]] : i32
+// CHECK: %[[V2:.+]] = arith.addi %{{[^,]+}}, %[[C2]] : i32
+// CHECK: %[[SUM:.+]] = arith.addi %[[V1]], %[[V2]] : i32
+// CHECK: arith.constant 0 : i32
+// CHECK: arith.addi %[[SUM]]
+// CHECK-NOT: func.call @__tl_inline_
+// CHECK-NOT: func.func private @__tl_inline_pair_i32
+// CHECK-NOT: func.func private @__tl_inline_sink_i32

--- a/test/basic/tilelang_inline_proc_backend_inline.pto
+++ b/test/basic/tilelang_inline_proc_backend_inline.pto
@@ -1,0 +1,30 @@
+// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: i32) attributes { pto.tilelang.instance } {
+    %0 = func.call @__tl_inline_add1_i32(%arg0) : (i32) -> i32
+    func.call @__tl_inline_sink_i32(%0) : (i32) -> ()
+    return
+  }
+
+  func.func private @__tl_inline_add1_i32(%x: i32) -> i32 attributes { pto.tilelang.inline_proc } {
+    %c1 = arith.constant 1 : i32
+    %v = arith.addi %x, %c1 : i32
+    return %v : i32
+  }
+
+  func.func private @__tl_inline_sink_i32(%x: i32) attributes { pto.tilelang.inline_proc } {
+    %c2 = arith.constant 2 : i32
+    %t = arith.addi %x, %c2 : i32
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @kernel
+// CHECK: %[[C1:.+]] = arith.constant 1 : i32
+// CHECK: %[[ADD1:.+]] = arith.addi %arg0, %[[C1]] : i32
+// CHECK: %[[C2:.+]] = arith.constant 2 : i32
+// CHECK: arith.addi %[[ADD1]], %[[C2]] : i32
+// CHECK-NOT: func.call @__tl_inline_
+// CHECK-NOT: func.func private @__tl_inline_add1_i32
+// CHECK-NOT: func.func private @__tl_inline_sink_i32

--- a/test/basic/vpto_mainline_inline_proc_cleanup.pto
+++ b/test/basic/vpto_mainline_inline_proc_cleanup.pto
@@ -1,0 +1,28 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: i32) attributes { pto.tilelang.instance } {
+    %0 = func.call @__tl_inline_add1_i32(%arg0) : (i32) -> i32
+    func.call @__tl_inline_sink_i32(%0) : (i32) -> ()
+    return
+  }
+
+  func.func private @__tl_inline_add1_i32(%x: i32) -> i32 attributes { pto.tilelang.inline_proc } {
+    %c1 = arith.constant 1 : i32
+    %v = arith.addi %x, %c1 : i32
+    return %v : i32
+  }
+
+  func.func private @__tl_inline_sink_i32(%x: i32) attributes { pto.tilelang.inline_proc } {
+    %c2 = arith.constant 2 : i32
+    %t = arith.addi %x, %c2 : i32
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @kernel
+// CHECK: return
+// CHECK-NOT: func.call @__tl_inline_
+// CHECK-NOT: call @__tl_inline_
+// CHECK-NOT: pto.tilelang.inline_proc
+// CHECK-NOT: func.func private @__tl_inline_

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -24,6 +24,33 @@ x = pto.i32(1024)      # Explicit i32 constant
 y: pto.i32 = 1024      # Type annotation
 ```
 
+### Floating-Point Literal Forms
+
+`pto.f16(...)`, `pto.bf16(...)`, and `pto.f32(...)` accept multiple literal forms.
+
+```python
+# Signed numeric literals
+a = pto.f16(-1.5)
+b = pto.bf16(+2.5)
+c = pto.f32(-3.5)
+
+# Special floating-point values
+pos_inf = pto.f32("inf")
+neg_inf = pto.f32("-inf")
+qnan = pto.f32("nan")
+
+# Bit-pattern form (hex string, interpreted by target dtype)
+f16_neg_inf = pto.f16("0xFC00")
+bf16_neg_inf = pto.bf16("0xFF80")
+f32_neg_inf = pto.f32("0xFF800000")
+```
+
+Notes:
+- Prefer dtype constructors for reduction seeds and boundary values (for example rowmax initialization).
+- For float bit-pattern constants, pass a **string** hex literal to the matching dtype constructor.
+- Avoid passing raw integer bit-patterns directly into vector broadcast/dup APIs when a floating vector is expected.
+- `float(...)` function calls are not part of the TileLang DSL public call surface; use constructor forms above.
+
 ### Vector Types
 
 Vector registers have fixed 256-byte width:
@@ -102,5 +129,4 @@ buf2d = pto.memref((256, 128), pto.f32, MemorySpace.UB)   # 2D: 256x128 f32 buff
 - **Multi-dimensional shapes**: Use a tuple (e.g., `(256, 128)`)
 
 MemRefs are used for stateless load/store operations that accept `buf_like` operands in VPTO.
-
 

--- a/tilelang-dsl/docs/user_guide/08-control-flow.md
+++ b/tilelang-dsl/docs/user_guide/08-control-flow.md
@@ -78,6 +78,38 @@ with pto.vecscope():
 - `pto.vecscope()` does not support `as (...)` bindings.
 - When any explicit `pto.vecscope()` is present in a kernel body, automatic vecscope inference is disabled for that kernel.
 
+### Inline Procedures (`@pto.inline_proc`)
+
+TileLang DSL supports reusable top-level procedures decorated with `@pto.inline_proc`.
+`inline_proc` follows function-call semantics in frontend IR and is force-inlined
+later by the VPTO backend mainline in `ptoas`.
+
+```python
+@pto.inline_proc
+def store_row(dst: pto.Tile, src: pto.Tile, row: pto.i32):
+    vec = pto.vlds(src[row, 0:])
+    mask = pto.make_mask(dst.element_type, pto.PAT.ALL)
+    pto.vsts(vec, dst[row, 0:], mask)
+    return None
+
+@pto.vkernel(op="pto.row_copy", dtypes=[(pto.f32, pto.f32, pto.i32)])
+def row_copy(dst: pto.Tile, src: pto.Tile, row: pto.i32):
+    store_row(dst, src, row)
+    return None
+```
+
+Important semantics:
+
+- Frontend preserves helper `func.func` and `func.call` in `mlir_text()` output.
+- VPTO backend mainline force-inlines helper calls before downstream lowering.
+- Helper definitions support default parameter values.
+- Helper calls support positional arguments and keyword arguments.
+- Helper calls can appear in statement and expression positions.
+- Helper definitions can use trailing `return <expr>` to return values.
+- Implicit capture is rejected; pass required values as explicit arguments.
+- Recursive/mutually-recursive helper call graphs are rejected.
+- `*args`, `**kwargs`, and keyword-only parameters are unsupported in current version.
+
 ### Loops
 
 Counted loops use Python's `range` syntax:
@@ -108,4 +140,3 @@ else:
 ```
 
 Variables defined in only one branch are local to that branch.
-

--- a/tilelang-dsl/docs/user_guide/13-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/13-vector-arithmetic-operations.md
@@ -887,6 +887,10 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 # Broadcast scalar constant to vector
 zero_vec = pto.vbr(0.0)
 one_vec = pto.vbr(1.0)
+
+# Reduction seed with explicit floating dtype
+rowmax_seed_f32 = pto.vbr(pto.f32("-inf"))
+rowmax_seed_f16 = pto.vbr(pto.f16("0xFC00"))
 ```
 
 **Position Mode Enum**: The `PositionMode` enum provides type-safe position selection for `pto.vdup` operations. Currently only `LOWEST` (selects the lowest-index element) is supported, with more position options planned for future releases.
@@ -917,6 +921,10 @@ one_vec = pto.vbr(1.0)
 # Broadcast scalar to vector (similar to pto.vbr)
 broadcast = pto.vdup(3.14)  # position defaults to "POS_LOWEST"
 
+# Use dtype constructor when the semantic value is floating-point special value
+seed = pto.vdup(pto.f32("-inf"))
+seed_f16 = pto.vdup(pto.f16("0xFC00"))
+
 # Duplicate lowest element of vector to all lanes
 vec = pto.vreg_f32(64)  # 64-element vector
 dup_lowest = pto.vdup(vec)  # position defaults to "POS_LOWEST"
@@ -924,6 +932,10 @@ dup_lowest = pto.vdup(vec)  # position defaults to "POS_LOWEST"
 # Explicit position specification
 dup_explicit = pto.vdup(vec, position=PositionMode.LOWEST)
 ```
+
+**Type Safety Note**:
+- For floating-point seeds, prefer `pto.f16(...)` / `pto.bf16(...)` / `pto.f32(...)` constructors.
+- Do not pass integer bit-pattern literals directly (for example `0xFF800000`) when a floating vector type is intended.
 
 ### Carry & Select Operations
 

--- a/tilelang-dsl/python/tilelang_dsl/__init__.py
+++ b/tilelang-dsl/python/tilelang_dsl/__init__.py
@@ -10,10 +10,12 @@
 
 from .kernel import (
     BoundKernelParameter,
+    InlineProcDescriptor,
     KernelRegistry,
     MaterializedMLIRModule,
     TileLangFrontendError,
     VKernelDescriptor,
+    inline_proc,
     select_kernel,
     vkernel,
 )
@@ -59,10 +61,12 @@ from .types import (
 
 __all__ = [
     "BoundKernelParameter",
+    "InlineProcDescriptor",
     "KernelRegistry",
     "MaterializedMLIRModule",
     "TileLangFrontendError",
     "VKernelDescriptor",
+    "inline_proc",
     "select_kernel",
     "vkernel",
     "ScalarType",

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -743,6 +743,28 @@ def _build_expr(node: ast.AST, context: _FrontendBuildContext) -> FrontendExprNo
         return FrontendNameExpr(name=node.id)
     if isinstance(node, ast.Constant):
         return FrontendConstantExpr(value=node.value)
+    if isinstance(node, ast.UnaryOp):
+        if isinstance(node.op, ast.UAdd):
+            sign = 1
+        elif isinstance(node.op, ast.USub):
+            sign = -1
+        else:
+            raise context.error(
+                node,
+                f"unsupported unary operator `{type(node.op).__name__}` in TileLang DSL v1",
+            )
+        if not isinstance(node.operand, ast.Constant) or isinstance(node.operand.value, bool):
+            raise context.error(
+                node,
+                "unary +/- currently only supports numeric literals in TileLang DSL v1",
+            )
+        literal = node.operand.value
+        if not isinstance(literal, (int, float)):
+            raise context.error(
+                node,
+                "unary +/- currently only supports numeric literals in TileLang DSL v1",
+            )
+        return FrontendConstantExpr(value=literal if sign > 0 else -literal)
     if isinstance(node, ast.Slice):
         start = None if node.lower is None else _build_expr(node.lower, context)
         stop = None if node.upper is None else _build_expr(node.upper, context)

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import inspect
 from dataclasses import dataclass
 from typing import Any
 
@@ -159,6 +160,20 @@ class FrontendStrictVecscopeStmt(FrontendStmtNode):
 
 
 @dataclass(frozen=True)
+class FrontendInlineProcParameterNode:
+    name: str
+    annotation: Any
+    default: FrontendExprNode | None
+
+
+@dataclass(frozen=True)
+class FrontendInlineProcNode:
+    name: str
+    parameters: tuple[FrontendInlineProcParameterNode, ...]
+    body: tuple[FrontendStmtNode, ...]
+
+
+@dataclass(frozen=True)
 class FrontendKernelNode:
     target: str
     op: str
@@ -169,6 +184,14 @@ class FrontendKernelNode:
     parameters: tuple[FrontendParameterNode, ...]
     tile_specializations: tuple[FrontendTileSpecializationNode, ...]
     body: tuple[FrontendStmtNode, ...]
+    inline_procs: tuple[FrontendInlineProcNode, ...] = ()
+
+
+@dataclass(frozen=True)
+class _FrontendInlineProc:
+    name: str
+    source_info: Any
+    signature: inspect.Signature
 
 
 @dataclass(frozen=True)
@@ -177,6 +200,8 @@ class _FrontendBuildContext:
     templates: dict[str, dict[str, str]]
     selected_op: str | None
     advanced_enabled: bool
+    inline_procs: dict[str, _FrontendInlineProc]
+    active_inline_proc_stack: tuple[str, ...] = ()
     vecscope_depth: int = 0
 
     def error(self, node: ast.AST, message: str) -> Exception:
@@ -190,8 +215,378 @@ class _FrontendBuildContext:
             templates=self.templates,
             selected_op=self.selected_op,
             advanced_enabled=self.advanced_enabled,
+            inline_procs=self.inline_procs,
+            active_inline_proc_stack=self.active_inline_proc_stack,
             vecscope_depth=self.vecscope_depth + 1,
         )
+
+    def enter_inline_proc(self, name: str, source_info: Any) -> "_FrontendBuildContext":
+        return _FrontendBuildContext(
+            source_info=source_info,
+            templates=self.templates,
+            selected_op=self.selected_op,
+            advanced_enabled=self.advanced_enabled,
+            inline_procs=self.inline_procs,
+            active_inline_proc_stack=(*self.active_inline_proc_stack, name),
+            vecscope_depth=self.vecscope_depth,
+        )
+
+
+def _inline_proc_param_specs(inline_proc: _FrontendInlineProc) -> tuple[tuple[str, ast.expr | None], ...]:
+    function_def = inline_proc.source_info.function_def
+    params = function_def.args.args
+    defaults = function_def.args.defaults
+    first_default = len(params) - len(defaults)
+    specs: list[tuple[str, ast.expr | None]] = []
+    for index, param in enumerate(params):
+        default_node: ast.expr | None = None
+        if index >= first_default:
+            default_node = defaults[index - first_default]
+        specs.append((param.arg, default_node))
+    return tuple(specs)
+
+
+def _bind_inline_proc_call(
+    node: ast.Call,
+    inline_proc: _FrontendInlineProc,
+    context: _FrontendBuildContext,
+) -> tuple[FrontendExprNode, ...]:
+    if any(keyword.arg is None for keyword in node.keywords):
+        raise context.error(
+            node,
+            "keyword unpacking via `**` is not supported in TileLang DSL v1",
+        )
+
+    param_specs = _inline_proc_param_specs(inline_proc)
+    param_names = tuple(param_name for param_name, _ in param_specs)
+    bound: dict[str, FrontendExprNode] = {}
+
+    if len(node.args) > len(param_specs):
+        raise context.error(
+            node,
+            f"inline_proc `{inline_proc.name}` accepts at most {len(param_specs)} positional arguments in TileLang DSL v1",
+        )
+
+    for index, arg_node in enumerate(node.args):
+        param_name = param_names[index]
+        bound[param_name] = _build_expr(arg_node, context)
+
+    seen_keywords: set[str] = set()
+    for keyword in node.keywords:
+        assert keyword.arg is not None
+        if keyword.arg in seen_keywords:
+            raise context.error(
+                keyword.value,
+                f"duplicate keyword `{keyword.arg}` for inline_proc `{inline_proc.name}` in TileLang DSL v1",
+            )
+        if keyword.arg not in param_names:
+            raise context.error(
+                keyword.value,
+                f"inline_proc `{inline_proc.name}` does not define keyword `{keyword.arg}` in TileLang DSL v1",
+            )
+        if keyword.arg in bound:
+            raise context.error(
+                keyword.value,
+                f"inline_proc `{inline_proc.name}` got multiple values for argument `{keyword.arg}` in TileLang DSL v1",
+            )
+        seen_keywords.add(keyword.arg)
+        bound[keyword.arg] = _build_expr(keyword.value, context)
+
+    ordered_args: list[FrontendExprNode] = []
+    for param_name, default_node in param_specs:
+        value = bound.get(param_name)
+        if value is None:
+            if default_node is None:
+                raise context.error(
+                    node,
+                    f"inline_proc `{inline_proc.name}` is missing required argument `{param_name}` in TileLang DSL v1",
+                )
+            value = _build_expr(default_node, context)
+        ordered_args.append(value)
+    return tuple(ordered_args)
+
+
+def _collect_name_reads(expr: FrontendExprNode) -> set[str]:
+    if isinstance(expr, FrontendNameExpr):
+        return {expr.name}
+    if isinstance(expr, (FrontendConstantExpr, FrontendSymbolExpr)):
+        return set()
+    if isinstance(expr, FrontendSliceExpr):
+        names: set[str] = set()
+        if expr.start is not None:
+            names |= _collect_name_reads(expr.start)
+        if expr.stop is not None:
+            names |= _collect_name_reads(expr.stop)
+        if expr.step is not None:
+            names |= _collect_name_reads(expr.step)
+        return names
+    if isinstance(expr, FrontendTupleExpr):
+        names: set[str] = set()
+        for element in expr.elements:
+            names |= _collect_name_reads(element)
+        return names
+    if isinstance(expr, FrontendAttributeExpr):
+        return _collect_name_reads(expr.base)
+    if isinstance(expr, FrontendSubscriptExpr):
+        return _collect_name_reads(expr.base) | _collect_name_reads(expr.index)
+    if isinstance(expr, FrontendBinaryExpr):
+        return _collect_name_reads(expr.lhs) | _collect_name_reads(expr.rhs)
+    if isinstance(expr, FrontendCallExpr):
+        names: set[str] = set()
+        for arg in expr.args:
+            names |= _collect_name_reads(arg)
+        for _, keyword_value in expr.keywords:
+            names |= _collect_name_reads(keyword_value)
+        return names
+    return set()
+
+
+def _extract_target_names(target: FrontendTargetNode) -> set[str]:
+    if isinstance(target, FrontendNameTarget):
+        return {target.name}
+    if isinstance(target, FrontendTupleTarget):
+        return {element.name for element in target.elements}
+    return set()
+
+def _validate_inline_capture(
+    stmt: FrontendStmtNode,
+    param_names: set[str],
+    assigned_names: set[str],
+    *,
+    context: _FrontendBuildContext,
+) -> None:
+    allowed = param_names | assigned_names
+    if isinstance(stmt, FrontendAssignStmt):
+        missing = _collect_name_reads(stmt.value) - allowed
+        if missing:
+            name = sorted(missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+        assigned_names |= _extract_target_names(stmt.target)
+        return
+    if isinstance(stmt, FrontendExprStmt):
+        missing = _collect_name_reads(stmt.expr) - allowed
+        if missing:
+            name = sorted(missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+        return
+    if isinstance(stmt, FrontendReturnStmt):
+        if stmt.value is None:
+            return
+        missing = _collect_name_reads(stmt.value) - allowed
+        if missing:
+            name = sorted(missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+        return
+    if isinstance(stmt, FrontendForStmt):
+        header_reads = (
+            _collect_name_reads(stmt.lower_bound)
+            | _collect_name_reads(stmt.upper_bound)
+            | _collect_name_reads(stmt.step)
+        )
+        missing = header_reads - allowed
+        if missing:
+            name = sorted(missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+
+        loop_assigned = set(assigned_names)
+        loop_assigned.add(stmt.target)
+        for child in stmt.body:
+            _validate_inline_capture(child, param_names, loop_assigned, context=context)
+        assigned_names.add(stmt.target)
+        return
+    if isinstance(stmt, FrontendIfStmt):
+        missing = _collect_name_reads(stmt.condition) - allowed
+        if missing:
+            name = sorted(missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+        then_assigned = set(assigned_names)
+        else_assigned = set(assigned_names)
+        for child in stmt.then_body:
+            _validate_inline_capture(child, param_names, then_assigned, context=context)
+        for child in stmt.else_body:
+            _validate_inline_capture(child, param_names, else_assigned, context=context)
+        assigned_names |= then_assigned | else_assigned
+        return
+    if isinstance(stmt, FrontendVecscopeStmt):
+        scope_assigned = set(assigned_names)
+        for child in stmt.body:
+            _validate_inline_capture(child, param_names, scope_assigned, context=context)
+        assigned_names |= scope_assigned
+        return
+    if isinstance(stmt, FrontendStrictVecscopeStmt):
+        captures_missing = set().union(*(_collect_name_reads(capture) for capture in stmt.captures)) - allowed
+        if captures_missing:
+            name = sorted(captures_missing)[0]
+            raise context.error(
+                context.source_info.function_def,
+                f"implicit capture of '{name}' is not allowed in inline_proc",
+            )
+        scope_assigned = set(assigned_names) | set(stmt.block_arguments)
+        for child in stmt.body:
+            _validate_inline_capture(child, param_names, scope_assigned, context=context)
+        assigned_names |= scope_assigned
+
+
+def _collect_inline_proc_calls_expr(
+    expr: FrontendExprNode,
+    inline_proc_names: set[str],
+    into: set[str],
+) -> None:
+    if isinstance(expr, FrontendCallExpr):
+        if expr.namespace is None and expr.name in inline_proc_names:
+            into.add(expr.name)
+        for arg in expr.args:
+            _collect_inline_proc_calls_expr(arg, inline_proc_names, into)
+        for _, keyword_value in expr.keywords:
+            _collect_inline_proc_calls_expr(keyword_value, inline_proc_names, into)
+        return
+    if isinstance(expr, FrontendBinaryExpr):
+        _collect_inline_proc_calls_expr(expr.lhs, inline_proc_names, into)
+        _collect_inline_proc_calls_expr(expr.rhs, inline_proc_names, into)
+        return
+    if isinstance(expr, FrontendTupleExpr):
+        for element in expr.elements:
+            _collect_inline_proc_calls_expr(element, inline_proc_names, into)
+        return
+    if isinstance(expr, FrontendSliceExpr):
+        if expr.start is not None:
+            _collect_inline_proc_calls_expr(expr.start, inline_proc_names, into)
+        if expr.stop is not None:
+            _collect_inline_proc_calls_expr(expr.stop, inline_proc_names, into)
+        if expr.step is not None:
+            _collect_inline_proc_calls_expr(expr.step, inline_proc_names, into)
+        return
+    if isinstance(expr, FrontendAttributeExpr):
+        _collect_inline_proc_calls_expr(expr.base, inline_proc_names, into)
+        return
+    if isinstance(expr, FrontendSubscriptExpr):
+        _collect_inline_proc_calls_expr(expr.base, inline_proc_names, into)
+        _collect_inline_proc_calls_expr(expr.index, inline_proc_names, into)
+
+
+def _collect_inline_proc_calls_stmt(
+    stmt: FrontendStmtNode,
+    inline_proc_names: set[str],
+    into: set[str],
+) -> None:
+    if isinstance(stmt, FrontendAssignStmt):
+        _collect_inline_proc_calls_expr(stmt.value, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendExprStmt):
+        _collect_inline_proc_calls_expr(stmt.expr, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendReturnStmt):
+        if stmt.value is not None:
+            _collect_inline_proc_calls_expr(stmt.value, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendForStmt):
+        _collect_inline_proc_calls_expr(stmt.lower_bound, inline_proc_names, into)
+        _collect_inline_proc_calls_expr(stmt.upper_bound, inline_proc_names, into)
+        _collect_inline_proc_calls_expr(stmt.step, inline_proc_names, into)
+        for child in stmt.body:
+            _collect_inline_proc_calls_stmt(child, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendIfStmt):
+        _collect_inline_proc_calls_expr(stmt.condition, inline_proc_names, into)
+        for child in stmt.then_body:
+            _collect_inline_proc_calls_stmt(child, inline_proc_names, into)
+        for child in stmt.else_body:
+            _collect_inline_proc_calls_stmt(child, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendVecscopeStmt):
+        for child in stmt.body:
+            _collect_inline_proc_calls_stmt(child, inline_proc_names, into)
+        return
+    if isinstance(stmt, FrontendStrictVecscopeStmt):
+        for capture in stmt.captures:
+            _collect_inline_proc_calls_expr(capture, inline_proc_names, into)
+        for child in stmt.body:
+            _collect_inline_proc_calls_stmt(child, inline_proc_names, into)
+
+
+def _validate_inline_proc_call_graph(
+    kernel_body: tuple[FrontendStmtNode, ...],
+    inline_proc_nodes: tuple[FrontendInlineProcNode, ...],
+    inline_proc_source_infos: dict[str, Any],
+) -> None:
+    inline_proc_names = {node.name for node in inline_proc_nodes}
+    if not inline_proc_names:
+        return
+
+    edges: dict[str, set[str]] = {node.name: set() for node in inline_proc_nodes}
+    for inline_proc_node in inline_proc_nodes:
+        callees = edges[inline_proc_node.name]
+        for stmt in inline_proc_node.body:
+            _collect_inline_proc_calls_stmt(stmt, inline_proc_names, callees)
+
+    root_callees: set[str] = set()
+    for stmt in kernel_body:
+        _collect_inline_proc_calls_stmt(stmt, inline_proc_names, root_callees)
+
+    color: dict[str, int] = {}
+
+    def dfs(name: str) -> None:
+        state = color.get(name, 0)
+        if state == 1:
+            source_info = inline_proc_source_infos.get(name)
+            if source_info is not None:
+                raise source_info.error(
+                    source_info.function_def,
+                    f"recursive inline_proc call `{name}` is not supported in TileLang DSL v1",
+                )
+            raise ValueError(f"recursive inline_proc call `{name}` is not supported in TileLang DSL v1")
+        if state == 2:
+            return
+        color[name] = 1
+        for callee in edges.get(name, ()):
+            dfs(callee)
+        color[name] = 2
+
+    for callee in sorted(root_callees):
+        dfs(callee)
+
+
+def _collect_reachable_inline_procs(
+    kernel_body: tuple[FrontendStmtNode, ...],
+    inline_proc_nodes: tuple[FrontendInlineProcNode, ...],
+) -> set[str]:
+    inline_proc_names = {node.name for node in inline_proc_nodes}
+    if not inline_proc_names:
+        return set()
+
+    edges: dict[str, set[str]] = {node.name: set() for node in inline_proc_nodes}
+    for inline_proc_node in inline_proc_nodes:
+        for stmt in inline_proc_node.body:
+            _collect_inline_proc_calls_stmt(stmt, inline_proc_names, edges[inline_proc_node.name])
+
+    roots: set[str] = set()
+    for stmt in kernel_body:
+        _collect_inline_proc_calls_stmt(stmt, inline_proc_names, roots)
+
+    reachable: set[str] = set()
+    stack = list(roots)
+    while stack:
+        name = stack.pop()
+        if name in reachable:
+            continue
+        reachable.add(name)
+        stack.extend(edges.get(name, ()))
+    return reachable
 
 
 _BINARY_OP_NAMES = {
@@ -417,6 +812,19 @@ def _build_expr(node: ast.AST, context: _FrontendBuildContext) -> FrontendExprNo
             )
         return expr
     if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id in context.inline_procs:
+            inline_proc = context.inline_procs[node.func.id]
+            if node.func.id in context.active_inline_proc_stack:
+                raise context.error(
+                    node,
+                    f"recursive inline_proc call `{node.func.id}` is not supported in TileLang DSL v1",
+                )
+            return FrontendCallExpr(
+                namespace=None,
+                name=node.func.id,
+                args=_bind_inline_proc_call(node, inline_proc, context),
+                keywords=(),
+            )
         if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
@@ -515,6 +923,10 @@ def _build_target(node: ast.AST, context: _FrontendBuildContext) -> FrontendTarg
     )
 
 
+def _build_stmt_list(nodes: list[ast.stmt] | tuple[ast.stmt, ...], context: _FrontendBuildContext) -> tuple[FrontendStmtNode, ...]:
+    return tuple(_build_stmt(node, context) for node in nodes)
+
+
 def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtNode:
     if isinstance(node, ast.Assign):
         if len(node.targets) != 1:
@@ -551,7 +963,7 @@ def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtN
             lower_bound=_build_expr(node.iter.args[0], context),
             upper_bound=_build_expr(node.iter.args[1], context),
             step=_build_expr(node.iter.args[2], context),
-            body=tuple(_build_stmt(stmt, context) for stmt in node.body),
+            body=_build_stmt_list(node.body, context),
         )
     if isinstance(node, ast.If):
         is_constexpr = False
@@ -577,8 +989,8 @@ def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtN
             condition_node = node.test.args[0]
         return FrontendIfStmt(
             condition=_build_expr(condition_node, context),
-            then_body=tuple(_build_stmt(stmt, context) for stmt in node.body),
-            else_body=tuple(_build_stmt(stmt, context) for stmt in node.orelse),
+            then_body=_build_stmt_list(node.body, context),
+            else_body=_build_stmt_list(node.orelse, context),
             is_constexpr=is_constexpr,
         )
     if isinstance(node, ast.With):
@@ -606,7 +1018,7 @@ def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtN
             if item.optional_vars is not None:
                 raise context.error(item, "pto.vecscope() does not support `as` bindings in TileLang DSL v1")
             return FrontendVecscopeStmt(
-                body=tuple(_build_stmt(stmt, context.nested_vecscope()) for stmt in node.body),
+                body=_build_stmt_list(node.body, context.nested_vecscope()),
             )
         if with_name != "strict_vecscope":
             raise context.error(
@@ -628,7 +1040,7 @@ def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtN
         return FrontendStrictVecscopeStmt(
             captures=tuple(_build_expr(arg, context) for arg in item.context_expr.args),
             block_arguments=tuple(block_arguments),
-            body=tuple(_build_stmt(stmt, context.nested_vecscope()) for stmt in node.body),
+            body=_build_stmt_list(node.body, context.nested_vecscope()),
         )
     raise context.error(
         node,
@@ -659,15 +1071,107 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
         for name, spec in descriptor.specializations
     )
     source_info = descriptor._source_info
+    sorted_inline_procs = tuple(sorted(descriptor.inline_procs.items(), key=lambda item: item[0]))
     context = _FrontendBuildContext(
         source_info=source_info,
         templates=descriptor.templates,
         selected_op=descriptor.selected_op,
         advanced_enabled=descriptor.advanced_enabled,
+        inline_procs={
+            name: _FrontendInlineProc(
+                name=name,
+                source_info=proc.source_info,
+                signature=proc.signature,
+            )
+            for name, proc in sorted_inline_procs
+        },
     )
     body = ()
     if source_info is not None:
-        body = tuple(_build_stmt(stmt, context) for stmt in source_info.function_def.body)
+        body = _build_stmt_list(source_info.function_def.body, context)
+
+    inline_proc_descriptors = {name: descriptor for name, descriptor in sorted_inline_procs}
+    inline_proc_names = set(inline_proc_descriptors)
+    root_inline_calls: set[str] = set()
+    for stmt in body:
+        _collect_inline_proc_calls_stmt(stmt, inline_proc_names, root_inline_calls)
+
+    inline_proc_nodes_by_name: dict[str, FrontendInlineProcNode] = {}
+    inline_proc_source_infos: dict[str, Any] = {}
+    pending = list(sorted(root_inline_calls))
+    while pending:
+        name = pending.pop()
+        if name in inline_proc_nodes_by_name:
+            continue
+        inline_proc_descriptor = inline_proc_descriptors.get(name)
+        if inline_proc_descriptor is None:
+            continue
+        inline_source = inline_proc_descriptor.source_info
+        if inline_source is None:
+            if source_info is not None:
+                raise context.error(
+                    source_info.function_def,
+                    f"inline_proc `{name}` requires source-visible Python functions",
+                )
+            raise ValueError(
+                f"inline_proc `{name}` requires source-visible Python functions"
+            )
+        inline_proc_source_infos[name] = inline_source
+        helper_context = context.enter_inline_proc(name, inline_source)
+        helper_body = _build_stmt_list(inline_source.function_def.body, helper_context)
+        parameter_specs = _inline_proc_param_specs(
+            _FrontendInlineProc(
+                name=name,
+                source_info=inline_source,
+                signature=inline_proc_descriptor.signature,
+            )
+        )
+        inline_proc_node = FrontendInlineProcNode(
+            name=name,
+            parameters=tuple(
+                FrontendInlineProcParameterNode(
+                    name=param_name,
+                    annotation=arg.annotation,
+                    default=None
+                    if default_node is None
+                    else _build_expr(default_node, helper_context),
+                )
+                for (param_name, default_node), arg in zip(parameter_specs, inline_source.function_def.args.args)
+            ),
+            body=helper_body,
+        )
+        inline_proc_nodes_by_name[name] = inline_proc_node
+        nested_calls: set[str] = set()
+        for stmt in helper_body:
+            _collect_inline_proc_calls_stmt(stmt, inline_proc_names, nested_calls)
+        for nested in sorted(nested_calls):
+            if nested not in inline_proc_nodes_by_name:
+                pending.append(nested)
+
+    reachable_inline_proc_nodes = tuple(
+        inline_proc_nodes_by_name[name]
+        for name, _ in sorted_inline_procs
+        if name in inline_proc_nodes_by_name
+    )
+    for inline_proc_node in reachable_inline_proc_nodes:
+        source = inline_proc_source_infos[inline_proc_node.name]
+        helper_context = context.enter_inline_proc(inline_proc_node.name, source)
+        assigned_names: set[str] = set()
+        param_names = {parameter.name for parameter in inline_proc_node.parameters}
+        for stmt in inline_proc_node.body:
+            _validate_inline_capture(
+                stmt,
+                param_names,
+                assigned_names,
+                context=helper_context,
+            )
+
+    _validate_inline_proc_call_graph(
+        body,
+        reachable_inline_proc_nodes,
+        inline_proc_source_infos,
+    )
+
     return FrontendKernelNode(
         target=descriptor.target,
         op=descriptor.op,
@@ -678,6 +1182,7 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
         parameters=parameters,
         tile_specializations=tile_specializations,
         body=body,
+        inline_procs=reachable_inline_proc_nodes,
     )
 
 
@@ -691,6 +1196,8 @@ __all__ = [
     "FrontendExprStmt",
     "FrontendForStmt",
     "FrontendIfStmt",
+    "FrontendInlineProcNode",
+    "FrontendInlineProcParameterNode",
     "FrontendKernelNode",
     "FrontendNameExpr",
     "FrontendNameTarget",

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -59,6 +59,141 @@ _SUPPORTED_TEMPLATE_PTO_CALLS = frozenset(
 )
 
 
+_INLINE_PROC_REGISTRY: dict[tuple[str, str], "InlineProcDescriptor"] = {}
+
+
+@dataclass(frozen=True)
+class InlineProcDescriptor:
+    """Descriptor returned by @tilelang_dsl.inline_proc."""
+
+    name: str
+    py_fn: Callable[..., Any] = field(repr=False)
+    signature: inspect.Signature = field(repr=False)
+    source_info: "_FunctionSourceInfo | None" = field(repr=False, default=None)
+
+
+class _InlineProcValidator(ast.NodeVisitor):
+    def __init__(self, source_info: "_FunctionSourceInfo"):
+        self.source_info = source_info
+
+    def validate(self) -> None:
+        fn = self.source_info.function_def
+        args = fn.args
+        if args.posonlyargs:
+            raise self.source_info.error(args.posonlyargs[0], "inline_proc does not support positional-only parameters in TileLang DSL v1")
+        if args.vararg is not None:
+            raise self.source_info.error(args.vararg, "inline_proc does not support *args in TileLang DSL v1")
+        if args.kwarg is not None:
+            raise self.source_info.error(args.kwarg, "inline_proc does not support **kwargs in TileLang DSL v1")
+        if args.kwonlyargs:
+            raise self.source_info.error(args.kwonlyargs[0], "inline_proc does not support keyword-only parameters in TileLang DSL v1")
+        tail_return: ast.Return | None = fn.body[-1] if fn.body and isinstance(fn.body[-1], ast.Return) else None
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Return):
+                continue
+            if node is tail_return:
+                continue
+            raise self.source_info.error(
+                node,
+                "inline_proc only supports an optional trailing `return` in TileLang DSL v1",
+            )
+
+        for stmt in fn.body:
+            self.visit(stmt)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node is self.source_info.function_def:
+            for stmt in node.body:
+                self.visit(stmt)
+            return
+        raise self.source_info.error(node, "nested function definitions are not supported inside inline_proc in TileLang DSL v1")
+
+
+def _inline_proc_registry_key(fn: Callable[..., Any]) -> tuple[str, str]:
+    return (fn.__module__, fn.__name__)
+
+
+def _find_inline_proc(name: str, *, module_name: str | None) -> InlineProcDescriptor | None:
+    if module_name is None:
+        return None
+    return _INLINE_PROC_REGISTRY.get((module_name, name))
+
+
+def _validate_inline_proc_call_surface(
+    source_info: _FunctionSourceInfo,
+    node: ast.Call,
+    inline_proc: InlineProcDescriptor,
+) -> None:
+    if any(keyword.arg is None for keyword in node.keywords):
+        keyword = next(keyword for keyword in node.keywords if keyword.arg is None)
+        raise source_info.error(
+            keyword.value,
+            "keyword unpacking via `**` is not supported in TileLang DSL v1",
+        )
+    seen_keywords: set[str] = set()
+    for keyword in node.keywords:
+        assert keyword.arg is not None
+        if keyword.arg in seen_keywords:
+            raise source_info.error(
+                keyword.value,
+                f"duplicate keyword `{keyword.arg}` for inline_proc `{inline_proc.name}` in TileLang DSL v1",
+            )
+        seen_keywords.add(keyword.arg)
+    positional_placeholders = [object() for _ in node.args]
+    keyword_placeholders = {keyword.arg: object() for keyword in node.keywords if keyword.arg is not None}
+    try:
+        inline_proc.signature.bind(*positional_placeholders, **keyword_placeholders)
+    except TypeError as exc:
+        raise source_info.error(
+            node,
+            f"invalid inline_proc call `{inline_proc.name}` in TileLang DSL v1: {exc}",
+        ) from exc
+
+
+def _collect_inline_procs(module_name: str) -> tuple[tuple[str, InlineProcDescriptor], ...]:
+    return tuple(
+        sorted(
+            (
+                (symbol, descriptor)
+                for (registered_module, symbol), descriptor in _INLINE_PROC_REGISTRY.items()
+                if registered_module == module_name
+            ),
+            key=lambda item: item[0],
+        )
+    )
+
+
+def _register_inline_proc(descriptor: InlineProcDescriptor) -> InlineProcDescriptor:
+    _INLINE_PROC_REGISTRY[_inline_proc_registry_key(descriptor.py_fn)] = descriptor
+    return descriptor
+
+
+def inline_proc(
+    py_fn: Callable[..., Any] | None = None,
+) -> InlineProcDescriptor | Callable[[Callable[..., Any]], InlineProcDescriptor]:
+    """Register a top-level compile-time inline procedure for TileLang DSL kernels."""
+
+    def wrap(fn: Callable[..., Any]) -> InlineProcDescriptor:
+        if not callable(fn):
+            raise TypeError("@inline_proc can only decorate callables")
+        source_info = _load_function_source_info(fn)
+        if source_info is None:
+            raise TypeError("@inline_proc requires source-visible Python functions")
+        _InlineProcValidator(source_info).validate()
+        return _register_inline_proc(
+            InlineProcDescriptor(
+                name=fn.__name__,
+                py_fn=fn,
+                source_info=source_info,
+                signature=inspect.signature(fn),
+            )
+        )
+
+    if py_fn is None:
+        return wrap
+    return wrap(py_fn)
+
+
 def _validate_dtype_pattern(dtype: Any) -> ScalarType | WildcardType | TypeVariable:
     if isinstance(dtype, (ScalarType, WildcardType, TypeVariable)):
         return dtype
@@ -99,9 +234,10 @@ class _FunctionSourceInfo:
 
 
 class _KernelBodyValidator(ast.NodeVisitor):
-    def __init__(self, source_info: _FunctionSourceInfo, *, advanced_enabled: bool):
+    def __init__(self, source_info: _FunctionSourceInfo, *, advanced_enabled: bool, module_name: str | None):
         self.source_info = source_info
         self.advanced_enabled = advanced_enabled
+        self.module_name = module_name
         self._vecscope_depth = 0
 
     def validate(self) -> None:
@@ -319,6 +455,10 @@ class _KernelBodyValidator(ast.NodeVisitor):
             if node.func.id == "range":
                 self._validate_call_keywords(node)
                 return
+            inline_proc = _find_inline_proc(node.func.id, module_name=self.module_name)
+            if inline_proc is not None:
+                _validate_inline_proc_call_surface(self.source_info, node, inline_proc)
+                return
             raise self.source_info.error(
                 node,
                 f"arbitrary external call `{node.func.id}` is not supported in TileLang DSL v1",
@@ -349,12 +489,14 @@ def _validate_function_body(
     source_info: _FunctionSourceInfo | None,
     *,
     advanced_enabled: bool,
+    module_name: str | None,
 ) -> None:
     if source_info is None:
         return
     _KernelBodyValidator(
         source_info,
         advanced_enabled=advanced_enabled,
+        module_name=module_name,
     ).validate()
 
 
@@ -570,6 +712,7 @@ class VKernelDescriptor:
     constraints: tuple[Callable[[Mapping[str, Any]], Any], ...] = field(default=(), repr=False)
     priority: int = 0
     _templates: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = field(default=(), repr=False)
+    _inline_procs: tuple[tuple[str, InlineProcDescriptor], ...] = field(default=(), repr=False)
     _selected_op: str | None = None
     _selected_dtype_signature: tuple[ScalarType, ...] | None = None
     _parameters: tuple[BoundKernelParameter, ...] | None = field(default=None, repr=False)
@@ -598,6 +741,10 @@ class VKernelDescriptor:
             slot: dict(op_bindings)
             for slot, op_bindings in self._templates
         }
+
+    @property
+    def inline_procs(self) -> dict[str, InlineProcDescriptor]:
+        return {name: descriptor for name, descriptor in self._inline_procs}
 
     @property
     def dtype_signature(self) -> tuple[ScalarType, ...]:
@@ -631,6 +778,7 @@ class VKernelDescriptor:
             "constraints": self.constraints,
             "priority": self.priority,
             "templates": self.templates,
+            "inline_procs": tuple(sorted(self.inline_procs.keys())),
         }
 
     @property
@@ -671,6 +819,7 @@ class VKernelDescriptor:
             constraints=self.constraints,
             priority=self.priority,
             _templates=self._templates,
+            _inline_procs=self._inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -696,6 +845,7 @@ class VKernelDescriptor:
             constraints=self.constraints,
             priority=self.priority,
             _templates=self._templates,
+            _inline_procs=self._inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=dtype_signature,
             _parameters=bound_parameters,
@@ -724,6 +874,7 @@ class VKernelDescriptor:
             constraints=self.constraints,
             priority=self.priority,
             _templates=self._templates,
+            _inline_procs=self._inline_procs,
             _selected_op=normalized_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -764,6 +915,7 @@ class VKernelDescriptor:
             constraints=self.constraints,
             priority=self.priority,
             _templates=self._templates,
+            _inline_procs=self._inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -1656,7 +1808,12 @@ def _build_descriptor(
 
     source_info = _load_function_source_info(py_fn)
     advanced_enabled = _validate_advanced(advanced)
-    _validate_function_body(source_info, advanced_enabled=advanced_enabled)
+    inline_procs = _collect_inline_procs(py_fn.__module__)
+    _validate_function_body(
+        source_info,
+        advanced_enabled=advanced_enabled,
+        module_name=py_fn.__module__,
+    )
     match_ops = _freeze_match_ops(op=op, ops=ops)
     frozen_templates = _freeze_templates(templates, match_ops=match_ops)
     parameter_specs = _collect_parameter_specs(py_fn)
@@ -1687,6 +1844,7 @@ def _build_descriptor(
         constraints=_validate_constraints(constraints),
         priority=_validate_priority(priority),
         _templates=frozen_templates,
+        _inline_procs=inline_procs,
         _selected_op=selected_op,
         _selected_dtype_signature=selected_dtype_signature,
         _parameters=bound_parameters,
@@ -1891,10 +2049,12 @@ def vkernel(
 
 __all__ = [
     "BoundKernelParameter",
+    "InlineProcDescriptor",
     "KernelRegistry",
     "MaterializedMLIRModule",
     "TileLangFrontendError",
     "VKernelDescriptor",
+    "inline_proc",
     "select_kernel",
     "vkernel",
 ]

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -77,7 +77,61 @@ class AuthoringModule:
     kernel: SemanticKernel
 
     def render(self) -> str:
-        return _AuthoringRenderer(self.kernel).render()
+        kernel_text = _AuthoringRenderer(self.kernel).render()
+        if not self.kernel.inline_helpers:
+            return kernel_text
+
+        base_lines = kernel_text.splitlines()
+        module_close_index = max(
+            (index for index, line in enumerate(base_lines) if line == "}"),
+            default=-1,
+        )
+        if module_close_index < 0:
+            return kernel_text
+
+        merged_lines = base_lines[:module_close_index]
+        for helper in self.kernel.inline_helpers:
+            helper_lines = _extract_single_function_lines(
+                _AuthoringRenderer(helper).render()
+            )
+            if not helper_lines:
+                continue
+            helper_lines[0] = _rewrite_inline_helper_attrs(helper_lines[0])
+            merged_lines.extend(helper_lines)
+
+        merged_lines.append("}")
+        merged_lines.append("")
+        return "\n".join(merged_lines)
+
+
+def _extract_single_function_lines(rendered_text: str) -> list[str]:
+    lines = rendered_text.splitlines()
+    try:
+        function_start = next(
+            index for index, line in enumerate(lines) if line.lstrip().startswith("func.func ")
+        )
+    except StopIteration:
+        return []
+    module_close_index = max(
+        (index for index, line in enumerate(lines) if line == "}"),
+        default=-1,
+    )
+    if module_close_index <= function_start:
+        return []
+    return lines[function_start:module_close_index]
+
+
+def _rewrite_inline_helper_attrs(function_line: str) -> str:
+    kernel_attr = "attributes { pto.tilelang.instance }"
+    helper_attr = 'attributes { sym_visibility = "private", pto.tilelang.inline_proc }'
+    if kernel_attr in function_line:
+        return function_line.replace(kernel_attr, helper_attr)
+    if "attributes {" in function_line:
+        return function_line
+    if function_line.rstrip().endswith("{"):
+        stripped = function_line.rstrip()
+        return stripped[:-1] + f" {helper_attr} {{"
+    return function_line
 
 
 @dataclass(frozen=True)
@@ -311,8 +365,9 @@ class _AuthoringRenderer:
         if isinstance(stmt, SemanticAssignStmt):
             return self._render_assign(stmt, env, indent=indent)
         if isinstance(stmt, SemanticExprStmt):
-            self._lower_expr(stmt.expr, env, indent=indent)
-            return []
+            lines: list[str] = []
+            self._lower_expr(stmt.expr, env, indent=indent, into=lines)
+            return lines
         if isinstance(stmt, SemanticDmaLoadStmt):
             return self._render_dma_load(stmt, env, indent=indent)
         if isinstance(stmt, SemanticDmaStoreStmt):
@@ -336,10 +391,12 @@ class _AuthoringRenderer:
         if isinstance(stmt, SemanticLowLevelCopyStmt):
             return self._render_low_level_copy(stmt, env, indent=indent)
         if isinstance(stmt, SemanticReturnStmt):
+            lines: list[str] = []
             if stmt.value is None:
                 return [self._indent(indent) + "return"]
-            value = self._lower_expr(stmt.value, env, indent=indent)
-            return [self._indent(indent) + f"return {value.name} : {self._render_type(value.type)}"]
+            value = self._lower_expr(stmt.value, env, indent=indent, into=lines)
+            lines.append(self._indent(indent) + f"return {value.name} : {self._render_type(value.type)}")
+            return lines
         if isinstance(stmt, SemanticVecscopeStmt):
             return self._render_vecscope(stmt, env, indent=indent)
         if isinstance(stmt, SemanticStrictVecscopeStmt):
@@ -1913,6 +1970,32 @@ class _AuthoringRenderer:
         desired_name: str | None,
         into: list[str] | None,
     ) -> _RenderedValue:
+        if expr.namespace is None:
+            if into is None:
+                into = []
+            rendered_args = [
+                self._lower_expr(arg, env, indent=indent, into=into)
+                for arg in expr.args
+            ]
+            rendered_arg_names = ", ".join(arg.name for arg in rendered_args)
+            rendered_arg_types = ", ".join(self._render_type(arg.type) for arg in rendered_args)
+            if not rendered_arg_types:
+                rendered_arg_types = ""
+            if expr.type is None:
+                into.append(
+                    self._indent(indent)
+                    + f"func.call {_format_symbol_name(expr.name)}({rendered_arg_names}) : "
+                    + f"({rendered_arg_types}) -> ()"
+                )
+                return _RenderedValue(name="__void_call__", type=SemanticMetaType(kind="void"))
+            result_name = desired_name or self._new_temp()
+            into.append(
+                self._indent(indent)
+                + f"{result_name} = func.call {_format_symbol_name(expr.name)}({rendered_arg_names}) : "
+                + f"({rendered_arg_types}) -> {self._render_type(expr.type)}"
+            )
+            return _RenderedValue(name=result_name, type=expr.type)
+
         if expr.namespace != "pto":
             raise NotImplementedError(f"unsupported call namespace {expr.namespace!r}")
         if isinstance(expr.type, SemanticTupleType):

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -24,6 +24,7 @@ from .frontend_ast import (
     FrontendExprStmt,
     FrontendForStmt,
     FrontendIfStmt,
+    FrontendInlineProcNode,
     FrontendKernelNode,
     FrontendNameExpr,
     FrontendNameTarget,
@@ -517,6 +518,7 @@ class SemanticKernel:
     parameters: tuple[SemanticParameter, ...]
     tile_bindings: tuple[SemanticTileBinding, ...]
     body: tuple[SemanticStmt, ...]
+    inline_helpers: tuple["SemanticKernel", ...] = ()
 
 
 class _SemanticAnalyzer:
@@ -529,6 +531,13 @@ class _SemanticAnalyzer:
             spec.name: spec for spec in node.tile_specializations
         }
         self._hidden_parameters: list[SemanticParameter] = []
+        self._inline_proc_nodes: dict[str, FrontendInlineProcNode] = {
+            inline_proc.name: inline_proc for inline_proc in node.inline_procs
+        }
+        self._inline_proc_specializations: dict[tuple[str, tuple[SemanticType, ...]], SemanticKernel] = {}
+        self._inline_proc_return_types: dict[tuple[str, tuple[SemanticType, ...]], SemanticType | None] = {}
+        self._inline_proc_order: list[tuple[str, tuple[SemanticType, ...]]] = []
+        self._inline_proc_active_stack: list[tuple[str, tuple[SemanticType, ...]]] = []
 
     def analyze(self) -> SemanticKernel:
         env: dict[str, SemanticBinding] = {}
@@ -564,6 +573,10 @@ class _SemanticAnalyzer:
             parameters=tuple(parameters),
             tile_bindings=tile_bindings,
             body=body,
+            inline_helpers=tuple(
+                self._inline_proc_specializations[key]
+                for key in self._inline_proc_order
+            ),
         )
 
     def _analyze_kernel_body(
@@ -1039,6 +1052,132 @@ class _SemanticAnalyzer:
         if isinstance(stmt, FrontendStrictVecscopeStmt):
             return self._analyze_strict_vecscope(stmt, env)
         raise ValueError(f"unsupported frontend statement {type(stmt).__name__}")
+
+    def _inline_proc_specialization_key(
+        self,
+        name: str,
+        args: tuple[SemanticExpr, ...],
+    ) -> tuple[str, tuple[SemanticType, ...]]:
+        return (name, tuple(arg.type for arg in args))
+
+    def _inline_proc_symbol_name(
+        self,
+        name: str,
+        index: int,
+    ) -> str:
+        sanitized = "".join(char if char.isalnum() else "_" for char in name)
+        return f"__tl_inline_{sanitized}_{index}"
+
+    def _collect_inline_helper_tile_bindings(
+        self,
+        parameters: tuple[SemanticParameter, ...],
+    ) -> tuple[SemanticTileBinding, ...]:
+        tile_bindings: list[SemanticTileBinding] = []
+        for parameter in parameters:
+            if not isinstance(parameter.type, SemanticTileType):
+                continue
+            if parameter.type.shape is None:
+                continue
+            tile_bindings.append(
+                SemanticTileBinding(
+                    name=parameter.name,
+                    shape=parameter.type.shape,
+                    valid_shape=parameter.type.valid_shape,
+                    memory_space=parameter.type.memory_space or "ub",
+                    config=None,
+                )
+            )
+        return tuple(tile_bindings)
+
+    def _materialize_inline_proc_specialization(
+        self,
+        name: str,
+        args: tuple[SemanticExpr, ...],
+    ) -> SemanticKernel:
+        inline_proc_node = self._inline_proc_nodes.get(name)
+        if inline_proc_node is None:
+            raise TypeError(f"inline_proc `{name}` is not registered in the current TileLang module")
+
+        key = self._inline_proc_specialization_key(name, args)
+        existing = self._inline_proc_specializations.get(key)
+        if existing is not None:
+            return existing
+        if key in self._inline_proc_active_stack:
+            raise TypeError(
+                f"recursive inline_proc call `{name}` is not supported in TileLang DSL v1"
+            )
+
+        if len(inline_proc_node.parameters) != len(args):
+            raise TypeError(
+                f"inline_proc `{name}` expects {len(inline_proc_node.parameters)} arguments in TileLang DSL v1"
+            )
+
+        helper_env: dict[str, SemanticBinding] = {}
+        helper_parameters: list[SemanticParameter] = []
+        for index, (param, arg_expr) in enumerate(zip(inline_proc_node.parameters, args)):
+            binding = SemanticBinding(
+                name=param.name,
+                ssa_name=f"%arg{index}",
+                type=arg_expr.type,
+                origin="inline_param",
+            )
+            helper_env[param.name] = binding
+            helper_parameters.append(SemanticParameter(binding=binding))
+
+        saved_hidden_parameters = self._hidden_parameters
+        self._hidden_parameters = []
+        self._inline_proc_active_stack.append(key)
+        try:
+            body, _ = self._analyze_block(
+                inline_proc_node.body,
+                helper_env,
+                allow_outer_lookup=False,
+            )
+        finally:
+            self._inline_proc_active_stack.pop()
+        helper_hidden_parameters = tuple(self._hidden_parameters)
+        self._hidden_parameters = saved_hidden_parameters
+
+        if helper_hidden_parameters:
+            raise TypeError(
+                f"inline_proc `{name}` currently does not support dynamic shape metadata captures in TileLang DSL v1"
+            )
+
+        return_type: SemanticType | None = None
+        if body and isinstance(body[-1], SemanticReturnStmt):
+            return_type = None if body[-1].value is None else body[-1].value.type
+
+        helper_index = len(self._inline_proc_order)
+        helper_kernel = SemanticKernel(
+            target=self.node.target,
+            op=self.node.op,
+            symbol_name=self._inline_proc_symbol_name(name, helper_index),
+            verify_enabled=False,
+            advanced_enabled=self.node.advanced_enabled,
+            dtype_signature=self.node.dtype_signature,
+            parameters=tuple(helper_parameters),
+            tile_bindings=self._collect_inline_helper_tile_bindings(tuple(helper_parameters)),
+            body=body,
+            inline_helpers=(),
+        )
+        self._inline_proc_specializations[key] = helper_kernel
+        self._inline_proc_return_types[key] = return_type
+        self._inline_proc_order.append(key)
+        return helper_kernel
+
+    def _analyze_inline_proc_call_expr(
+        self,
+        name: str,
+        args: tuple[SemanticExpr, ...],
+    ) -> SemanticExpr:
+        helper_kernel = self._materialize_inline_proc_specialization(name, args)
+        key = self._inline_proc_specialization_key(name, args)
+        return SemanticCallExpr(
+            namespace=None,
+            name=helper_kernel.symbol_name,
+            args=args,
+            type=self._inline_proc_return_types.get(key),
+        )
 
     def _contains_explicit_vecscope(self, statements: tuple[FrontendStmtNode, ...]) -> bool:
         for stmt in statements:
@@ -2041,6 +2180,16 @@ class _SemanticAnalyzer:
             result_type = self._binary_type(lhs, rhs, expr.op)
             return SemanticBinaryExpr(lhs=lhs, op=expr.op, rhs=rhs, type=result_type)
         if isinstance(expr, FrontendCallExpr):
+            if expr.namespace is None and expr.name in self._inline_proc_nodes:
+                if expr.keywords:
+                    raise TypeError(
+                        f"inline_proc call `{expr.name}` reached semantic analysis with unresolved keywords in TileLang DSL v1"
+                    )
+                args = tuple(
+                    self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                    for arg in expr.args
+                )
+                return self._analyze_inline_proc_call_expr(expr.name, args)
             if expr.namespace not in {None, "pto"} and expr.name == "as_ptr":
                 if expr.keywords:
                     raise TypeError("method call `as_ptr` does not support keyword arguments in TileLang DSL v1")
@@ -2445,6 +2594,10 @@ class _SemanticAnalyzer:
     ) -> SemanticExpr:
         if namespace is None and name == "range":
             return SemanticCallExpr(namespace=namespace, name=name, args=args, type=None)
+        if namespace is None:
+            raise TypeError(
+                f"call surface `{name}` is not supported in TileLang DSL v1"
+            )
         if namespace != "pto":
             raise TypeError(
                 f"call surface `{namespace + '.' if namespace else ''}{name}` is not supported in TileLang DSL v1 yet"

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import ast
+import struct
 from dataclasses import dataclass
 from typing import Any
 
@@ -2690,6 +2691,18 @@ class _SemanticAnalyzer:
             raise TypeError(f"pto.{name} expects exactly 1 positional argument in TileLang DSL v1")
 
         target_dtype = _DTYPE_SYMBOLS[name]
+        if (
+            target_dtype.name in {"f16", "bf16", "f32"}
+            and isinstance(args[0], SemanticLiteralExpr)
+            and isinstance(args[0].type, SemanticMetaType)
+            and args[0].type.kind == "string"
+        ):
+            parsed = self._parse_float_literal_string(args[0].value, target_dtype, f"pto.{name} value")
+            return SemanticLiteralExpr(
+                value=parsed,
+                type=SemanticScalarType(dtype=target_dtype),
+            )
+
         value = self._require_scalar_or_index_expr(args[0], f"pto.{name} value")
 
         if isinstance(value.type, SemanticScalarType) and value.type.dtype == target_dtype:
@@ -2733,6 +2746,58 @@ class _SemanticAnalyzer:
             args=(value,),
             type=SemanticScalarType(dtype=target_dtype),
         )
+
+    def _parse_float_literal_string(
+        self,
+        literal: str,
+        target_dtype: ScalarType,
+        context: str,
+    ) -> float:
+        text = literal.strip().lower()
+        if text in {"inf", "+inf", "infinity", "+infinity"}:
+            return float("inf")
+        if text in {"-inf", "-infinity"}:
+            return float("-inf")
+        if text in {"nan", "+nan", "-nan"}:
+            return float("nan")
+
+        if text.startswith("0x"):
+            try:
+                bit_pattern = int(text, 16)
+            except ValueError as exc:
+                raise TypeError(
+                    f"{context} string literal {literal!r} is not a valid hex bit-pattern"
+                ) from exc
+            return self._float_from_bit_pattern(bit_pattern, target_dtype, context=context)
+
+        try:
+            return float(text)
+        except ValueError as exc:
+            raise TypeError(
+                f"{context} string literal {literal!r} is not a valid float literal"
+            ) from exc
+
+    def _float_from_bit_pattern(
+        self,
+        bit_pattern: int,
+        target_dtype: ScalarType,
+        *,
+        context: str,
+    ) -> float:
+        if target_dtype.name == "f16":
+            if bit_pattern < 0 or bit_pattern > 0xFFFF:
+                raise TypeError(f"{context} f16 bit-pattern must be in [0x0, 0xFFFF]")
+            return float(struct.unpack(">e", struct.pack(">H", bit_pattern))[0])
+        if target_dtype.name == "bf16":
+            if bit_pattern < 0 or bit_pattern > 0xFFFF:
+                raise TypeError(f"{context} bf16 bit-pattern must be in [0x0, 0xFFFF]")
+            widened = bit_pattern << 16
+            return float(struct.unpack(">f", struct.pack(">I", widened))[0])
+        if target_dtype.name == "f32":
+            if bit_pattern < 0 or bit_pattern > 0xFFFFFFFF:
+                raise TypeError(f"{context} f32 bit-pattern must be in [0x0, 0xFFFFFFFF]")
+            return float(struct.unpack(">f", struct.pack(">I", bit_pattern))[0])
+        raise TypeError(f"{context} bit-pattern literals are not supported for dtype {target_dtype.name}")
 
     def _analyze_ptr_type(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
         if len(args) != 2:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2080,6 +2080,37 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("arith.extf", text)
         self.assertIn("arith.truncf", text)
 
+    def test_scalar_constructor_accepts_signed_float_literals(self) -> None:
+        @pto.vkernel(op="scalar_constructor_signed_float_literals_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            a = pto.f16(-1.5)
+            b = pto.bf16(+2.5)
+            c = pto.f32(-3.5)
+            return None
+
+        text = kernel.mlir_text()
+        self.assertIn("= arith.constant -1.5 : f16", text)
+        self.assertIn("= arith.constant 2.5 : bf16", text)
+        self.assertIn("= arith.constant -3.5 : f32", text)
+
+    def test_scalar_constructor_accepts_special_float_string_literals(self) -> None:
+        @pto.vkernel(op="scalar_constructor_special_float_literals_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            a = pto.f16("-inf")
+            b = pto.bf16("inf")
+            c = pto.f32("nan")
+            d = pto.f16("0xFC00")
+            e = pto.bf16("0xFF80")
+            f = pto.f32("0xFF800000")
+            return None
+
+        text = kernel.mlir_text()
+        self.assertIn("= arith.constant -inf : f16", text)
+        self.assertIn("= arith.constant inf : bf16", text)
+        self.assertIn("= arith.constant nan : f32", text)
+        self.assertIn("= arith.constant -inf : bf16", text)
+        self.assertIn("= arith.constant -inf : f32", text)
+
     def test_scalar_constructor_rejects_bad_arity(self) -> None:
         @pto.vkernel(op="scalar_constructor_bad_arity_no_arg_unique", dtypes=[(pto.f32,)])
         def kernel_no_arg(inp: pto.TensorView):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -33,6 +33,7 @@ from tilelang_dsl.semantic import (
     SemanticBinaryExpr,
     SemanticCallExpr,
     SemanticDmaConfigStmt,
+    SemanticExprStmt,
     SemanticForStmt,
     SemanticIfStmt,
     SemanticIndexType,
@@ -3183,6 +3184,307 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             analyze_frontend_kernel(build_frontend_kernel_node(specialized))
         self.assertIn("implicit capture of 'scale' is not allowed", str(ctx.exception))
+
+
+class TileLangDSLInlineProcTests(unittest.TestCase):
+    @pto.inline_proc
+    def _inline_copy_row(dst: pto.Tile, src: pto.Tile, lane: pto.i32):
+        mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+        vec = pto.vlds(src, lane)
+        pto.vsts(vec, dst, lane, mask)
+        return None
+
+    @pto.inline_proc
+    def _inline_recur(dst: pto.Tile):
+        _inline_recur(dst)
+        return None
+
+    @pto.inline_proc
+    def _inline_capture(dst: pto.Tile):
+        pto.vlds(dst, lane)
+        return None
+
+    def test_inline_proc_exports_from_package_surface(self) -> None:
+        self.assertTrue(hasattr(pto, "inline_proc"))
+        self.assertTrue(hasattr(pto, "InlineProcDescriptor"))
+
+    def test_inline_proc_call_keeps_call_in_frontend_and_mlir_text(self) -> None:
+        @pto.vkernel(op="inline_proc_backend_call_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            _inline_copy_row(dst, src, 0)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+
+        frontend_kernel = build_frontend_kernel_node(specialized)
+        self.assertEqual(len(frontend_kernel.body), 2)
+        self.assertIsInstance(frontend_kernel.body[0], FrontendExprStmt)
+        self.assertIsInstance(frontend_kernel.body[0].expr, FrontendCallExpr)
+        self.assertEqual(frontend_kernel.body[0].expr.name, "_inline_copy_row")
+        self.assertGreaterEqual(len(frontend_kernel.inline_procs), 1)
+        self.assertIn("_inline_copy_row", {proc.name for proc in frontend_kernel.inline_procs})
+
+        text = specialized.mlir_text()
+        self.assertIn("func.call", text)
+        self.assertIn("pto.tilelang.inline_proc", text)
+        self.assertRegex(text, r"func\.call @__tl_inline_")
+
+    def test_inline_proc_supports_default_parameters_and_keyword_call(self) -> None:
+        @pto.inline_proc
+        def inline_store(dst: pto.Tile, src: pto.Tile, lane: pto.i32 = 0):
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, lane)
+            pto.vsts(vec, dst, lane, mask)
+            return None
+
+        @pto.vkernel(op="inline_proc_keyword_default_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            inline_store(dst=dst, src=src)
+            return None
+
+        text = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        ).mlir_text()
+        self.assertIn("func.call", text)
+        self.assertIn("pto.tilelang.inline_proc", text)
+
+    def test_inline_proc_supports_return_expression_in_expression_position(self) -> None:
+        @pto.inline_proc
+        def inline_load(src: pto.Tile, lane: pto.i32 = 0):
+            return pto.vlds(src, lane)
+
+        @pto.vkernel(op="inline_proc_expr_return_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = inline_load(src)
+            pto.vsts(vec, dst, 0, mask)
+            return None
+
+        text = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        ).mlir_text()
+        self.assertIn("func.call", text)
+        self.assertRegex(text, r"= func\.call @__tl_inline_")
+        self.assertIn("pto.vsts", text)
+
+    def test_inline_proc_rejects_non_trailing_return(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.inline_proc
+            def bad_inline(flag: pto.i32):
+                if flag:
+                    return flag
+                return flag
+
+        self.assertIn("optional trailing `return`", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_rejects_recursive_calls(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_recursive_unique", dtypes=[(pto.f32,)])
+            def kernel(dst: pto.Tile):
+                _inline_recur(dst)
+                return None
+
+            kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB)
+            ).mlir_text()
+
+        self.assertIn("recursive inline_proc call `_inline_recur` is not supported", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_rejects_implicit_capture(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_capture_unique", dtypes=[(pto.f32,)])
+            def kernel(dst: pto.Tile):
+                lane = pto.i32(0)
+                _inline_capture(dst)
+                return None
+
+            kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB)
+            ).mlir_text()
+
+        self.assertIn("implicit capture of 'lane' is not allowed in inline_proc", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_rejects_kw_only_vararg_and_kwargs(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as kw_only_ctx:
+
+            @pto.inline_proc
+            def bad_kw_only(dst: pto.Tile, *, lane: pto.i32):
+                return None
+
+        self.assertIn("keyword-only parameters", str(kw_only_ctx.exception))
+
+        with self.assertRaises(pto.TileLangFrontendError) as vararg_ctx:
+
+            @pto.inline_proc
+            def bad_vararg(dst: pto.Tile, *lanes: pto.i32):
+                return None
+
+        self.assertIn("does not support *args", str(vararg_ctx.exception))
+
+        with self.assertRaises(pto.TileLangFrontendError) as kwargs_ctx:
+
+            @pto.inline_proc
+            def bad_kwargs(dst: pto.Tile, **opts: pto.i32):
+                return None
+
+        self.assertIn("does not support **kwargs", str(kwargs_ctx.exception))
+
+    def test_inline_proc_rejects_invalid_keyword_binding(self) -> None:
+        @pto.inline_proc
+        def inline_store(dst: pto.Tile, src: pto.Tile):
+            return None
+
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_invalid_keyword_unique", dtypes=[(pto.f32, pto.f32)])
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                inline_store(dst=dst, src=src, lane=0)
+                return None
+
+        self.assertIn("unexpected keyword argument 'lane'", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_rejects_missing_required_argument(self) -> None:
+        @pto.inline_proc
+        def inline_store(dst: pto.Tile, src: pto.Tile):
+            return None
+
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_missing_required_unique", dtypes=[(pto.f32, pto.f32)])
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                inline_store(dst=dst)
+                return None
+
+        self.assertIn("missing a required argument: 'src'", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_rejects_multiple_values_for_single_parameter(self) -> None:
+        @pto.inline_proc
+        def inline_store(dst: pto.Tile, src: pto.Tile):
+            return None
+
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_multiple_values_unique", dtypes=[(pto.f32, pto.f32)])
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                inline_store(dst, src, src=src)
+                return None
+
+        self.assertIn("multiple values for argument 'src'", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_semantic_emits_controlled_namespace_none_call(self) -> None:
+        @pto.vkernel(op="inline_proc_semantic_call_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            _inline_copy_row(dst, src, 0)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+
+        call_stmts = [
+            stmt
+            for stmt in semantic_kernel.body
+            if isinstance(stmt, SemanticExprStmt) and isinstance(stmt.expr, SemanticCallExpr)
+        ]
+        self.assertGreaterEqual(len(call_stmts), 1)
+        inline_call = call_stmts[0].expr
+        self.assertIsNone(inline_call.namespace)
+        self.assertRegex(inline_call.name, r"^__tl_inline_")
+        self.assertGreaterEqual(len(semantic_kernel.inline_helpers), 1)
+        self.assertRegex(semantic_kernel.inline_helpers[0].symbol_name, r"^__tl_inline_")
+
+    def test_inline_proc_semantic_keeps_expression_call_return_type(self) -> None:
+        @pto.inline_proc
+        def inline_const_i32():
+            return pto.i32(1)
+
+        @pto.vkernel(op="inline_proc_semantic_expr_unique", dtypes=[(pto.f32,)])
+        def kernel(dst: pto.Tile):
+            lane = inline_const_i32()
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+
+        assign_stmt = next(
+            stmt
+            for stmt in semantic_kernel.body
+            if isinstance(stmt, SemanticAssignStmt) and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_stmt.value.namespace)
+        self.assertRegex(assign_stmt.value.name, r"^__tl_inline_")
+        self.assertIsInstance(assign_stmt.value.type, SemanticScalarType)
+
+    def test_inline_proc_lowering_renders_private_helpers_and_call_bindings(self) -> None:
+        @pto.inline_proc
+        def inline_const_i32():
+            return 1
+
+        @pto.inline_proc
+        def inline_store(dst: pto.Tile, src: pto.Tile):
+            lane = inline_const_i32()
+            _inline_copy_row(dst, src, lane)
+            return None
+
+        @pto.vkernel(op="inline_proc_lowering_helpers_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            lane = inline_const_i32()
+            inline_store(dst, src)
+            _inline_copy_row(dst, src, lane)
+            return None
+
+        text = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        ).mlir_text()
+        self.assertIn('sym_visibility = "private", pto.tilelang.inline_proc', text)
+        self.assertGreaterEqual(text.count("func.func"), 3)
+        self.assertGreaterEqual(text.count("pto.tilelang.inline_proc"), 2)
+        self.assertRegex(text, r"= func\.call @__tl_inline_[A-Za-z0-9_]+\(.*\) : \([^\)]*\) -> index")
+        self.assertRegex(text, r"func\.call @__tl_inline_[A-Za-z0-9_]+\(.*\) : \([^\)]*\) -> \(\)")
+
+    def test_inline_proc_rejects_mutual_recursion(self) -> None:
+        @pto.inline_proc
+        def inline_a(dst: pto.Tile):
+            inline_b(dst)
+            return None
+
+        @pto.inline_proc
+        def inline_b(dst: pto.Tile):
+            inline_a(dst)
+            return None
+
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="inline_proc_mutual_recursion_unique", dtypes=[(pto.f32,)])
+            def kernel(dst: pto.Tile):
+                inline_a(dst)
+                return None
+
+            kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB)
+            ).mlir_text()
+
+        self.assertIn("recursive inline_proc call", str(ctx.exception))
+        self.assertIn(f"{__file__}:", str(ctx.exception))
 
 
 class TileLangDSLDiagnosticsTests(unittest.TestCase):

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -714,9 +714,9 @@ static void addVPTOBackendMainlinePasses(OpPassManager &pm,
     expandOpts.tilelangPath = tilelangPath;
     expandOpts.tilelangPkgPath = tilelangPkgPath;
     pm.addPass(pto::createExpandTileOpPass(expandOpts));
-
-    pm.addPass(pto::createPTOInlineLibCallPass());
-    pm.addNestedPass<mlir::func::FuncOp>(
+  
+  pm.addPass(pto::createPTOInlineLibCallPass());
+      pm.addNestedPass<mlir::func::FuncOp>(
         pto::createFoldTileBufIntrinsicsPass());
   }
 


### PR DESCRIPTION
## Summary
- support function-call style inline-proc expansion/lowering path in TileLang DSL and align VPTO inline-libcall backend behavior
- add floating-point literal coverage for TileLang scalar constructors, including signed numeric literals and string forms for `inf`/`-inf`/`nan` plus dtype-specific hex bit-patterns
- update user-guide sections for scalar type literal forms and `vbr`/`vdup` floating seed usage

## Commits
- 8f8badb7 Support function call in tilelang dsl
- 12c31b10 Support more floating-point literals

## Validation
- TileLang DSL unit tests updated under `tilelang-dsl/tests/test_tilelang_dsl_v1.py`
- template rendering path verified for rowmax/trowsum related flows
