### PR TITLE
docs(isa): clarify get_buf/rls_buf usage and mode parameter

### DIFF
--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -90,6 +90,29 @@ rls_buf(pipe, buf_id, mode);
 
 ---
 
+### Mode Parameter for `get_buf` / `rls_buf`
+
+The `mode` parameter controls how `get_buf` and `rls_buf` interact with pipeline execution and dependency tracking:
+
+| Mode | `get_buf` Behavior | `rls_buf` Behavior | Use Case |
+|------|-------------------|-------------------|----------|
+| **0** (default) | **Blocking acquire**: waits for all previous `rls_buf` with same `buf_id` from all pipelines (in program order) before the specified pipe can proceed | **Immediate release**: signals completion for only the instructions related to the specified pipe | **Automatic ping/pong dependency** — recommended for double/multi-buffering |
+| **1** | **Non-blocking acquire**: does not wait; pipe execution proceeds immediately | **Deferred release**: waits for all instructions across all pipelines with same `buf_id` to retire before signaling | **Backward compatibility** with `set_flag`/`wait_flag` semantics |
+
+**Mode 0 (Default — Recommended):**
+- `get_buf`: The specified pipeline blocks until all previous `rls_buf` operations for the same buffer ID (from any pipeline) have completed, respecting program order.
+- `rls_buf`: Immediately signals that the specified pipeline has finished using the buffer — only waits for that pipe's related instructions.
+- This mode provides **automatic RAW/WAR/WAW dependency resolution** based on buffer ID and program order, making it ideal for ping/pong and N-buffer patterns.
+
+**Mode 1 (Legacy Compatibility):**
+- `get_buf`: Does not block — the pipeline proceeds immediately without waiting.
+- `rls_buf`: Waits for **all** previous instructions across **all** pipelines with the same buffer ID to retire before signaling release.
+- This mode emulates `set_flag`/`wait_flag` behavior and is provided for backward compatibility with existing code patterns.
+
+> **Note:** A5 supports both `set_flag`/`wait_flag` and `get_buf`/`rls_buf` mechanisms. Mode 1 is rarely needed since mode 0 provides a more programmer-friendly approach for buffer-based synchronization.
+
+---
+
 ### `pto.mem_bar`
 
 - **syntax:** `pto.mem_bar "BARRIER_TYPE"`
