### PR TITLE
Fix vdup scalar/vector semantics in DSL frontend & lowering

### DIFF
--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -893,12 +893,8 @@ rowmax_seed_f32 = pto.vbr(pto.f32("-inf"))
 rowmax_seed_f16 = pto.vbr(pto.f16("0xFC00"))
 ```
 
-**Position Mode Enum**: The `PositionMode` enum provides type-safe source-lane
-selection for `pto.vdup`. `LOWEST` selects the lowest-index element of the
-source vector and `HIGHEST` selects the highest-index element. When the input is
-a scalar, the duplicated scalar value is independent of `position`.
-
-#### `pto.vdup(input: ScalarType | VRegType, mask: MaskType, position: PositionMode = PositionMode.LOWEST) -> VRegType`
+#### `pto.vdup(input: ScalarType, mask: MaskType) -> VRegType`
+#### `pto.vdup(input: VRegType, mask: MaskType, position: PositionMode = PositionMode.LOWEST) -> VRegType`
 
 **Description**: Duplicate a scalar value or one selected vector element into
 the active lanes of a destination vector.
@@ -908,7 +904,12 @@ the active lanes of a destination vector.
 |-----------|------|-------------|
 | `input` | `ScalarType` or `VRegType` | Input scalar or source vector |
 | `mask` | `MaskType` | Predicate mask controlling which lanes are written |
-| `position` | `PositionMode` | Optional enum selecting the source vector element to duplicate (default: `PositionMode.LOWEST`) |
+| `position` | `PositionMode` | Optional enum for the vector-input overload, selecting the source vector element to duplicate (default: `PositionMode.LOWEST`) |
+
+**Position Mode Enum**: The `PositionMode` enum provides type-safe source-lane
+selection for `pto.vdup`. `LOWEST` selects the lowest-index element of the
+source vector and `HIGHEST` selects the highest-index element. The enum is only
+used by the vector-input overload.
 
 **Returns**:
 | Return Value | Type | Description |
@@ -921,6 +922,7 @@ the active lanes of a destination vector.
 - When `input` is a scalar, the scalar value is duplicated to every active lane.
 - When `input` is a vector, `position` selects a single source element and that
   value is duplicated to every active lane.
+- The scalar overload does not accept `position`.
 - Inactive lanes follow VPTO predicate semantics and are not guaranteed to carry
   meaningful values for subsequent masked-off use.
 - Supported scalar types are the 8/16/32-bit integer families (`i*`, `si*`, `ui*`) plus `f16`, `bf16`, and `f32`.
@@ -932,7 +934,7 @@ the active lanes of a destination vector.
 mask32 = pto.make_mask(pto.f32, pto.PAT.ALL)
 
 # Duplicate a scalar into all active lanes.
-broadcast = pto.vdup(3.14, mask32)  # position defaults to "LOWEST"
+broadcast = pto.vdup(3.14, mask32)
 
 # Use dtype constructors for floating-point special values.
 seed = pto.vdup(pto.f32("-inf"), mask32)

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2545,12 +2545,19 @@ class _AuthoringRenderer:
         if expr.name == "vdup":
             value = self._lower_expr(expr.args[0], env, indent=indent, into=into)
             mask = self._lower_expr(expr.args[1], env, indent=indent, into=into)
-            position = self._render_string_literal(expr.args[2])
-            into.append(
-                self._indent(indent)
-                + f"{result_name} = pto.vdup {value.name}, {mask.name} {{position = {position}}} : "
-                + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
-            )
+            if len(expr.args) == 3:
+                position = self._render_string_literal(expr.args[2])
+                into.append(
+                    self._indent(indent)
+                    + f"{result_name} = pto.vdup {value.name}, {mask.name} {{position = {position}}} : "
+                    + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+                )
+            else:
+                into.append(
+                    self._indent(indent)
+                    + f"{result_name} = pto.vdup {value.name}, {mask.name} : "
+                    + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+                )
             return _RenderedValue(name=result_name, type=expr.type)
 
         if expr.name == "vci":

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4032,16 +4032,29 @@ class _SemanticAnalyzer:
             value = args[0]
             if isinstance(value.type, SemanticVRegType):
                 vec_type = value.type
-            else:
-                vec_type = self._vreg_type_for_scalar_or_index(value, "pto.vdup input")
+                mask = args[1]
+                self._require_mask_for_vreg(mask, vec_type, "pto.vdup")
+                position_arg = args[2] if len(args) == 3 else None
+                position = self._normalize_position_mode(position_arg, "pto.vdup position")
+                return SemanticCallExpr(
+                    namespace="pto",
+                    name=name,
+                    args=(value, mask, position),
+                    type=vec_type,
+                )
+
+            if len(args) == 3:
+                raise TypeError(
+                    "pto.vdup scalar input does not accept `position`; use `pto.vdup(input, mask)` "
+                    "in TileLang DSL v1"
+                )
+            vec_type = self._vreg_type_for_scalar_or_index(value, "pto.vdup input")
             mask = args[1]
             self._require_mask_for_vreg(mask, vec_type, "pto.vdup")
-            position_arg = args[2] if len(args) == 3 else None
-            position = self._normalize_position_mode(position_arg, "pto.vdup position")
             return SemanticCallExpr(
                 namespace="pto",
                 name=name,
-                args=(value, mask, position),
+                args=(value, mask),
                 type=vec_type,
             )
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2517,8 +2517,9 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         )
         self.assertRegex(
             text,
-            r'pto\.vdup\s+%[^\s]+,\s+%[^\s]+\s+\{position = "LOWEST"\}\s+:',
+            r'pto\.vdup\s+%[^\s]+,\s+%[^\s]+\s+:',
         )
+        self.assertNotIn('position = "LOWEST"', text)
         self.assertNotIn('position = "POS_LOWEST"', text)
         self.assertRegex(
             text,
@@ -2528,6 +2529,27 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             text,
             r'pto\.vci\s+%[^\s]+,\s*"ORDER_ASC"\s+:',
         )
+
+    def test_vdup_scalar_input_rejects_position_argument(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vdup_scalar_reject_position_unique",
+                dtypes=[(pto.i32, pto.i32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, seed: pto.i32):
+                all_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                out = pto.vdup(seed, all_mask, pto.PositionMode.HIGHEST)
+                pto.vsts(out, dst, 0, all_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("pto.vdup scalar input does not accept `position`", str(ctx.exception))
 
     def test_signed_and_unsigned_integer_dtypes_lower_distinctly(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## What this PR fixes
This PR fixes a vdup semantic mismatch in TileLang DSL:
- position is only meaningful when input is a vector register.
- scalar-input vdup should not carry or require position.

## Changes
- update DSL semantic analysis for vdup overload behavior:
  - scalar overload: vdup(input, mask)
  - vector overload: vdup(input, mask[, position])
- update lowering output so position is emitted only for vector-input vdup.
- align tests/docs with the corrected vdup behavior.

## Base / source
- based on feature-vpto-backend
- includes the vdup fix commit via cherry-pick

Closes https://github.com/mouliangyu/PTOAS/issues/66