### PR TITLE
Fix vshls/vshrs scalar legality to i16 in TileLang semantic checks

### DIFF
--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -759,7 +759,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 |--------------|------|-------------|
 | `result` | `VRegType` | Leaky ReLU activated values |
 
-#### `pto.vshls(vec: VRegType, shift: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vshls(vec: VRegType, shift: i16, mask: MaskType) -> VRegType`
 
 **Description**: Vector shift left by scalar (uniform shift).
 
@@ -767,7 +767,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
-| `shift` | `ScalarType` | Shift amount (same for all elements) |
+| `shift` | `i16` | Shift amount (same for all elements) |
 | `mask` | `MaskType` | Predicate mask |
 
 **Returns**:
@@ -775,7 +775,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 |--------------|------|-------------|
 | `result` | `VRegType` | Shifted values |
 
-#### `pto.vshrs(vec: VRegType, shift: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vshrs(vec: VRegType, shift: i16, mask: MaskType) -> VRegType`
 
 **Description**: Vector shift right by scalar (uniform shift).
 
@@ -783,7 +783,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
-| `shift` | `ScalarType` | Shift amount (same for all elements) |
+| `shift` | `i16` | Shift amount (same for all elements) |
 | `mask` | `MaskType` | Predicate mask |
 
 **Returns**:

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4107,7 +4107,10 @@ class _SemanticAnalyzer:
         vector_expr, scalar_expr, mask = args
         vreg = self._require_vreg_expr(vector_expr, f"pto.{name} vector")
         scalar = self._require_scalar_expr(scalar_expr, f"pto.{name} scalar")
-        if scalar.dtype != vreg.element_dtype:
+        if name in {"vshls", "vshrs"}:
+            if scalar.dtype != i16:
+                raise TypeError(f"pto.{name} scalar dtype must be i16")
+        elif scalar.dtype != vreg.element_dtype:
             raise TypeError(f"pto.{name} scalar dtype must match vector element dtype")
         self._require_mask_for_vreg(mask, vreg, f"pto.{name}")
         self._validate_vector_scalar_dtype(name, vreg.element_dtype)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2374,10 +2374,10 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
     def test_extended_integer_vector_ops_surface_lowers(self) -> None:
         @pto.vkernel(
             op="extended_integer_vector_ops_unique",
-            dtypes=[(pto.i32, pto.i32, pto.i32)],
+            dtypes=[(pto.i32, pto.i32, pto.i16)],
             advanced=True,
         )
-        def kernel(dst: pto.Tile, src: pto.Tile, shift: pto.i32):
+        def kernel(dst: pto.Tile, src: pto.Tile, shift: pto.i16):
             all_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
             vec0 = pto.vlds(src, 0)
             vec1 = pto.vlds(src, 64)


### PR DESCRIPTION
## Summary
- align TileLang semantic checks with VPTO spec for `pto.vshls`/`pto.vshrs`
- require scalar operand to be `i16` instead of vector element dtype match
- update user guide signatures/parameter types for `vshls` and `vshrs` to `i16`

## Why
VPTO spec defines `pto.vshls` and `pto.vshrs` scalar operand as fixed `i16`, so current same-dtype validation rejects legal IR patterns.

Closes #59
Related: https://github.com/mouliangyu/PTOAS/issues/59