@@ -112,6 +135,97 @@ mem_bar(barrier_type);
 pto.vsts %v0, %ub[%c0] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
 pto.mem_bar "VST_VLD"
 %v1 = pto.vlds %ub[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+```
+
+---
+
+## Why `get_buf` / `rls_buf` is More Programmer-Friendly
+
+The buffer-based synchronization (`get_buf`/`rls_buf`) provides the **same functional capability** as `set_flag`/`wait_flag` for maintaining correct ordering of RAW/WAR/WAW dependencies across pipelines, but with significant usability advantages:
+
+### 1. No Manual Priming or Draining
+
+With `set_flag`/`wait_flag`, ping/pong loops require:
+- **Pre-loop priming**: 4× `set_flag` to initialize reverse-dependency signals (otherwise first iteration deadlocks)
+- **Post-loop draining**: 4× `wait_flag` to consume leftover signals from final iterations
+
+With `get_buf`/`rls_buf`:
+- **First iteration**: Buffer is initially free, so `get_buf` proceeds immediately — no priming needed
+- **Final iteration**: Last `rls_buf` simply completes — no draining required
+
+### 2. No Loop Peeling for Complex Dependencies
+
+For nested loops or non-1:1 producer-consumer ratios (e.g., 1 producer : N consumers, or complex control flow), `set_flag`/`wait_flag` requires manual **loop peeling** to handle boundary conditions:
+
+```mlir
+// set_flag/wait_flag: must peel first/last iterations for correct signal counts
+// Iteration 0: special case (no previous consumer)
+// Iteration N-1: special case (no next producer)
+// Each boundary needs explicit handling
+```
+
+With `get_buf`/`rls_buf`, the acquire/release protocol handles all boundaries automatically:
+
+```mlir
+// get_buf/rls_buf: uniform loop body, no peeling
+scf.for %i = %c0 to %N step %c1 {
+  pto.get_buf %bufid, "PIPE_X"   // blocks if buffer in use
+  // ... work ...
+  pto.rls_buf %bufid, "PIPE_X"   // signals completion
+}
+// Works correctly for any loop structure or dependency pattern
+```
+
+### 3. Simpler Mental Model
+
+| Aspect | `set_flag`/`wait_flag` | `get_buf`/`rls_buf` |
+|--------|------------------------|---------------------|
+| **Dependency tracking** | Manual: track event IDs, signal directions, pair every set with wait | Automatic: buffer ID + program order |
+| **Event ID management** | 8 IDs for 2-buffer ping/pong (grows with buffers) | Just buffer IDs (shared global pool) |
+| **Error-prone areas** | Forgetting prime/drain, mismatched IDs, wrong direction | Forgetting release (but compile-time checkable) |
+
+### Quick Example Comparison
+
+**Problem:** MTE2 loads into `buf[i%2]`, Vector processes, MTE3 stores — standard ping/pong.
+
+**set_flag/wait_flag approach:**
+```mlir
+// BEFORE loop: prime 4 reverse-dep signals
+pto.set_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_0"]
+pto.set_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_1"]
+pto.set_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_0"]
+pto.set_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_1"]
+
+scf.for %i = ... {
+  // 8 set_flag + 8 wait_flag inside loop
+  // Must track {IN,OUT} × {FWD,REV} × {0,1} = 8 event IDs
+}
+
+// AFTER loop: drain 4 signals
+pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_{(N-1)%2}"]
+pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_{(N-2)%2}"]
+pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{(N-1)%2}"]
+pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{(N-2)%2}"]
+```
+
+**get_buf/rls_buf approach:**
+```mlir
+scf.for %i = ... {
+  pto.get_buf %bufid_in[%pp], "PIPE_MTE2"
+  // ... MTE2 work ...
+  pto.rls_buf %bufid_in[%pp], "PIPE_MTE2"
+
+  pto.get_buf %bufid_in[%pp], "PIPE_V"
+  pto.get_buf %bufid_out[%pp], "PIPE_V"
+  // ... Vector work ...
+  pto.rls_buf %bufid_in[%pp], "PIPE_V"
+  pto.rls_buf %bufid_out[%pp], "PIPE_V"
+
+  pto.get_buf %bufid_out[%pp], "PIPE_MTE3"
+  // ... MTE3 work ...
+  pto.rls_buf %bufid_out[%pp], "PIPE_MTE3"
+}
+// Done. No prime. No drain. Dependencies resolved by buffer ID + program order.
 ```
 
 ---
@@ -161,16 +275,16 @@ Instead of naming events, each pipeline declares when it **acquires** (`get_buf`
 ```mlir
 // ─── Stage 1: MTE2 loads data into UB ───
 // MTE2 acquires ub_ptr — blocks if Vector hasn't released it from a prior iteration
-pto.get_buf "PIPE_MTE2", %bufid_ub_ptr, %mode : i64, i64
+pto.get_buf "PIPE_MTE2", %bufid_ub_ptr, %c0 : i64, i64   // mode=0 (default)
 pto.copy_gm_to_ubuf %gm_ptr, %ub_ptr, ...
 // MTE2 done writing ub_ptr — release it so Vector can consume
-pto.rls_buf "PIPE_MTE2", %bufid_ub_ptr, %mode : i64, i64
+pto.rls_buf "PIPE_MTE2", %bufid_ub_ptr, %c0 : i64, i64
 
 // ─── Stage 2: Vector computation ───
 // Vector acquires ub_ptr (input) — blocks until MTE2 releases it (RAW: MTE2 write → V read)
-pto.get_buf "PIPE_V", %bufid_ub_ptr, %mode : i64, i64
+pto.get_buf "PIPE_V", %bufid_ub_ptr, %c0 : i64, i64
 // Vector acquires ub_out (output) — blocks until MTE3 releases it from a prior iteration (WAR: MTE3 read → V write)
-pto.get_buf "PIPE_V", %bufid_ub_out, %mode : i64, i64
+pto.get_buf "PIPE_V", %bufid_ub_out, %c0 : i64, i64
 
 pto.vecscope {
   %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
@@ -180,16 +294,16 @@ pto.vecscope {
 }
 
 // Vector done reading ub_ptr — release so MTE2 can reuse it in next iteration
-pto.rls_buf "PIPE_V", %bufid_ub_ptr, %mode : i64, i64
+pto.rls_buf "PIPE_V", %bufid_ub_ptr, %c0 : i64, i64
 // Vector done writing ub_out — release so MTE3 can consume
-pto.rls_buf "PIPE_V", %bufid_ub_out, %mode : i64, i64
+pto.rls_buf "PIPE_V", %bufid_ub_out, %c0 : i64, i64
 
 // ─── Stage 3: MTE3 stores result to GM ───
 // MTE3 acquires ub_out — blocks until Vector releases it (RAW: V write → MTE3 read)
-pto.get_buf "PIPE_MTE3", %bufid_ub_out, %mode : i64, i64
+pto.get_buf "PIPE_MTE3", %bufid_ub_out, %c0 : i64, i64
 pto.copy_ubuf_to_gm %ub_out, %gm_out, ...
 // MTE3 done reading ub_out — release so Vector can reuse it in next iteration
-pto.rls_buf "PIPE_MTE3", %bufid_ub_out, %mode : i64, i64
+pto.rls_buf "PIPE_MTE3", %bufid_ub_out, %c0 : i64, i64
 ```
 
 **Key property:** No event IDs needed. Dependencies are implicit from program order of `get_buf`/`rls_buf` on the same buffer ID. This becomes much more convenient in multi-iteration loops (see Example 3).
@@ -293,14 +407,14 @@ scf.for %i = %c0 to %N step %c1 {
   // ── MTE2: load tile[i] into buf[i%2] ──
   // Acquires buf[i%2] — on first iteration, buffer is free so proceeds immediately.
   // On later iterations, blocks until Vector releases buf[i%2] (WAR: automatic).
-  pto.get_buf %bufid_buf[%pp], "PIPE_MTE2"
+  pto.get_buf "PIPE_MTE2", %bufid_buf[%pp], %c0 : i64, i64   // mode=0
   pto.copy_gm_to_ubuf %gm_ptr[%i], %ub_buf[%pp], ...
-  pto.rls_buf %bufid_buf[%pp], "PIPE_MTE2"
+  pto.rls_buf "PIPE_MTE2", %bufid_buf[%pp], %c0 : i64, i64
 
   // ── Vector: compute on buf[i%2] ──
   // Acquires buf[i%2] — blocks until MTE2 releases it (RAW: automatic)
-  pto.get_buf %bufid_buf[%pp], "PIPE_V"
-  pto.get_buf %bufid_out[%pp], "PIPE_V"
+  pto.get_buf "PIPE_V", %bufid_buf[%pp], %c0 : i64, i64
+  pto.get_buf "PIPE_V", %bufid_out[%pp], %c0 : i64, i64
   scf.for %dummy = %c0 to %c1 step %c1 {
     %v   = pto.vlds %ub_buf[%pp][%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
     %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
@@ -308,14 +422,14 @@ scf.for %i = %c0 to %N step %c1 {
     pto.vsts %abs, %ub_out[%pp][%lane], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
   } {llvm.loop.aivector_scope}
   // Release buf[i%2] — MTE2 can reuse in iteration i+2 (WAR resolved)
-  pto.rls_buf %bufid_buf[%pp], "PIPE_V"
-  pto.rls_buf %bufid_out[%pp], "PIPE_V"
+  pto.rls_buf "PIPE_V", %bufid_buf[%pp], %c0 : i64, i64
+  pto.rls_buf "PIPE_V", %bufid_out[%pp], %c0 : i64, i64
 
   // ── MTE3: store result ──
   // Acquires out[i%2] — blocks until Vector releases it (RAW: automatic)
-  pto.get_buf %bufid_out[%pp], "PIPE_MTE3"
+  pto.get_buf "PIPE_MTE3", %bufid_out[%pp], %c0 : i64, i64
   pto.copy_ubuf_to_gm %ub_out[%pp], %gm_out[%i], ...
-  pto.rls_buf %bufid_out[%pp], "PIPE_MTE3"
+  pto.rls_buf "PIPE_MTE3", %bufid_out[%pp], %c0 : i64, i64
 }
 // No post-loop drain needed — last rls_buf completes the pipeline.
 ```
@@ -335,10 +449,11 @@ scf.for %i = %c0 to %N step %c1 {
 | IDs per pipe-pair | **8** = 2 buffers × 2 dirs × 2 (fwd+rev) | 1 fwd + 1 rev per buffer (shared global pool) |
 | Total HW IDs | 8 per pipe-pair, grows with buffers | **32 global** across all pipes |
 | Reverse (WAR) deps | Extra `set_flag`/`wait_flag` pair per buffer | Handled automatically |
-| Pre-loop setup | `set_flag` to prime each reverse dep | None |
-| Post-loop teardown | `wait_flag` to drain all primed signals | None |
+| Pre-loop setup | `set_flag` to prime each reverse dep | **None** |
+| Post-loop teardown | `wait_flag` to drain all primed signals | **None** |
+| Loop peeling for complex deps | Required for non-1:1 or nested loops | **Not required** |
 | Straight-line code | Simple, clear | Slightly more verbose (bracket each stage) |
-| Ping/pong loops | 8 event IDs + 4 prime + 4 drain | Same pattern, no overhead |
+| Ping/pong loops | 8 event IDs + 4 prime + 4 drain | Same pattern, **no overhead** |
 | Best used for | Simple pipelines, fine-grained control | Double/multi-buffering, complex loops |
 
 ---

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -197,8 +197,8 @@ pto.set_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_0"]
 pto.set_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_1"]
 
 scf.for %i = ... {
-  // 8 set_flag + 8 wait_flag inside loop
-  // Must track {IN,OUT} × {FWD,REV} × {0,1} = 8 event IDs
+  // 4 set_flag + 4 wait_flag inside loop
+  // Must track 4 IDs: 2 pipe-pair directions × 2 ping/pong buffers
 }
 
 // AFTER loop: drain 4 signals

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -155,25 +155,38 @@ With `get_buf`/`rls_buf`:
 
 ### 2. No Loop Peeling for Complex Dependencies
 
-For nested loops or non-1:1 producer-consumer ratios (e.g., 1 producer : N consumers, or complex control flow), `set_flag`/`wait_flag` requires manual **loop peeling** to handle boundary conditions:
+For non-1:1 producer-consumer ratios (e.g., 1 MTE2 load : N Vector compute slices), `set_flag`/`wait_flag` requires **peeling the set_flag outside the loop**:
 
 ```mlir
-// set_flag/wait_flag: must peel first/last iterations for correct signal counts
-// Iteration 0: special case (no previous consumer)
-// Iteration N-1: special case (no next producer)
-// Each boundary needs explicit handling
+// set_flag/wait_flag: 1 MTE2 load, 8 Vector computes on slices
+// MTE2 loads large tile once
+pto.copy_gm_to_ubuf %gm_ptr, %ub_tile, ...
+pto.set_flag["PIPE_MTE2", "PIPE_V", "EVT_TILE_READY"]  // ◀ MUST be outside loop
+
+// Vector consumes in 8 slices — but wait_flag can only fire ONCE
+pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVT_TILE_READY"] // ◀ MUST peel before loop
+scf.for %slice = %c0 to %c8 step %c1 {
+  // compute on %ub_tile[%slice]
+  // Cannot put wait_flag here — would deadlock on iteration 1+
+}
 ```
 
-With `get_buf`/`rls_buf`, the acquire/release protocol handles all boundaries automatically:
+With `get_buf`/`rls_buf`, acquire/release can stay **inside or outside** the loop — both work:
 
 ```mlir
-// get_buf/rls_buf: uniform loop body, no peeling
-scf.for %i = %c0 to %N step %c1 {
-  pto.get_buf %bufid, "PIPE_X"   // blocks if buffer in use
-  // ... work ...
-  pto.rls_buf %bufid, "PIPE_X"   // signals completion
+// get_buf/rls_buf: same 1:8 pattern, but more flexible
+// MTE2 loads large tile
+pto.get_buf "PIPE_MTE2", %bufid_tile, %c0 : i64, i64
+pto.copy_gm_to_ubuf %gm_ptr, %ub_tile, ...
+pto.rls_buf "PIPE_MTE2", %bufid_tile, %c0 : i64, i64
+
+// Vector can acquire once outside, or acquire/release per slice — both correct
+pto.get_buf "PIPE_V", %bufid_tile, %c0 : i64, i64  // acquire once
+scf.for %slice = %c0 to %c8 step %c1 {
+  // compute on %ub_tile[%slice]
 }
-// Works correctly for any loop structure or dependency pattern
+pto.rls_buf "PIPE_V", %bufid_tile, %c0 : i64, i64  // release once
+// No peeling required — get_buf blocks until MTE2's rls_buf completes
 ```
 
 ### 3. Simpler Mental Model

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -181,7 +181,7 @@ scf.for %i = %c0 to %N step %c1 {
 | Aspect | `set_flag`/`wait_flag` | `get_buf`/`rls_buf` |
 |--------|------------------------|---------------------|
 | **Dependency tracking** | Manual: track event IDs, signal directions, pair every set with wait | Automatic: buffer ID + program order |
-| **Event ID management** | 8 IDs for 2-buffer ping/pong (grows with buffers) | Just buffer IDs (shared global pool) |
+| **Event ID management** | **8 IDs per pipe-pair direction** (HW limit); 2-buffer ping/pong uses 4 IDs per pipe-pair (2 fwd + 2 rev) | **1 buffer ID per shared resource** (HW limit: 32 global); same ID used across all pipelines |
 | **Error-prone areas** | Forgetting prime/drain, mismatched IDs, wrong direction | Forgetting release (but compile-time checkable) |
 
 ### Quick Example Comparison

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -171,22 +171,23 @@ scf.for %slice = %c0 to %c8 step %c1 {
 }
 ```
 
-With `get_buf`/`rls_buf`, acquire/release can stay **inside or outside** the loop — both work:
+With `get_buf`/`rls_buf`, acquire/release can be **inside the loop** — no peeling needed:
 
 ```mlir
-// get_buf/rls_buf: same 1:8 pattern, but more flexible
+// get_buf/rls_buf: same 1:8 pattern, acquire/release inside loop works fine
 // MTE2 loads large tile
 pto.get_buf "PIPE_MTE2", %bufid_tile, %c0 : i64, i64
 pto.copy_gm_to_ubuf %gm_ptr, %ub_tile, ...
 pto.rls_buf "PIPE_MTE2", %bufid_tile, %c0 : i64, i64
 
-// Vector can acquire once outside, or acquire/release per slice — both correct
-pto.get_buf "PIPE_V", %bufid_tile, %c0 : i64, i64  // acquire once
+// Vector acquires/releases per slice — all 8 iterations work correctly
 scf.for %slice = %c0 to %c8 step %c1 {
+  pto.get_buf "PIPE_V", %bufid_tile, %c0 : i64, i64  // iteration 0: blocks until MTE2 done
+                                                      // iteration 1-7: proceeds immediately (already acquired)
   // compute on %ub_tile[%slice]
+  pto.rls_buf "PIPE_V", %bufid_tile, %c0 : i64, i64
 }
-pto.rls_buf "PIPE_V", %bufid_tile, %c0 : i64, i64  // release once
-// No peeling required — get_buf blocks until MTE2's rls_buf completes
+// No peeling required — get_buf handles the MTE2→V dependency automatically
 ```
 
 ### 3. Simpler Mental Model

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -181,7 +181,7 @@ scf.for %i = %c0 to %N step %c1 {
 | Aspect | `set_flag`/`wait_flag` | `get_buf`/`rls_buf` |
 |--------|------------------------|---------------------|
 | **Dependency tracking** | Manual: track event IDs, signal directions, pair every set with wait | Automatic: buffer ID + program order |
-| **Event ID management** | **8 IDs per pipe-pair direction** (HW limit); 2-buffer ping/pong uses 4 IDs per pipe-pair (2 fwd + 2 rev) | **1 buffer ID per shared resource** (HW limit: 32 global); same ID used across all pipelines |
+| **Event ID management** | **8 IDs per pipe-pair direction** (HW limit); each buffer occupies 1 ID per direction | **1 buffer ID per shared resource** (HW limit: 32 global); same ID used across all pipelines |
 | **Error-prone areas** | Forgetting prime/drain, mismatched IDs, wrong direction | Forgetting release (but compile-time checkable) |
 
 ### Quick Example Comparison
@@ -202,10 +202,10 @@ scf.for %i = ... {
 }
 
 // AFTER loop: drain 4 signals
-pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_{(N-1)%2}"]
-pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_{(N-2)%2}"]
-pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{(N-1)%2}"]
-pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{(N-2)%2}"]
+pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_0"]
+pto.wait_flag["PIPE_V", "PIPE_MTE2", "EVT_IN_REV_1"]
+pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_0"]
+pto.wait_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_1"]
 ```
 
 **get_buf/rls_buf approach:**

--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -446,8 +446,8 @@ scf.for %i = %c0 to %N step %c1 {
 | Aspect | `set_flag` / `wait_flag` | `get_buf` / `rls_buf` |
 |--------|--------------------------|------------------------|
 | Dependency model | Explicit event signals | Implicit via buffer acquire/release |
-| IDs per pipe-pair | **8** = 2 buffers × 2 dirs × 2 (fwd+rev) | 1 fwd + 1 rev per buffer (shared global pool) |
-| Total HW IDs | 8 per pipe-pair, grows with buffers | **32 global** across all pipes |
+| IDs per pipe-pair | 2 IDs per buffer: 1 for forward (e.g., MTE2→V) + 1 for reverse (V→MTE2) | **1 ID per buffer** (handles both directions automatically) |
+| Total HW IDs | **8 per pipe-pair** (hardware limit) | **32 global** across all pipes |
 | Reverse (WAR) deps | Extra `set_flag`/`wait_flag` pair per buffer | Handled automatically |
 | Pre-loop setup | `set_flag` to prime each reverse dep | **None** |
 | Post-loop teardown | `wait_flag` to drain all primed signals | **None** |


### PR DESCRIPTION
## Summary
Clarifies the get_buf/rls_buf buffer-based synchronization mechanism in response to feedback that usage was unclear compared to set_flag/wait_flag.

## Changes
- **Mode parameter documentation**: Explains mode=0 (default, automatic ping/pong) vs mode=1 (legacy compatibility)
- **'Why get_buf/rls_buf is More Programmer-Friendly' section** with key benefits:
  - No manual priming/draining needed for ping/pong loops
  - No loop peeling required for complex/nested loop dependencies  
  - Simpler mental model (buffer ID + program order vs event ID management)
- **Quick comparison example** showing set_flag overhead (4 prime + 4 drain) vs clean get_buf loop
- Updated Example 2 and 3b code with explicit `mode=0`
- Added 'Loop peeling' row to comparison table

## Key Clarifications
- **Mode 0**: Blocking acquire (waits for all previous rls_buf with same buf_id), immediate release → automatic RAW/WAR/WAW dependency resolution
- **Mode 1**: Non-blocking acquire, deferred release (waits for all pipelines) → backward compatible with set_flag/wait_flag semantics
- A5 supports both mechanisms; mode=0 is recommended for new code