### PR TITLE
Fix semantics of vdup op

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -43,6 +43,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -92,11 +93,12 @@ struct OperandTypeInfo {
 
   // --- Tile-only (TileBufType) ---
   SmallVector<int64_t, 2> tileShape;
+  SmallVector<int64_t, 2> tileValidShape;
   std::string tileMemorySpace; // "ub" or "gm"
   int32_t blayout = 0;
   int32_t slayout = 0;
   int32_t fractal = 0;
-  int32_t pad = 0;
+  uint64_t pad = 0;
 
   // --- View-only (MemRefType) — for JSON / constraint checking only ---
   SmallVector<int64_t> viewShape;
@@ -109,6 +111,7 @@ struct OperandTypeInfo {
       return false;
     if (kind == OperandKind::Tile)
       return tileShape == rhs.tileShape &&
+             tileValidShape == rhs.tileValidShape &&
              tileMemorySpace == rhs.tileMemorySpace &&
              blayout == rhs.blayout && slayout == rhs.slayout &&
              fractal == rhs.fractal && pad == rhs.pad;
@@ -138,8 +141,10 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
       h = llvm::hash_combine(h, static_cast<int>(op.kind), op.dtype);
       if (op.kind == OperandKind::Tile) {
         h = llvm::hash_combine(h, op.tileMemorySpace, op.blayout,
-                                op.slayout, op.fractal, op.pad);
+                               op.slayout, op.fractal, op.pad);
         for (int64_t d : op.tileShape)
+          h = llvm::hash_combine(h, d);
+        for (int64_t d : op.tileValidShape)
           h = llvm::hash_combine(h, d);
       }
       // View/Scalar: only kind + dtype contribute to hash.
@@ -184,6 +189,20 @@ static std::string getMemorySpaceString(MemRefType mrTy) {
   return "ub";
 }
 
+static std::string getBLayoutString(int32_t blayout) {
+  if (blayout == static_cast<int32_t>(pto::BLayout::ColMajor))
+    return "col_major";
+  return "row_major";
+}
+
+static std::string getSLayoutString(int32_t slayout) {
+  if (slayout == static_cast<int32_t>(pto::SLayout::RowMajor))
+    return "row_major";
+  if (slayout == static_cast<int32_t>(pto::SLayout::ColMajor))
+    return "col_major";
+  return "none_box";
+}
+
 static std::optional<OperandTypeInfo> buildOperandTypeInfo(Type ty) {
   // Tile operand — from TileBufType.
   if (auto tbTy = dyn_cast<pto::TileBufType>(ty)) {
@@ -193,6 +212,11 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Type ty) {
     if (info.dtype.empty())
       return std::nullopt;
     info.tileShape.assign(tbTy.getShape().begin(), tbTy.getShape().end());
+    auto validShape = tbTy.getValidShape();
+    if (validShape.empty())
+      info.tileValidShape.assign(tbTy.getShape().begin(), tbTy.getShape().end());
+    else
+      info.tileValidShape.assign(validShape.begin(), validShape.end());
     info.tileMemorySpace = getMemorySpaceString(tbTy);
     if (auto config = tbTy.getConfigAttr()) {
       info.blayout = static_cast<int32_t>(config.getBLayout().getValue());
@@ -200,7 +224,7 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Type ty) {
       info.fractal = config.getSFractalSize()
                          ? static_cast<int32_t>(config.getSFractalSize().getInt())
                          : 0;
-      info.pad = static_cast<int32_t>(config.getPad().getValue());
+      info.pad = static_cast<uint64_t>(config.getPad().getValue());
     }
     return info;
   }
@@ -295,7 +319,20 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
     if (op.kind == OperandKind::Tile) {
       json += "{\"kind\":\"tile\",\"dtype\":\"" + op.dtype + "\",\"shape\":";
       appendJsonIntArray(json, op.tileShape);
-      json += ",\"memory_space\":\"" + op.tileMemorySpace + "\"}";
+      json += ",\"valid_shape\":";
+      appendJsonIntArray(json, op.tileValidShape);
+      json += ",\"memory_space\":\"";
+      json += op.tileMemorySpace;
+      json += "\",\"config\":{";
+      json += "\"b_layout\":\"";
+      json += getBLayoutString(op.blayout);
+      json += "\",\"s_layout\":\"";
+      json += getSLayoutString(op.slayout);
+      json += "\",\"s_fractal_size\":";
+      json += std::to_string(op.fractal);
+      json += ",\"pad_value\":\"0x";
+      json += llvm::utohexstr(op.pad, /*LowerCase=*/false);
+      json += "\"}}";
       continue;
     }
 
@@ -470,6 +507,12 @@ func::FuncOp ExpandState::invokeTilelangDSL(const SpecKey &key,
     if (op.kind == OperandKind::Tile) {
       for (int64_t d : op.tileShape)
         uniqueName += "_" + std::to_string(d);
+      for (int64_t d : op.tileValidShape)
+        uniqueName += "_v" + std::to_string(d);
+      uniqueName += "_bl" + std::to_string(op.blayout);
+      uniqueName += "_sl" + std::to_string(op.slayout);
+      uniqueName += "_fr" + std::to_string(op.fractal);
+      uniqueName += "_pd" + llvm::utohexstr(op.pad, /*LowerCase=*/false);
     }
   }
 

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -297,10 +297,10 @@ pad2 = pto.PadValue.custom_f32("0xBF800000")  # float32 bit pattern for -1.0f
 ```
 
 Notes:
-- `PadValue.value` on the host-side descriptor still exposes the encoded integer payload.
+- `PadValue.encoded` exposes the host-side uint64 payload. `PadValue.value` is intentionally unavailable to avoid confusion with kernel-side `.eval()`.
 - `PadValue.text` exposes the standard textual spelling for built-ins such as `null` and `zero`.
 - Custom pad values currently model an `f32` payload. In DSL v1, materializing a custom pad into a scalar is only supported for floating tile element dtypes.
-- `PadValue.NULL` does not denote a usable scalar fill constant. Reading `tile.pad_value.value` or `tile.config.pad_value.value` when the enum is `NULL` is a frontend error.
+- `PadValue.NULL` does not denote a usable scalar fill constant. Calling `tile.pad_value.eval()` or `tile.config.pad_value.eval()` when the enum is `NULL` is a frontend error.
 
 #### Tile Shape Concepts
 
@@ -330,13 +330,13 @@ pad_desc2 = tile.pad_value            # direct sugar for the same PadValue enum
 rank = tile.rank                      # 2
 ```
 
-`tile.config.pad_value` and `tile.pad_value` are enum-typed inside kernel code. Use `.value` to materialize the configured pad descriptor against the tile element dtype:
+`tile.config.pad_value` and `tile.pad_value` are enum-typed inside kernel code. Use `.eval()` to materialize the configured pad descriptor against the tile element dtype:
 
-- `tile.pad_value.value` with `PadValue.ZERO` becomes `0` / `0.0`
-- `tile.pad_value.value` with `PadValue.MAX` becomes dtype-aware max
-- `tile.pad_value.value` with `PadValue.MIN` becomes dtype-aware min
-- `tile.pad_value.value` with `PadValue.custom_f32(...)` becomes the authored floating scalar
-- `tile.pad_value.value` with `PadValue.NULL` raises a frontend error
+- `tile.pad_value.eval()` with `PadValue.ZERO` becomes `0` / `0.0`
+- `tile.pad_value.eval()` with `PadValue.MAX` becomes dtype-aware max
+- `tile.pad_value.eval()` with `PadValue.MIN` becomes dtype-aware min
+- `tile.pad_value.eval()` with `PadValue.custom_f32(...)` becomes the authored floating scalar
+- `tile.pad_value.eval()` with `PadValue.NULL` raises a frontend error
 
 Example: reading pad value from a `Tile`
 
@@ -352,8 +352,8 @@ def kernel(dst: pto.Tile):
     pad1 = dst.config.pad_value
 
     if pto.constexpr(pad0 != pto.PadValue.NULL):
-        scalar0 = pad0.value
-        scalar1 = pad1.value
+        scalar0 = pad0.eval()
+        scalar1 = pad1.eval()
         vec0 = pto.vdup(scalar0, mask)
         vec1 = pto.vdup(scalar1, mask)
         pto.vsts(vec0, dst[0, 0:], mask)
@@ -361,7 +361,7 @@ def kernel(dst: pto.Tile):
 ```
 
 If `dst` is specialized with `config=pto.TileConfig.from_mapping({"pad_value": pto.PadValue.ZERO})`,
-both `pad0` and `pad1` are `PadValue.ZERO`, and `pad0.value` / `pad1.value` materialize to the scalar `0.0` for an `f16` tile.
+both `pad0` and `pad1` are `PadValue.ZERO`, and `pad0.eval()` / `pad1.eval()` materialize to the scalar `0.0` for an `f16` tile.
 
 #### Conversion Operations
 

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -275,6 +275,33 @@ Important notes on shape and valid shape:
 | `valid_shape` | `tuple[int, ...]` | Actual data dimensions within the tile. Must be less than or equal to `shape` in each dimension |
 | `config` | `TileConfig` | Layout and padding configuration |
 
+#### Tile Pad Values
+
+`TileConfig.pad_value` is modeled after the C++ `PadValue : uint64_t` design.
+
+Standard pad values use small integer encodings:
+
+| DSL Value | Encoded Value | Meaning |
+|-----------|---------------|---------|
+| `pto.PadValue.NULL` | `0` | No concrete fill value |
+| `pto.PadValue.ZERO` | `1` | Zero fill |
+| `pto.PadValue.MAX` | `2` | Maximum finite / integer max for the tile element dtype |
+| `pto.PadValue.MIN` | `3` | Minimum finite / integer min for the tile element dtype |
+
+Custom pad values use the `CustomBase = 0x100000000` convention and are authored with `pto.PadValue.custom_f32(...)`:
+
+```python
+pad0 = pto.PadValue.ZERO
+pad1 = pto.PadValue.custom_f32(-1.0)
+pad2 = pto.PadValue.custom_f32("0xBF800000")  # float32 bit pattern for -1.0f
+```
+
+Notes:
+- `PadValue.value` on the host-side descriptor still exposes the encoded integer payload.
+- `PadValue.text` exposes the standard textual spelling for built-ins such as `null` and `zero`.
+- Custom pad values currently model an `f32` payload. In DSL v1, materializing a custom pad into a scalar is only supported for floating tile element dtypes.
+- `PadValue.NULL` does not denote a usable scalar fill constant. Reading `tile.pad_value.value` or `tile.config.pad_value.value` when the enum is `NULL` is a frontend error.
+
 #### Tile Shape Concepts
 
 - `shape` is the static physical allocation size of the tile buffer.
@@ -296,11 +323,45 @@ config = tile.config
 b_layout = config.b_layout            # pto.BLayout.ROW_MAJOR
 s_layout = config.s_layout            # pto.SLayout.NONE_BOX
 s_fractal = config.s_fractal_size     # pto.i32(512)
-pad = config.pad_value                # pto.PadValue.NULL
+pad_desc = tile.config.pad_value      # PadValue enum bound to the tile element dtype
+pad_desc2 = tile.pad_value            # direct sugar for the same PadValue enum
 
 # Dynamic properties
 rank = tile.rank                      # 2
 ```
+
+`tile.config.pad_value` and `tile.pad_value` are enum-typed inside kernel code. Use `.value` to materialize the configured pad descriptor against the tile element dtype:
+
+- `tile.pad_value.value` with `PadValue.ZERO` becomes `0` / `0.0`
+- `tile.pad_value.value` with `PadValue.MAX` becomes dtype-aware max
+- `tile.pad_value.value` with `PadValue.MIN` becomes dtype-aware min
+- `tile.pad_value.value` with `PadValue.custom_f32(...)` becomes the authored floating scalar
+- `tile.pad_value.value` with `PadValue.NULL` raises a frontend error
+
+Example: reading pad value from a `Tile`
+
+```python
+@pto.vkernel(op="fill_pad_demo", dtypes=[(pto.f16,)])
+def kernel(dst: pto.Tile):
+    mask, _ = pto.make_mask(pto.f16, 8)
+
+    # Read the Tile-bound PadValue enum.
+    pad0 = dst.pad_value
+
+    # Equivalent form through TileConfig metadata.
+    pad1 = dst.config.pad_value
+
+    if pto.constexpr(pad0 != pto.PadValue.NULL):
+        scalar0 = pad0.value
+        scalar1 = pad1.value
+        vec0 = pto.vdup(scalar0, mask)
+        vec1 = pto.vdup(scalar1, mask)
+        pto.vsts(vec0, dst[0, 0:], mask)
+        pto.vsts(vec1, dst[1, 0:], mask)
+```
+
+If `dst` is specialized with `config=pto.TileConfig.from_mapping({"pad_value": pto.PadValue.ZERO})`,
+both `pad0` and `pad1` are `PadValue.ZERO`, and `pad0.value` / `pad1.value` materialize to the scalar `0.0` for an `f16` tile.
 
 #### Conversion Operations
 

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -759,7 +759,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 |--------------|------|-------------|
 | `result` | `VRegType` | Leaky ReLU activated values |
 
-#### `pto.vshls(vec: VRegType, shift: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vshls(vec: VRegType, shift: i16, mask: MaskType) -> VRegType`
 
 **Description**: Vector shift left by scalar (uniform shift).
 
@@ -767,7 +767,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
-| `shift` | `ScalarType` | Shift amount (same for all elements) |
+| `shift` | `i16` | Shift amount (same for all elements) |
 | `mask` | `MaskType` | Predicate mask |
 
 **Returns**:
@@ -775,7 +775,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 |--------------|------|-------------|
 | `result` | `VRegType` | Shifted values |
 
-#### `pto.vshrs(vec: VRegType, shift: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vshrs(vec: VRegType, shift: i16, mask: MaskType) -> VRegType`
 
 **Description**: Vector shift right by scalar (uniform shift).
 
@@ -783,7 +783,7 @@ scaled = pto.vmuls(vec_f32, pto.f32(2.0), mask32)
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
-| `shift` | `ScalarType` | Shift amount (same for all elements) |
+| `shift` | `i16` | Shift amount (same for all elements) |
 | `mask` | `MaskType` | Predicate mask |
 
 **Returns**:

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -893,12 +893,8 @@ rowmax_seed_f32 = pto.vbr(pto.f32("-inf"))
 rowmax_seed_f16 = pto.vbr(pto.f16("0xFC00"))
 ```
 
-**Position Mode Enum**: The `PositionMode` enum provides type-safe source-lane
-selection for `pto.vdup`. `LOWEST` selects the lowest-index element of the
-source vector and `HIGHEST` selects the highest-index element. When the input is
-a scalar, the duplicated scalar value is independent of `position`.
-
-#### `pto.vdup(input: ScalarType | VRegType, mask: MaskType, position: PositionMode = PositionMode.LOWEST) -> VRegType`
+#### `pto.vdup(input: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vdup(input: VRegType, mask: MaskType, position: PositionMode = PositionMode.LOWEST) -> VRegType`
 
 **Description**: Duplicate a scalar value or one selected vector element into
 the active lanes of a destination vector.
@@ -908,7 +904,12 @@ the active lanes of a destination vector.
 |-----------|------|-------------|
 | `input` | `ScalarType` or `VRegType` | Input scalar or source vector |
 | `mask` | `MaskType` | Predicate mask controlling which lanes are written |
-| `position` | `PositionMode` | Optional enum selecting the source vector element to duplicate (default: `PositionMode.LOWEST`) |
+| `position` | `PositionMode` | Optional enum for the vector-input overload, selecting the source vector element to duplicate (default: `PositionMode.LOWEST`) |
+
+**Position Mode Enum**: The `PositionMode` enum provides type-safe source-lane
+selection for `pto.vdup`. `LOWEST` selects the lowest-index element of the
+source vector and `HIGHEST` selects the highest-index element. The enum is only
+used by the vector-input overload.
 
 **Returns**:
 | Return Value | Type | Description |
@@ -921,6 +922,7 @@ the active lanes of a destination vector.
 - When `input` is a scalar, the scalar value is duplicated to every active lane.
 - When `input` is a vector, `position` selects a single source element and that
   value is duplicated to every active lane.
+- The scalar overload does not accept `position`.
 - Inactive lanes follow VPTO predicate semantics and are not guaranteed to carry
   meaningful values for subsequent masked-off use.
 - Supported scalar types are the 8/16/32-bit integer families (`i*`, `si*`, `ui*`) plus `f16`, `bf16`, and `f32`.
@@ -932,7 +934,7 @@ the active lanes of a destination vector.
 mask32 = pto.make_mask(pto.f32, pto.PAT.ALL)
 
 # Duplicate a scalar into all active lanes.
-broadcast = pto.vdup(3.14, mask32)  # position defaults to "LOWEST"
+broadcast = pto.vdup(3.14, mask32)
 
 # Use dtype constructors for floating-point special values.
 seed = pto.vdup(pto.f32("-inf"), mask32)

--- a/tilelang-dsl/python/tilelang_dsl/expand_helper.py
+++ b/tilelang-dsl/python/tilelang_dsl/expand_helper.py
@@ -22,7 +22,7 @@ import sys
 from pathlib import Path
 
 from .kernel import VKernelDescriptor, _match_descriptor_dtype_signature
-from .types import MemorySpace, ScalarType, TileSpecialization
+from .types import MemorySpace, ScalarType, TileConfig, TileSpecialization
 
 
 _DTYPE_MAP: dict[str, ScalarType] = {}
@@ -129,16 +129,32 @@ def _parse_operand_specs(spec_text: str) -> list[dict]:
             shape = raw.get("shape")
             if not isinstance(shape, list) or not shape:
                 raise ValueError(f"operand-specs[{index}] tile shape must be a non-empty list")
+            valid_shape = raw.get("valid_shape")
+            if valid_shape is not None and (not isinstance(valid_shape, list) or not valid_shape):
+                raise ValueError(f"operand-specs[{index}] tile valid_shape must be a non-empty list")
             memory_space = _MEMSPACE_MAP.get(raw.get("memory_space"))
             if memory_space is None:
                 raise ValueError(
                     f"operand-specs[{index}] has unknown memory-space {raw.get('memory_space')!r}"
                 )
+            config_raw = raw.get("config")
+            config = None
+            if config_raw is not None:
+                if not isinstance(config_raw, dict):
+                    raise ValueError(f"operand-specs[{index}] tile config must be an object")
+                try:
+                    config = TileConfig.from_mapping(config_raw)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"operand-specs[{index}] has invalid tile config: {exc}"
+                    ) from exc
             specs.append(
                 {
                     "kind": "tile",
                     "dtype": dtype,
                     "shape": tuple(int(dim) for dim in shape),
+                    "valid_shape": None if valid_shape is None else tuple(int(dim) for dim in valid_shape),
+                    "config": config,
                     "memory_space": memory_space,
                 }
             )
@@ -262,6 +278,8 @@ def main(argv: list[str] | None = None) -> int:
             tile_specs[param.name] = TileSpecialization(
                 shape=operand_spec["shape"],
                 memory_space=operand_spec["memory_space"],
+                config=operand_spec.get("config"),
+                valid_shape=operand_spec.get("valid_shape"),
             )
             continue
         if param.kind in ("tensorview", "partition_tensor_view"):

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -620,6 +620,7 @@ _BINARY_OP_NAMES = {
     ast.Add: "add",
     ast.Sub: "sub",
     ast.Mult: "mul",
+    ast.Mod: "mod",
     ast.FloorDiv: "floordiv",
 }
 _COMPARE_OP_NAMES = {

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -1019,6 +1019,25 @@ def _build_expr(node: ast.AST, context: _FrontendBuildContext) -> FrontendExprNo
                 node,
                 context,
             )
+        if isinstance(node.func, ast.Attribute):
+            return _attach_source_location(
+                FrontendCallExpr(
+                    namespace=None,
+                    name=node.func.attr,
+                    args=(
+                        _build_expr(node.func.value, context),
+                        *(tuple(_build_expr(arg, context) for arg in node.args)),
+                    ),
+                    keywords=_build_call_keywords(
+                        node,
+                        namespace=None,
+                        name=node.func.attr,
+                        context=context,
+                    ),
+                ),
+                node,
+                context,
+            )
     raise context.error(
         node,
         f"unsupported expression `{type(node).__name__}` in TileLang DSL v1",

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -392,6 +392,19 @@ class _KernelBodyValidator(ast.NodeVisitor):
             seen.add(keyword.arg)
 
     def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "eval":
+            if node.keywords:
+                raise self.source_info.error(
+                    node,
+                    "`eval` does not support keyword arguments in TileLang DSL v1",
+                )
+            if node.args:
+                raise self.source_info.error(
+                    node,
+                    "`eval()` does not accept positional arguments in TileLang DSL v1",
+                )
+            return
+
         if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
             if node.func.attr == "as_ptr":
                 if node.keywords:

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2545,12 +2545,19 @@ class _AuthoringRenderer:
         if expr.name == "vdup":
             value = self._lower_expr(expr.args[0], env, indent=indent, into=into)
             mask = self._lower_expr(expr.args[1], env, indent=indent, into=into)
-            position = self._render_string_literal(expr.args[2])
-            into.append(
-                self._indent(indent)
-                + f"{result_name} = pto.vdup {value.name}, {mask.name} {{position = {position}}} : "
-                + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
-            )
+            if len(expr.args) == 3:
+                position = self._render_string_literal(expr.args[2])
+                into.append(
+                    self._indent(indent)
+                    + f"{result_name} = pto.vdup {value.name}, {mask.name} {{position = {position}}} : "
+                    + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+                )
+            else:
+                into.append(
+                    self._indent(indent)
+                    + f"{result_name} = pto.vdup {value.name}, {mask.name} : "
+                    + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+                )
             return _RenderedValue(name=result_name, type=expr.type)
 
         if expr.name == "vci":

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -3428,6 +3428,10 @@ class _AuthoringRenderer:
                 return "arith.subi"
             if op == "mul":
                 return "arith.muli"
+            if op == "mod":
+                if isinstance(ty, SemanticIndexType):
+                    return "arith.remui"
+                return "arith.remsi"
             if op == "floordiv":
                 return "arith.floordivsi"
         raise NotImplementedError(f"unsupported binary op '{op}' for type {ty!r}")

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -37,6 +37,7 @@ from .semantic import (
     SemanticLowLevelCopyStmt,
     SemanticMaskType,
     SemanticMetaType,
+    SemanticPadValueType,
     SemanticPipeBarrierStmt,
     SemanticPredicateStoreStmt,
     SemanticPtrType,
@@ -70,7 +71,9 @@ from .semantic import (
 )
 from .types import (
     MaskPattern,
+    PadValue,
     ScalarType,
+    TileConfig,
     bytewidth,
     get_lanes,
     integer_bitwidth,
@@ -586,7 +589,7 @@ class _AuthoringRenderer:
                 return self._render_tuple_expr_assign(stmt, env, indent=indent)
             return self._render_multi_result_assign(stmt, env, indent=indent)
         target = stmt.targets[0]
-        if isinstance(target.type, SemanticMetaType):
+        if isinstance(target.type, (SemanticMetaType, SemanticPadValueType)):
             env[target.name] = _RenderedValue(name=target.ssa_name, type=target.type)
             return []
         lines: list[str] = []
@@ -3525,11 +3528,13 @@ class _AuthoringRenderer:
         valid_shape = ty.valid_shape or ty.shape
         v_row = valid_shape[0]
         v_col = 1 if ty.rank == 1 else valid_shape[1]
+        config = ty.config or TileConfig()
         return (
             f"!pto.tile_buf<loc={self._render_tile_buf_loc(ty.memory_space or 'ub')}, "
             f"dtype={ty.element_dtype.name}, rows={rows}, cols={cols}, "
             f"v_row={self._render_tile_buf_dim(v_row)}, v_col={self._render_tile_buf_dim(v_col)}, "
-            "blayout=row_major, slayout=none_box, fractal=512, pad=0>"
+            f"blayout={config.b_layout.value}, slayout={config.s_layout.value}, "
+            f"fractal={config.s_fractal_size}, pad={self._render_tile_buf_pad_value(config.pad_value)}>"
         )
 
     def _render_tile_buf_loc(self, memory_space: str) -> str:
@@ -3541,6 +3546,13 @@ class _AuthoringRenderer:
 
     def _render_tile_buf_dim(self, dim: int | None) -> str:
         return "?" if dim is None else str(dim)
+
+    def _render_tile_buf_pad_value(self, pad_value: PadValue) -> str:
+        if pad_value.is_custom:
+            raise NotImplementedError(
+                "custom TileConfig.pad_value MLIR type rendering requires PTO tile_buf parser support for custom pad encodings"
+            )
+        return str(pad_value.encoded)
 
     def _dtype_byte_width(self, dtype: ScalarType) -> int:
         try:

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4113,7 +4113,10 @@ class _SemanticAnalyzer:
         vector_expr, scalar_expr, mask = args
         vreg = self._require_vreg_expr(vector_expr, f"pto.{name} vector")
         scalar = self._require_scalar_expr(scalar_expr, f"pto.{name} scalar")
-        if scalar.dtype != vreg.element_dtype:
+        if name in {"vshls", "vshrs"}:
+            if scalar.dtype != i16:
+                raise TypeError(f"pto.{name} scalar dtype must be i16")
+        elif scalar.dtype != vreg.element_dtype:
             raise TypeError(f"pto.{name} scalar dtype must match vector element dtype")
         self._require_mask_for_vreg(mask, vreg, f"pto.{name}")
         self._validate_vector_scalar_dtype(name, vreg.element_dtype)

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3419,7 +3419,7 @@ class _SemanticAnalyzer:
         rhs: SemanticExpr,
         op: str,
     ) -> SemanticType:
-        if op in {"add", "sub", "mul", "floordiv"}:
+        if op in {"add", "sub", "mul", "mod", "floordiv"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 return SemanticIndexType()
             raise TypeError("binary expressions currently only support index-typed operands")
@@ -5046,6 +5046,12 @@ class _SemanticAnalyzer:
             if expr.op == "mul":
                 if isinstance(lhs, int) and isinstance(rhs, int):
                     return lhs * rhs
+                return None
+            if expr.op == "mod":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if rhs == 0:
+                        return None
+                    return lhs % rhs
                 return None
             if expr.op == "floordiv":
                 if isinstance(lhs, int) and isinstance(rhs, int):

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -893,16 +893,20 @@ class _SemanticAnalyzer:
         env: dict[str, SemanticBinding],
         *,
         allow_outer_lookup: bool,
+        allow_inferred_vecscope: bool = True,
     ) -> tuple[tuple[SemanticStmt, ...], dict[str, SemanticBinding]]:
         current_env = dict(env)
         semantic_statements = []
         index = 0
         while index < len(statements):
-            if self._should_infer_vecscope(statements[index], allow_outer_lookup=allow_outer_lookup):
+            if self._should_infer_vecscope(
+                statements[index],
+                allow_inferred_vecscope=allow_inferred_vecscope,
+            ):
                 end = index + 1
                 while end < len(statements) and self._should_infer_vecscope(
                     statements[end],
-                    allow_outer_lookup=allow_outer_lookup,
+                    allow_inferred_vecscope=allow_inferred_vecscope,
                 ):
                     end += 1
                 run = statements[index:end]
@@ -982,13 +986,13 @@ class _SemanticAnalyzer:
         self,
         stmt: FrontendStmtNode,
         *,
-        allow_outer_lookup: bool,
+        allow_inferred_vecscope: bool,
     ) -> bool:
         if self._has_explicit_vecscope:
             return False
         if self._disable_inference_depth > 0:
             return False
-        if not allow_outer_lookup:
+        if not allow_inferred_vecscope:
             return False
         if isinstance(stmt, FrontendForStmt):
             return self._block_can_live_in_inferred_vecscope(stmt.body)
@@ -1365,6 +1369,7 @@ class _SemanticAnalyzer:
                 inline_proc_node.body,
                 helper_env,
                 allow_outer_lookup=False,
+                allow_inferred_vecscope=True,
             )
         finally:
             self._inline_proc_active_stack.pop()
@@ -2697,6 +2702,7 @@ class _SemanticAnalyzer:
             stmt.body,
             scope_env,
             allow_outer_lookup=False,
+            allow_inferred_vecscope=False,
         )
         return (
             SemanticStrictVecscopeStmt(

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4038,16 +4038,29 @@ class _SemanticAnalyzer:
             value = args[0]
             if isinstance(value.type, SemanticVRegType):
                 vec_type = value.type
-            else:
-                vec_type = self._vreg_type_for_scalar_or_index(value, "pto.vdup input")
+                mask = args[1]
+                self._require_mask_for_vreg(mask, vec_type, "pto.vdup")
+                position_arg = args[2] if len(args) == 3 else None
+                position = self._normalize_position_mode(position_arg, "pto.vdup position")
+                return SemanticCallExpr(
+                    namespace="pto",
+                    name=name,
+                    args=(value, mask, position),
+                    type=vec_type,
+                )
+
+            if len(args) == 3:
+                raise TypeError(
+                    "pto.vdup scalar input does not accept `position`; use `pto.vdup(input, mask)` "
+                    "in TileLang DSL v1"
+                )
+            vec_type = self._vreg_type_for_scalar_or_index(value, "pto.vdup input")
             mask = args[1]
             self._require_mask_for_vreg(mask, vec_type, "pto.vdup")
-            position_arg = args[2] if len(args) == 3 else None
-            position = self._normalize_position_mode(position_arg, "pto.vdup position")
             return SemanticCallExpr(
                 namespace="pto",
                 name=name,
-                args=(value, mask, position),
+                args=(value, mask),
                 type=vec_type,
             )
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -127,7 +127,10 @@ _MEMORY_SPACE_SYMBOLS = {memory_space.name: memory_space for memory_space in Mem
 _PAD_MODE_SYMBOLS = {pad_mode.name: pad_mode for pad_mode in PadMode}
 _B_LAYOUT_SYMBOLS = {layout.name: layout for layout in BLayout}
 _S_LAYOUT_SYMBOLS = {layout.name: layout for layout in SLayout}
-_PAD_VALUE_SYMBOLS = {pad_value.name: pad_value for pad_value in PadValue}
+_PAD_VALUE_SYMBOLS = {
+    pad_value.name: pad_value
+    for pad_value in (PadValue.NULL, PadValue.ZERO, PadValue.MAX, PadValue.MIN)
+}
 _DEINTERLEAVE_DIST_SYMBOLS = dict(DeinterleaveDist.__members__)
 _INTERLEAVE_DIST_SYMBOLS = dict(InterleaveDist.__members__)
 _POSITION_MODE_SYMBOLS = {position_mode.name: position_mode for position_mode in PositionMode}
@@ -267,7 +270,7 @@ class SemanticTileType(SemanticType):
 
 @dataclass(frozen=True)
 class SemanticTileConfigType(SemanticType):
-    pass
+    element_dtype: ScalarType | None = None
 
 
 @dataclass(frozen=True)
@@ -304,6 +307,11 @@ class SemanticTupleType(SemanticType):
 @dataclass(frozen=True)
 class SemanticMetaType(SemanticType):
     kind: str
+
+
+@dataclass(frozen=True)
+class SemanticPadValueType(SemanticType):
+    element_dtype: ScalarType | None = None
 
 
 @dataclass(frozen=True)
@@ -364,7 +372,7 @@ class SemanticSymbolExpr(SemanticExpr):
     namespace: str
     name: str
     value: Any
-    type: SemanticMetaType
+    type: SemanticType
 
 
 @dataclass(frozen=True)
@@ -2792,6 +2800,10 @@ class _SemanticAnalyzer:
                 return self._attach_expr_source_location(self._rank_expr(base), expr)
             if expr.attr == "memory_space":
                 return self._attach_expr_source_location(self._memory_space_expr(base), expr)
+            if expr.attr == "pad_value" and isinstance(base.type, SemanticTileType):
+                return self._attach_expr_source_location(self._tile_pad_value_expr(base), expr)
+            if expr.attr == "value" and isinstance(base.type, SemanticPadValueType):
+                return self._attach_expr_source_location(self._pad_value_value_expr(base), expr)
             if expr.attr == "config":
                 return self._attach_expr_source_location(self._tile_config_expr(base), expr)
             if expr.attr == "valid_shape":
@@ -3020,7 +3032,7 @@ class _SemanticAnalyzer:
                     namespace=expr.namespace,
                     name=expr.name,
                     value=pad_value,
-                    type=SemanticMetaType(kind="pad_value"),
+                    type=SemanticPadValueType(),
                 )
         if expr.namespace in {"DeinterleaveDist", "pto.DeinterleaveDist"}:
             dist = _DEINTERLEAVE_DIST_SYMBOLS.get(expr.name)
@@ -3151,9 +3163,43 @@ class _SemanticAnalyzer:
         if isinstance(base_type, SemanticTileType):
             return SemanticLiteralExpr(
                 value=base_type.config or TileConfig(),
-                type=SemanticTileConfigType(),
+                type=SemanticTileConfigType(element_dtype=base_type.element_dtype),
             )
         raise TypeError("unsupported attribute access 'config' in TileLang DSL v1")
+
+    def _tile_pad_value_expr(self, base: SemanticExpr) -> SemanticExpr:
+        base_type = base.type
+        if not isinstance(base_type, SemanticTileType):
+            raise TypeError("unsupported attribute access 'pad_value' in TileLang DSL v1")
+        config = base_type.config or TileConfig()
+        return SemanticSymbolExpr(
+            namespace="pto",
+            name=config.pad_value.name,
+            value=config.pad_value,
+            type=SemanticPadValueType(element_dtype=base_type.element_dtype),
+        )
+
+    def _pad_value_value_expr(self, base: SemanticExpr) -> SemanticExpr:
+        if not isinstance(base.type, SemanticPadValueType):
+            raise TypeError("unsupported attribute access 'value' in TileLang DSL v1")
+        if base.type.element_dtype is None:
+            raise TypeError(
+                "PadValue.value requires a Tile-bound or TileConfig-bound pad descriptor with an owning "
+                "Tile element dtype in TileLang DSL v1"
+            )
+        pad_value = self._try_static_value(base)
+        if not isinstance(pad_value, PadValue):
+            raise TypeError("PadValue.value expects a statically known PadValue enum in TileLang DSL v1")
+        pad_scalar = pad_value.materialize_scalar(base.type.element_dtype)
+        if pad_scalar is None:
+            raise TypeError(
+                "PadValue.NULL.value is invalid in TileLang DSL v1; "
+                "guard it with `pto.constexpr(tile.pad_value != pto.PadValue.NULL)` before reading `.value`"
+            )
+        return SemanticLiteralExpr(
+            value=pad_scalar,
+            type=SemanticScalarType(dtype=base.type.element_dtype),
+        )
 
     def _tile_config_attr_expr(self, base: SemanticExpr, attr: str) -> SemanticExpr:
         config = self._try_static_value(base)
@@ -3179,11 +3225,15 @@ class _SemanticAnalyzer:
                 type=SemanticScalarType(dtype=i32),
             )
         if attr == "pad_value":
+            if not isinstance(base.type, SemanticTileConfigType):
+                raise TypeError(
+                    "TileConfig.pad_value expects a TileConfig value in TileLang DSL v1"
+                )
             return SemanticSymbolExpr(
                 namespace="pto",
                 name=config.pad_value.name,
                 value=config.pad_value,
-                type=SemanticMetaType(kind="pad_value"),
+                type=SemanticPadValueType(element_dtype=base.type.element_dtype),
             )
         raise TypeError(f"unsupported TileConfig attribute access '{attr}' in TileLang DSL v1")
 
@@ -3427,6 +3477,8 @@ class _SemanticAnalyzer:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
+                return SemanticScalarType(dtype=i1)
+            if isinstance(lhs.type, SemanticPadValueType) and isinstance(rhs.type, SemanticPadValueType):
                 return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticMetaType) and lhs.type == rhs.type:
                 return SemanticScalarType(dtype=i1)
@@ -5242,6 +5294,7 @@ __all__ = [
     "SemanticLiteralExpr",
     "SemanticMemBarStmt",
     "SemanticMaskType",
+    "SemanticPadValueType",
     "SemanticParameter",
     "SemanticPipeBarrierStmt",
     "SemanticPredicateStoreStmt",

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -2802,8 +2802,6 @@ class _SemanticAnalyzer:
                 return self._attach_expr_source_location(self._memory_space_expr(base), expr)
             if expr.attr == "pad_value" and isinstance(base.type, SemanticTileType):
                 return self._attach_expr_source_location(self._tile_pad_value_expr(base), expr)
-            if expr.attr == "value" and isinstance(base.type, SemanticPadValueType):
-                return self._attach_expr_source_location(self._pad_value_value_expr(base), expr)
             if expr.attr == "config":
                 return self._attach_expr_source_location(self._tile_config_expr(base), expr)
             if expr.attr == "valid_shape":
@@ -2850,6 +2848,33 @@ class _SemanticAnalyzer:
                     for arg in expr.args
                 )
                 return self._analyze_inline_proc_call_expr(expr.name, args)
+            if expr.namespace is None and expr.name == "eval":
+                if expr.keywords:
+                    raise TypeError("method call `eval` does not support keyword arguments in TileLang DSL v1")
+                if not expr.args:
+                    raise TypeError("`eval()` expects a receiver in TileLang DSL v1")
+                base = self._analyze_expr(expr.args[0], env, allow_outer_lookup=allow_outer_lookup)
+                args = tuple(
+                    self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                    for arg in expr.args[1:]
+                )
+                return self._analyze_eval_method(base, args)
+            if expr.namespace not in {None, "pto"} and expr.name == "eval":
+                if expr.keywords:
+                    raise TypeError("method call `eval` does not support keyword arguments in TileLang DSL v1")
+                binding = env.get(expr.namespace)
+                if binding is None:
+                    if allow_outer_lookup:
+                        raise ValueError(f"unknown name '{expr.namespace}'")
+                    raise ValueError(
+                        f"implicit capture of '{expr.namespace}' is not allowed in pto.strict_vecscope"
+                    )
+                base = SemanticBindingRef(binding=binding, type=binding.type)
+                args = tuple(
+                    self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                    for arg in expr.args
+                )
+                return self._analyze_eval_method(base, args)
             if expr.namespace not in {None, "pto"} and expr.name == "as_ptr":
                 if expr.keywords:
                     raise TypeError("method call `as_ptr` does not support keyword arguments in TileLang DSL v1")
@@ -3179,27 +3204,36 @@ class _SemanticAnalyzer:
             type=SemanticPadValueType(element_dtype=base_type.element_dtype),
         )
 
-    def _pad_value_value_expr(self, base: SemanticExpr) -> SemanticExpr:
+    def _pad_value_eval_expr(self, base: SemanticExpr) -> SemanticExpr:
         if not isinstance(base.type, SemanticPadValueType):
-            raise TypeError("unsupported attribute access 'value' in TileLang DSL v1")
+            raise TypeError("`eval()` expects a PadValue descriptor in TileLang DSL v1")
         if base.type.element_dtype is None:
             raise TypeError(
-                "PadValue.value requires a Tile-bound or TileConfig-bound pad descriptor with an owning "
+                "PadValue.eval() requires a Tile-bound or TileConfig-bound pad descriptor with an owning "
                 "Tile element dtype in TileLang DSL v1"
             )
         pad_value = self._try_static_value(base)
         if not isinstance(pad_value, PadValue):
-            raise TypeError("PadValue.value expects a statically known PadValue enum in TileLang DSL v1")
+            raise TypeError("PadValue.eval() expects a statically known PadValue enum in TileLang DSL v1")
         pad_scalar = pad_value.materialize_scalar(base.type.element_dtype)
         if pad_scalar is None:
             raise TypeError(
-                "PadValue.NULL.value is invalid in TileLang DSL v1; "
-                "guard it with `pto.constexpr(tile.pad_value != pto.PadValue.NULL)` before reading `.value`"
+                "PadValue.NULL.eval() is invalid in TileLang DSL v1; "
+                "guard it with `pto.constexpr(tile.pad_value != pto.PadValue.NULL)` before calling `.eval()`"
             )
         return SemanticLiteralExpr(
             value=pad_scalar,
             type=SemanticScalarType(dtype=base.type.element_dtype),
         )
+
+    def _analyze_eval_method(
+        self,
+        base: SemanticExpr,
+        args: tuple[SemanticExpr, ...],
+    ) -> SemanticExpr:
+        if args:
+            raise TypeError("`eval()` does not accept positional arguments in TileLang DSL v1")
+        return self._pad_value_eval_expr(base)
 
     def _tile_config_attr_expr(self, base: SemanticExpr, attr: str) -> SemanticExpr:
         config = self._try_static_value(base)

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import struct
 from typing import Any, Mapping
 
 
@@ -205,11 +206,180 @@ class SLayout(str, Enum):
     COL_MAJOR = "col_major"
 
 
-class PadValue(str, Enum):
-    NULL = "null"
-    ZERO = "zero"
-    MAX = "max"
-    MIN = "min"
+def _float32_from_bits(bits: int) -> float:
+    return struct.unpack(">f", bits.to_bytes(4, byteorder="big", signed=False))[0]
+
+
+_FLOAT_DTYPE_MAX = {
+    "f16": 65504.0,
+    "bf16": _float32_from_bits(0x7F7F0000),
+    "f32": _float32_from_bits(0x7F7FFFFF),
+}
+_FLOAT_DTYPE_MIN = {
+    "f16": -65504.0,
+    "bf16": _float32_from_bits(0xFF7F0000),
+    "f32": _float32_from_bits(0xFF7FFFFF),
+}
+
+
+@dataclass(frozen=True)
+class PadValue:
+    """Tile pad descriptor matching the C++ PadValue design.
+
+    Standard values occupy the low integer range:
+    - NULL = 0
+    - ZERO = 1
+    - MAX = 2
+    - MIN = 3
+
+    Custom values use the C++ `CustomBase` convention and carry an f32 bit
+    pattern authored through `custom_f32(...)`.
+    """
+
+    encoded: int
+    _symbol_name: str | None = None
+    _float32_bits: int | None = None
+
+    CustomBase = 0x100000000
+    _STANDARD_TEXT = {
+        0: "null",
+        1: "zero",
+        2: "max",
+        3: "min",
+    }
+
+    def __post_init__(self) -> None:
+        if isinstance(self.encoded, bool) or not isinstance(self.encoded, int):
+            raise TypeError("PadValue.encoded must be a uint64-compatible integer")
+        if self.encoded < 0 or self.encoded >= (1 << 64):
+            raise ValueError("PadValue.encoded must be in uint64 range")
+        if self._float32_bits is not None and not (0 <= self._float32_bits < (1 << 32)):
+            raise ValueError("PadValue custom float32 payload must be a 32-bit integer")
+
+    @property
+    def name(self) -> str:
+        if self._symbol_name is not None:
+            return self._symbol_name
+        return "CUSTOM"
+
+    @property
+    def value(self) -> int:
+        return self.encoded
+
+    @property
+    def text(self) -> str:
+        standard = self._STANDARD_TEXT.get(self.encoded)
+        if standard is not None:
+            return standard
+        return f"0x{self.encoded:016X}"
+
+    @property
+    def is_custom(self) -> bool:
+        return self._symbol_name is None and self.encoded >= self.CustomBase
+
+    @property
+    def float32_bits(self) -> int:
+        if not self.is_custom:
+            raise ValueError("only custom PadValue instances carry a float32 payload")
+        if self._float32_bits is not None:
+            return self._float32_bits
+        return (self.encoded >> 32) & 0xFFFFFFFF
+
+    def as_float32(self) -> float:
+        return _float32_from_bits(self.float32_bits)
+
+    def materialize_scalar(self, dtype: ScalarType) -> int | float | None:
+        if not isinstance(dtype, ScalarType):
+            raise TypeError("PadValue.materialize_scalar expects a TileLang scalar dtype")
+        if self == PadValue.NULL:
+            return None
+        if self == PadValue.ZERO:
+            return 0.0 if is_float_dtype(dtype) else 0
+        if self == PadValue.MAX:
+            if is_float_dtype(dtype):
+                return _FLOAT_DTYPE_MAX[dtype.name]
+            width = integer_bitwidth(dtype)
+            signedness = integer_signedness(dtype)
+            if width is None or signedness is None:
+                raise TypeError(f"PadValue.MAX does not support dtype `{dtype.name}`")
+            if signedness == "unsigned":
+                return (1 << width) - 1
+            return (1 << (width - 1)) - 1
+        if self == PadValue.MIN:
+            if is_float_dtype(dtype):
+                return _FLOAT_DTYPE_MIN[dtype.name]
+            width = integer_bitwidth(dtype)
+            signedness = integer_signedness(dtype)
+            if width is None or signedness is None:
+                raise TypeError(f"PadValue.MIN does not support dtype `{dtype.name}`")
+            if signedness == "unsigned":
+                return 0
+            return -(1 << (width - 1))
+        if self.is_custom:
+            if not is_float_dtype(dtype):
+                raise TypeError(
+                    "custom Tile pad_value currently only materializes for floating Tile element dtypes"
+                )
+            return self.as_float32()
+        raise TypeError(f"unsupported PadValue payload {self!r}")
+
+    @classmethod
+    def from_uint64(cls, value: int) -> "PadValue":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("PadValue.from_uint64 expects an integer")
+        if value == 0:
+            return cls.NULL
+        if value == 1:
+            return cls.ZERO
+        if value == 2:
+            return cls.MAX
+        if value == 3:
+            return cls.MIN
+        if value < 0 or value >= (1 << 64):
+            raise ValueError("PadValue.from_uint64 expects a uint64-compatible integer")
+        return cls(value)
+
+    @classmethod
+    def custom_f32(cls, value: float | str | int) -> "PadValue":
+        bits = cls._normalize_custom_f32_bits(value)
+        encoded = cls.CustomBase | (bits << 32)
+        return cls(encoded=encoded, _float32_bits=bits)
+
+    @staticmethod
+    def _normalize_custom_f32_bits(value: float | str | int) -> int:
+        if isinstance(value, bool):
+            raise TypeError("PadValue.custom_f32 does not accept bool")
+        if isinstance(value, int):
+            if value < 0 or value >= (1 << 32):
+                raise ValueError("PadValue.custom_f32 integer payload must fit in 32 bits")
+            return value
+        if isinstance(value, str):
+            text = value.strip()
+            if text.lower().startswith("0x"):
+                bits = int(text, 16)
+                if bits < 0 or bits >= (1 << 32):
+                    raise ValueError("PadValue.custom_f32 hex payload must fit in 32 bits")
+                return bits
+            value = float(text)
+        packed = struct.pack(">f", float(value))
+        return int.from_bytes(packed, byteorder="big", signed=False)
+
+    def __repr__(self) -> str:
+        if self == PadValue.NULL:
+            return "PadValue.NULL"
+        if self == PadValue.ZERO:
+            return "PadValue.ZERO"
+        if self == PadValue.MAX:
+            return "PadValue.MAX"
+        if self == PadValue.MIN:
+            return "PadValue.MIN"
+        return f"PadValue.custom_f32(0x{self.float32_bits:08X})"
+
+
+PadValue.NULL = PadValue(0, "NULL")
+PadValue.ZERO = PadValue(1, "ZERO")
+PadValue.MAX = PadValue(2, "MAX")
+PadValue.MIN = PadValue(3, "MIN")
 
 
 class DeinterleaveDist(str, Enum):
@@ -338,7 +508,12 @@ class TileConfig:
     def _normalize_pad_value(value: Any) -> PadValue:
         if isinstance(value, PadValue):
             return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            return PadValue.from_uint64(value)
         if isinstance(value, str):
+            text = value.strip()
+            if text.lower().startswith("0x"):
+                return PadValue.from_uint64(int(text, 16))
             normalized = value.strip().upper().replace("-", "_")
             if normalized == "NULL":
                 return PadValue.NULL

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -264,7 +264,10 @@ class PadValue:
 
     @property
     def value(self) -> int:
-        return self.encoded
+        raise AttributeError(
+            "PadValue.value is not available; use PadValue.encoded for host-side payload access "
+            "or pad.eval() for Tile-bound scalar materialization"
+        )
 
     @property
     def text(self) -> str:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -125,10 +125,10 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.PadMode.PadValue.value, "PadValue")
         self.assertEqual(pto.BLayout.ROW_MAJOR.value, "row_major")
         self.assertEqual(pto.SLayout.NONE_BOX.value, "none_box")
-        self.assertEqual(pto.PadValue.NULL.value, 0)
-        self.assertEqual(pto.PadValue.ZERO.value, 1)
-        self.assertEqual(pto.PadValue.MAX.value, 2)
-        self.assertEqual(pto.PadValue.MIN.value, 3)
+        self.assertEqual(pto.PadValue.NULL.encoded, 0)
+        self.assertEqual(pto.PadValue.ZERO.encoded, 1)
+        self.assertEqual(pto.PadValue.MAX.encoded, 2)
+        self.assertEqual(pto.PadValue.MIN.encoded, 3)
         self.assertEqual(pto.PadValue.NULL.text, "null")
         self.assertEqual(pto.DeinterleaveDist.DINTLV.value, "DINTLV")
         self.assertEqual(pto.DeinterleaveDist.BDINTLV.value, "BDINTLV")
@@ -180,7 +180,7 @@ class TileLangDSLPackageTests(unittest.TestCase):
         custom = pto.PadValue.custom_f32(-1.0)
         self.assertTrue(custom.is_custom)
         self.assertEqual(custom.float32_bits, 0xBF800000)
-        self.assertEqual(custom.value, pto.PadValue.CustomBase | (0xBF800000 << 32))
+        self.assertEqual(custom.encoded, pto.PadValue.CustomBase | (0xBF800000 << 32))
         self.assertAlmostEqual(custom.as_float32(), -1.0)
         self.assertAlmostEqual(custom.materialize_scalar(pto.f32), -1.0)
         self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.ui16), 0xFFFF)
@@ -188,6 +188,8 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.i16), 0x7FFF)
         self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.i16), -0x8000)
         self.assertIsNone(pto.PadValue.NULL.materialize_scalar(pto.f16))
+        with self.assertRaises(AttributeError):
+            _ = pto.PadValue.ZERO.value
 
 
 class TileLangDSLExpandHelperTests(unittest.TestCase):
@@ -200,7 +202,7 @@ def kernel(src: pto.Tile, dst: pto.Tile):
     rows, cols = src.valid_shape
     pad = dst.pad_value
     if pto.constexpr(pad != pto.PadValue.NULL):
-        scalar = pad.value
+        scalar = pad.eval()
     return None
 """
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1804,8 +1806,8 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             fractal = config.s_fractal_size
             pad = config.pad_value
             pad_direct = tile.pad_value
-            pad_scalar = pad.value
-            pad_direct_scalar = pad_direct.value
+            pad_scalar = pad.eval()
+            pad_direct_scalar = pad_direct.eval()
             rank = tile.rank
             space = tile.memory_space
             return None
@@ -1887,10 +1889,10 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertEqual(space_assign.value.value, pto.MemorySpace.UB)
         self.assertEqual(space_assign.value.type.kind, "memory_space")
 
-    def test_pad_value_value_requires_non_null_enum(self) -> None:
-        @pto.vkernel(op="tile_pad_value_null_value", dtypes=[(pto.f16,)])
+    def test_pad_value_eval_requires_non_null_enum(self) -> None:
+        @pto.vkernel(op="tile_pad_value_null_eval", dtypes=[(pto.f16,)])
         def kernel(tile: pto.Tile):
-            scalar = tile.pad_value.value
+            scalar = tile.pad_value.eval()
             return None
 
         specialized = kernel.specialize(
@@ -1903,7 +1905,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         with self.assertRaises(TypeError) as ctx:
             analyze_frontend_kernel(build_frontend_kernel_node(specialized))
 
-        self.assertIn("PadValue.NULL.value is invalid", str(ctx.exception))
+        self.assertIn("PadValue.NULL.eval() is invalid", str(ctx.exception))
 
 
     def test_make_mask_vlds_vsts_and_vector_families_lower_inside_strict_vecscope(self) -> None:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -44,6 +44,7 @@ from tilelang_dsl.semantic import (
     SemanticMemBarStmt,
     SemanticLowLevelCopyStmt,
     SemanticMaskType,
+    SemanticPadValueType,
     SemanticPipeBarrierStmt,
     SemanticPtrType,
     SemanticPredicateStoreStmt,
@@ -123,7 +124,11 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.PadMode.PadValue.value, "PadValue")
         self.assertEqual(pto.BLayout.ROW_MAJOR.value, "row_major")
         self.assertEqual(pto.SLayout.NONE_BOX.value, "none_box")
-        self.assertEqual(pto.PadValue.NULL.value, "null")
+        self.assertEqual(pto.PadValue.NULL.value, 0)
+        self.assertEqual(pto.PadValue.ZERO.value, 1)
+        self.assertEqual(pto.PadValue.MAX.value, 2)
+        self.assertEqual(pto.PadValue.MIN.value, 3)
+        self.assertEqual(pto.PadValue.NULL.text, "null")
         self.assertEqual(pto.DeinterleaveDist.DINTLV.value, "DINTLV")
         self.assertEqual(pto.DeinterleaveDist.BDINTLV.value, "BDINTLV")
         self.assertEqual(pto.InterleaveDist.INTLV.value, "INTLV")
@@ -169,6 +174,19 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(config.s_layout, pto.SLayout.ROW_MAJOR)
         self.assertEqual(config.s_fractal_size, 16)
         self.assertEqual(config.pad_value, pto.PadValue.MAX)
+
+    def test_pad_value_supports_standard_and_custom_payloads(self) -> None:
+        custom = pto.PadValue.custom_f32(-1.0)
+        self.assertTrue(custom.is_custom)
+        self.assertEqual(custom.float32_bits, 0xBF800000)
+        self.assertEqual(custom.value, pto.PadValue.CustomBase | (0xBF800000 << 32))
+        self.assertAlmostEqual(custom.as_float32(), -1.0)
+        self.assertAlmostEqual(custom.materialize_scalar(pto.f32), -1.0)
+        self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.ui16), 0xFFFF)
+        self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.ui16), 0)
+        self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.i16), 0x7FFF)
+        self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.i16), -0x8000)
+        self.assertIsNone(pto.PadValue.NULL.materialize_scalar(pto.f16))
 
 
 class TileLangDSLSupportMatrixTests(unittest.TestCase):
@@ -990,7 +1008,12 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             tile=pto.TileSpecialization(
                 shape=(16, 32),
                 memory_space=pto.MemorySpace.UB,
-                config=pto.TileConfig.from_mapping({"layout": "row_major"}),
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "layout": "row_major",
+                        "pad_value": pto.PadValue.ZERO,
+                    }
+                ),
             )
         )
 
@@ -1000,7 +1023,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("// tilelang.specialize tile shape=(16, 32) memory_space=ub", text)
         self.assertIn('module attributes {pto.target_arch = "a5"} {', text)
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance } {",
+            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>) attributes { pto.tilelang.instance } {",
             text,
         )
         module = specialized.mlir_module()
@@ -1693,6 +1716,9 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             secondary = config.s_layout
             fractal = config.s_fractal_size
             pad = config.pad_value
+            pad_direct = tile.pad_value
+            pad_scalar = pad.value
+            pad_direct_scalar = pad_direct.value
             rank = tile.rank
             space = tile.memory_space
             return None
@@ -1713,8 +1739,19 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         )
 
         semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
-        config_assign, layout_assign, secondary_assign, fractal_assign, pad_assign, rank_assign, space_assign = (
-            semantic_kernel.body[:7]
+        (
+            config_assign,
+            layout_assign,
+            secondary_assign,
+            fractal_assign,
+            pad_assign,
+            pad_direct_assign,
+            pad_scalar_assign,
+            pad_direct_scalar_assign,
+            rank_assign,
+            space_assign,
+        ) = (
+            semantic_kernel.body[:10]
         )
 
         self.assertIsInstance(config_assign, SemanticAssignStmt)
@@ -1738,7 +1775,23 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIsInstance(pad_assign.value, SemanticSymbolExpr)
         self.assertEqual(pad_assign.value.value, pto.PadValue.ZERO)
-        self.assertEqual(pad_assign.value.type.kind, "pad_value")
+        self.assertIsInstance(pad_assign.targets[0].type, SemanticPadValueType)
+        self.assertEqual(pad_assign.targets[0].type.element_dtype, pto.f16)
+
+        self.assertIsInstance(pad_direct_assign.value, SemanticSymbolExpr)
+        self.assertEqual(pad_direct_assign.value.value, pto.PadValue.ZERO)
+        self.assertIsInstance(pad_direct_assign.targets[0].type, SemanticPadValueType)
+        self.assertEqual(pad_direct_assign.targets[0].type.element_dtype, pto.f16)
+
+        self.assertIsInstance(pad_scalar_assign.value, SemanticLiteralExpr)
+        self.assertEqual(pad_scalar_assign.value.value, 0.0)
+        self.assertIsInstance(pad_scalar_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(pad_scalar_assign.targets[0].type.dtype, pto.f16)
+
+        self.assertIsInstance(pad_direct_scalar_assign.value, SemanticLiteralExpr)
+        self.assertEqual(pad_direct_scalar_assign.value.value, 0.0)
+        self.assertIsInstance(pad_direct_scalar_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(pad_direct_scalar_assign.targets[0].type.dtype, pto.f16)
 
         self.assertEqual(rank_assign.value.value, 2)
         self.assertIsInstance(rank_assign.targets[0].type, SemanticIndexType)
@@ -1746,6 +1799,24 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIsInstance(space_assign.value, SemanticSymbolExpr)
         self.assertEqual(space_assign.value.value, pto.MemorySpace.UB)
         self.assertEqual(space_assign.value.type.kind, "memory_space")
+
+    def test_pad_value_value_requires_non_null_enum(self) -> None:
+        @pto.vkernel(op="tile_pad_value_null_value", dtypes=[(pto.f16,)])
+        def kernel(tile: pto.Tile):
+            scalar = tile.pad_value.value
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+            )
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+
+        self.assertIn("PadValue.NULL.value is invalid", str(ctx.exception))
 
 
     def test_make_mask_vlds_vsts_and_vector_families_lower_inside_strict_vecscope(self) -> None:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -5,6 +5,7 @@ from importlib import util
 from pathlib import Path
 
 import tilelang_dsl as pto
+import tilelang_dsl.expand_helper as expand_helper
 import tilelang_dsl.kernel as kernel_impl
 from tilelang_dsl.support_matrix import (
     ADVANCED_EXPLICIT_VECSCOPE_SURFACES,
@@ -187,6 +188,92 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.i16), 0x7FFF)
         self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.i16), -0x8000)
         self.assertIsNone(pto.PadValue.NULL.materialize_scalar(pto.f16))
+
+
+class TileLangDSLExpandHelperTests(unittest.TestCase):
+    def test_operand_specs_preserve_tile_valid_shape_and_pad_value(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(op="pto.expand_helper_tile_config_unique", dtypes=[(pto.f32, pto.f32)])
+def kernel(src: pto.Tile, dst: pto.Tile):
+    rows, cols = src.valid_shape
+    pad = dst.pad_value
+    if pto.constexpr(pad != pto.PadValue.NULL):
+        scalar = pad.value
+    return None
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "expand_helper_tile_config_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+
+            mod = expand_helper._import_py_file(module_path)
+            self.assertIsNotNone(mod)
+            descriptors = expand_helper._find_descriptors(mod)
+            self.assertTrue(descriptors)
+
+            operand_specs = expand_helper._parse_operand_specs(
+                """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [16, 64],
+    "valid_shape": [8, 48],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [16, 64],
+    "valid_shape": [8, 48],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x1"
+    }
+  }
+]
+"""
+            )
+            desc = expand_helper._match_descriptor(
+                descriptors,
+                "pto.expand_helper_tile_config_unique",
+                tuple(spec["dtype"] for spec in operand_specs),
+            )
+            self.assertIsNotNone(desc)
+
+            tile_specs = {}
+            for param, operand_spec in zip(desc.parameters, operand_specs):
+                self.assertEqual(param.kind, "tile")
+                tile_specs[param.name] = pto.TileSpecialization(
+                    shape=operand_spec["shape"],
+                    memory_space=operand_spec["memory_space"],
+                    config=operand_spec["config"],
+                    valid_shape=operand_spec["valid_shape"],
+                )
+
+            mlir_text = desc.specialize(**tile_specs).mlir_text()
+
+        self.assertIn("valid_shape=(8, 48)", mlir_text)
+        self.assertIn(
+            "!pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=8, v_col=48, "
+            "blayout=row_major, slayout=none_box, fractal=512, pad=0>",
+            mlir_text,
+        )
+        self.assertIn(
+            "!pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=8, v_col=48, "
+            "blayout=row_major, slayout=none_box, fractal=512, pad=1>",
+            mlir_text,
+        )
 
 
 class TileLangDSLSupportMatrixTests(unittest.TestCase):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2517,8 +2517,9 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         )
         self.assertRegex(
             text,
-            r'pto\.vdup\s+%[^\s]+,\s+%[^\s]+\s+\{position = "LOWEST"\}\s+:',
+            r'pto\.vdup\s+%[^\s]+,\s+%[^\s]+\s+:',
         )
+        self.assertNotIn('position = "LOWEST"', text)
         self.assertNotIn('position = "POS_LOWEST"', text)
         self.assertRegex(
             text,
@@ -2528,6 +2529,27 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             text,
             r'pto\.vci\s+%[^\s]+,\s*"ORDER_ASC"\s+:',
         )
+
+    def test_vdup_scalar_input_rejects_position_argument(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vdup_scalar_reject_position_unique",
+                dtypes=[(pto.i32, pto.i32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, seed: pto.i32):
+                all_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                out = pto.vdup(seed, all_mask, pto.PositionMode.HIGHEST)
+                pto.vsts(out, dst, 0, all_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("pto.vdup scalar input does not accept `position`", str(ctx.exception))
 
     def test_signed_and_unsigned_integer_dtypes_lower_distinctly(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary\n- fix DSL vdup semantic/lowering behavior for scalar vs vector inputs\n- keep position mode meaningful only for vector-input vdup path\n\nCloses https://github.com/mouliangyu/PTOAS/issues/66