### PR TITLE
fix(dsl): extend scalar arithmetic/bitwise support and safe index floordiv lowering

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -622,6 +622,11 @@ _BINARY_OP_NAMES = {
     ast.Mult: "mul",
     ast.Mod: "mod",
     ast.FloorDiv: "floordiv",
+    ast.BitAnd: "bitand",
+    ast.BitOr: "bitor",
+    ast.BitXor: "bitxor",
+    ast.LShift: "lshift",
+    ast.RShift: "rshift",
 }
 _COMPARE_OP_NAMES = {
     ast.Eq: "eq",

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -78,6 +78,7 @@ from .types import (
     get_lanes,
     integer_bitwidth,
     integer_signedness,
+    is_float_dtype,
     is_integer_dtype,
 )
 
@@ -3431,7 +3432,7 @@ class _AuthoringRenderer:
         raise NotImplementedError(f"unsupported constant type {ty!r}")
 
     def _render_binary_op(self, op: str, ty: SemanticType) -> str:
-        if isinstance(ty, (SemanticIndexType, SemanticScalarType)):
+        if isinstance(ty, SemanticIndexType):
             if op == "add":
                 return "arith.addi"
             if op == "sub":
@@ -3441,9 +3442,41 @@ class _AuthoringRenderer:
             if op == "mod":
                 if isinstance(ty, SemanticIndexType):
                     return "arith.remui"
-                return "arith.remsi"
             if op == "floordiv":
-                return "arith.floordivsi"
+                return "arith.divui"
+        if isinstance(ty, SemanticScalarType):
+            dtype = ty.dtype
+            if is_float_dtype(dtype):
+                if op == "add":
+                    return "arith.addf"
+                if op == "sub":
+                    return "arith.subf"
+                if op == "mul":
+                    return "arith.mulf"
+            if is_integer_dtype(dtype):
+                if op == "add":
+                    return "arith.addi"
+                if op == "sub":
+                    return "arith.subi"
+                if op == "mul":
+                    return "arith.muli"
+                if op == "mod":
+                    sign = integer_signedness(dtype)
+                    return "arith.remui" if sign == "unsigned" else "arith.remsi"
+                if op == "floordiv":
+                    sign = integer_signedness(dtype)
+                    return "arith.divui" if sign == "unsigned" else "arith.floordivsi"
+                if op == "bitand":
+                    return "arith.andi"
+                if op == "bitor":
+                    return "arith.ori"
+                if op == "bitxor":
+                    return "arith.xori"
+                if op == "lshift":
+                    return "arith.shli"
+                if op == "rshift":
+                    sign = integer_signedness(dtype)
+                    return "arith.shrui" if sign == "unsigned" else "arith.shrsi"
         raise NotImplementedError(f"unsupported binary op '{op}' for type {ty!r}")
 
     def _render_type(self, ty: SemanticType) -> str:

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -2698,12 +2698,16 @@ class _SemanticAnalyzer:
             block_binding = self._make_binding(name, capture.type, "strict_vecscope_arg")
             scope_env[name] = block_binding
             block_arguments.append(block_binding)
-        body, _ = self._analyze_block(
-            stmt.body,
-            scope_env,
-            allow_outer_lookup=False,
-            allow_inferred_vecscope=False,
-        )
+        self._disable_inference_depth += 1
+        try:
+            body, _ = self._analyze_block(
+                stmt.body,
+                scope_env,
+                allow_outer_lookup=False,
+                allow_inferred_vecscope=False,
+            )
+        finally:
+            self._disable_inference_depth -= 1
         return (
             SemanticStrictVecscopeStmt(
                 captures=captures,
@@ -3509,10 +3513,23 @@ class _SemanticAnalyzer:
         rhs: SemanticExpr,
         op: str,
     ) -> SemanticType:
-        if op in {"add", "sub", "mul", "mod", "floordiv"}:
+        if op in {"add", "sub", "mul", "mod", "floordiv", "bitand", "bitor", "bitxor", "lshift", "rshift"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
-                return SemanticIndexType()
-            raise TypeError("binary expressions currently only support index-typed operands")
+                if op in {"add", "sub", "mul", "mod", "floordiv"}:
+                    return SemanticIndexType()
+            if isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
+                dtype = lhs.type.dtype
+                if op in {"add", "sub", "mul"} and (is_integer_dtype(dtype) or is_float_dtype(dtype)):
+                    return SemanticScalarType(dtype=dtype)
+                if op in {"mod", "floordiv"} and is_integer_dtype(dtype):
+                    return SemanticScalarType(dtype=dtype)
+                if op in {"bitand", "bitor", "bitxor", "lshift", "rshift"} and is_integer_dtype(dtype):
+                    return SemanticScalarType(dtype=dtype)
+            raise TypeError(
+                "binary expressions currently require matching index operands, "
+                "or matching scalar operands (add/sub/mul for integer/float; "
+                "mod/floordiv/bitwise/shift for integer)"
+            )
         if op in {"eq", "ne"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 return SemanticScalarType(dtype=i1)
@@ -5144,15 +5161,30 @@ class _SemanticAnalyzer:
             if lhs is None or rhs is None:
                 return None
             if expr.op == "add":
-                if isinstance(lhs, int) and isinstance(rhs, int):
+                if (
+                    isinstance(lhs, (int, float))
+                    and isinstance(rhs, (int, float))
+                    and not isinstance(lhs, bool)
+                    and not isinstance(rhs, bool)
+                ):
                     return lhs + rhs
                 return None
             if expr.op == "sub":
-                if isinstance(lhs, int) and isinstance(rhs, int):
+                if (
+                    isinstance(lhs, (int, float))
+                    and isinstance(rhs, (int, float))
+                    and not isinstance(lhs, bool)
+                    and not isinstance(rhs, bool)
+                ):
                     return lhs - rhs
                 return None
             if expr.op == "mul":
-                if isinstance(lhs, int) and isinstance(rhs, int):
+                if (
+                    isinstance(lhs, (int, float))
+                    and isinstance(rhs, (int, float))
+                    and not isinstance(lhs, bool)
+                    and not isinstance(rhs, bool)
+                ):
                     return lhs * rhs
                 return None
             if expr.op == "mod":
@@ -5166,6 +5198,36 @@ class _SemanticAnalyzer:
                     if rhs == 0:
                         return None
                     return lhs // rhs
+                return None
+            if expr.op == "bitand":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if isinstance(lhs, bool) or isinstance(rhs, bool):
+                        return None
+                    return lhs & rhs
+                return None
+            if expr.op == "bitor":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if isinstance(lhs, bool) or isinstance(rhs, bool):
+                        return None
+                    return lhs | rhs
+                return None
+            if expr.op == "bitxor":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if isinstance(lhs, bool) or isinstance(rhs, bool):
+                        return None
+                    return lhs ^ rhs
+                return None
+            if expr.op == "lshift":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if isinstance(lhs, bool) or isinstance(rhs, bool) or rhs < 0:
+                        return None
+                    return lhs << rhs
+                return None
+            if expr.op == "rshift":
+                if isinstance(lhs, int) and isinstance(rhs, int):
+                    if isinstance(lhs, bool) or isinstance(rhs, bool) or rhs < 0:
+                        return None
+                    return lhs >> rhs
                 return None
             if expr.op == "eq":
                 return lhs == rhs

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2040,6 +2040,129 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.plt_b32", text)
         self.assertIn("pto.vadd", text)
 
+    def test_scalar_binary_arithmetic_supports_float_and_integer_paths(self) -> None:
+        @pto.vkernel(
+            op="scalar_binary_arithmetic_unique",
+            dtypes=[(pto.f32, pto.f32, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst_tile: pto.Tile, src_tile: pto.Tile, gate: pto.i32):
+            rows = src_tile.shape[0]
+            cols = src_tile.shape[1]
+            with pto.strict_vecscope(
+                src_tile,
+                dst_tile,
+                gate,
+                rows,
+                cols,
+                0,
+                rows,
+                1,
+            ) as (src, dst, in_gate, valid_rows, valid_cols, row_lb, row_ub, row_step):
+                for row in range(row_lb, row_ub, row_step):
+                    for lane in range(0, valid_cols, 64):
+                        half = in_gate // pto.i32(2)
+                        remain = in_gate % pto.i32(7)
+                        factor = pto.f32(half) + pto.f32(remain) * pto.f32(0.5)
+                        mask, _ = pto.make_mask(pto.f32, valid_cols - lane)
+                        vec = pto.vlds(src, lane)
+                        vec = pto.vmuls(vec, factor, mask)
+                        pto.vsts(vec, dst, lane, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst_tile=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src_tile=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r"= arith\.floordivsi %in_gate_\d+, %c2_i32 : i32")
+        self.assertRegex(text, r"= arith\.remsi %in_gate_\d+, %c7_i32 : i32")
+        self.assertRegex(text, r"= arith\.mulf %tmp_\d+, %c0\.5_f32 : f32")
+        self.assertRegex(text, r"= arith\.addf %tmp_\d+, %tmp_\d+ : f32")
+
+    def test_index_floordiv_lowers_to_divui_instead_of_floordivsi(self) -> None:
+        @pto.vkernel(
+            op="index_floordiv_lowering_unique",
+            dtypes=[(pto.f32, pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(
+            lhs_tile: pto.Tile,
+            rhs_tile: pto.Tile,
+            dst_tile: pto.Tile,
+        ):
+            rows = lhs_tile.shape[0]
+            cols = lhs_tile.shape[1]
+            with pto.strict_vecscope(
+                lhs_tile,
+                rhs_tile,
+                dst_tile,
+                rows,
+                cols,
+                0,
+                rows,
+                1,
+            ) as (lhs, rhs, dst, valid_rows, valid_cols, row_lb, row_ub, row_step):
+                for row in range(row_lb, row_ub, row_step):
+                    for lane in range(0, valid_cols, 64):
+                        row_bucket = row // valid_cols
+                        offset = row_bucket * valid_cols + lane
+                        mask, _ = pto.make_mask(pto.f32, valid_cols - lane)
+                        summed = pto.vadd(pto.vlds(lhs, offset), pto.vlds(rhs, offset), mask)
+                        pto.vsts(summed, dst, offset, mask)
+            return None
+
+        specialized = kernel.specialize(
+            lhs_tile=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            rhs_tile=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            dst_tile=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r"= arith\.divui %row_\d+, %valid_cols_\d+ : index")
+        self.assertNotRegex(text, r"arith\.floordivsi .*: index")
+
+    def test_scalar_bitwise_and_shift_ops_lower_for_signed_and_unsigned(self) -> None:
+        @pto.vkernel(
+            op="scalar_bitwise_shift_unique",
+            dtypes=[(pto.i32, pto.ui32)],
+            advanced=True,
+        )
+        def kernel(signed_val: pto.i32, unsigned_val: pto.ui32):
+            signed_mix = (signed_val & pto.i32(15)) | pto.i32(1)
+            signed_mix = signed_mix ^ pto.i32(2)
+            signed_mix = signed_mix >> pto.i32(1)
+            signed_mix = signed_mix << pto.i32(3)
+
+            unsigned_mix = unsigned_val & pto.ui32(31)
+            unsigned_mix = unsigned_mix >> pto.ui32(2)
+            unsigned_mix = unsigned_mix << pto.ui32(1)
+            unsigned_mix = unsigned_mix ^ pto.ui32(7)
+            return None
+
+        specialized = kernel.specialize()
+        text = specialized.mlir_text()
+
+        self.assertIn("arith.andi", text)
+        self.assertIn("arith.ori", text)
+        self.assertIn("arith.xori", text)
+        self.assertRegex(text, r"= arith\.shrsi %\w+_\d+, %c1_i32 : i32")
+        self.assertRegex(text, r"= arith\.shli %\w+_\d+, %c3_i32 : i32")
+        self.assertRegex(text, r"= arith\.shrui %\w+_\d+, %c2_ui32 : ui32")
+        self.assertRegex(text, r"= arith\.shli %\w+_\d+, %c1_ui32 : ui32")
+
+    def test_scalar_bitwise_rejects_float_operands(self) -> None:
+        @pto.vkernel(op="scalar_bitwise_float_reject_unique", dtypes=[(pto.f32,)])
+        def kernel(value: pto.f32):
+            _ = value & pto.f32(1.0)
+            return None
+
+        specialized = kernel.specialize()
+        with self.assertRaises(TypeError) as ctx:
+            specialized.mlir_text()
+        self.assertIn("mod/floordiv/bitwise/shift for integer", str(ctx.exception))
+
     def test_stable_mode_infers_vecscope_and_lowers_tile_vector_sugar(self) -> None:
         @pto.vkernel(op="tadd_stable", dtypes=[(pto.f32, pto.f32, pto.f32)])
         def kernel(dst: pto.Tile, src0: pto.Tile, src1: pto.Tile):
@@ -2374,10 +2497,10 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
     def test_extended_integer_vector_ops_surface_lowers(self) -> None:
         @pto.vkernel(
             op="extended_integer_vector_ops_unique",
-            dtypes=[(pto.i32, pto.i32, pto.i32)],
+            dtypes=[(pto.i32, pto.i32, pto.i16)],
             advanced=True,
         )
-        def kernel(dst: pto.Tile, src: pto.Tile, shift: pto.i32):
+        def kernel(dst: pto.Tile, src: pto.Tile, shift: pto.i16):
             all_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
             vec0 = pto.vlds(src, 0)
             vec1 = pto.vlds(src, 64)


### PR DESCRIPTION
## Summary
- extend TileLang DSL binary operator parsing to include scalar bitwise/shift ops (`& | ^ << >>`)
- extend semantic typing and constexpr folding for scalar arithmetic + bitwise/shift paths
- update lowering op selection to be dtype-aware for scalar arithmetic/bitwise, and lower index `floordiv` via `arith.divui`
- add regression tests for scalar arithmetic, bitwise/shift lowering, and index floordiv lowering

## Repro / Motivation
Issue #71 reports VPTO LLVM emission failures around `builtin.unrealized_conversion_cast` when templates use index scalar arithmetic in pad paths.

## Validation
- `cd tilelang-dsl && PYTHONPATH=python python3 -m unittest discover -s tests -p 'test_*.py'`
- result: `Ran 161 tests ... OK`
- `ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --vpto-emit-hivm-llvm test/dsl/expand_tile_op_tilelang_tfillpad.pto`
- result: `EXIT:0`

Closes #71