### PR TITLE
fix(dsl): align vbitsort and vmrgsort4 with vpto

### DIFF
--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1395,38 +1395,50 @@ vec_f16_narrow = pto.vcvt(
 )
 ```
 
-#### `pto.vbitsort(vec: VRegType, mask: MaskType) -> VRegType`
+#### `pto.vbitsort(dest: ptr, src: ptr, indices: ptr, repeat_times: index) -> None`  [Advanced Tier]
 
-**Description**: Bitonic sort of vector elements.
-
-**Parameters**:
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `vec` | `VRegType` | Input vector |
-| `mask` | `MaskType` | Predicate mask |
-
-**Returns**:
-| Return Value | Type | Description |
-|--------------|------|-------------|
-| `result` | `VRegType` | Sorted vector |
-
-#### `pto.vmrgsort4(vec1: VRegType, vec2: VRegType, vec3: VRegType, vec4: VRegType, mask: MaskType) -> VRegType`
-
-**Description**: 4-way merge sort of vectors.
+**Description**: Sort 32 region proposals by score and materialize sorted proposal
+records into UB memory. This is a UB helper and not a `vreg -> vreg` operation.
 
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `vec1` | `VRegType` | First input vector |
-| `vec2` | `VRegType` | Second input vector |
-| `vec3` | `VRegType` | Third input vector |
-| `vec4` | `VRegType` | Fourth input vector |
-| `mask` | `MaskType` | Predicate mask |
+| `dest` | `ptr` | Destination pointer in UB memory space |
+| `src` | `ptr` | Source score pointer in UB memory space |
+| `indices` | `ptr` | Source index pointer in UB memory space |
+| `repeat_times` | `index` | Repeat count; each repeat processes the next adjacent group of 32 scores and 32 indices |
 
 **Returns**:
-| Return Value | Type | Description |
-|--------------|------|-------------|
-| `result` | `VRegType` | Merged and sorted vector |
+None. The op writes UB memory directly.
+
+**Constraints**:
+- `dest`, `src`, and `indices` must be UB-backed pointers
+- Scores are sorted in descending order
+- Equal-score ties preserve the earlier input proposal first
+- Output records occupy 8 bytes each: upper 4 bytes for the index and lower 4 bytes for the score
+
+#### `pto.vmrgsort4(dest: ptr, src0: ptr, src1: ptr, src2: ptr, src3: ptr, count: pto.i64, config: pto.i64) -> None`  [Advanced Tier]
+
+**Description**: Merge-sort 4 pre-sorted UB inputs. This op writes UB memory
+directly and does not return a vector SSA value.
+
+**Parameters**:
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `dest` | `ptr` | Destination pointer in UB memory space |
+| `src0` | `ptr` | First pre-sorted input pointer in UB memory space |
+| `src1` | `ptr` | Second pre-sorted input pointer in UB memory space |
+| `src2` | `ptr` | Third pre-sorted input pointer in UB memory space |
+| `src3` | `ptr` | Fourth pre-sorted input pointer in UB memory space |
+| `count` | `pto.i64` | Number of valid input elements participating in the merge |
+| `config` | `pto.i64` | Operation control word encoding sort behavior |
+
+**Returns**:
+None. The op writes UB memory directly.
+
+**Constraints**:
+- `dest` and `src0` through `src3` must be UB-backed pointers
+- Inputs must already be sorted according to the order encoded by `config`
 
 **Order Mode Enum**: The `OrderMode` enum provides type-safe order selection for `pto.vci` operations. Currently only `ASC` (ascending order) is supported, with more order options planned for future releases.
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2741,19 +2741,37 @@ class _AuthoringRenderer:
             )
             return _RenderedValue(name=result_name, type=expr.type)
 
-        if expr.name == "vmrgsort4":
-            vec0 = self._lower_expr(expr.args[0], env, indent=indent, into=into)
-            vec1 = self._lower_expr(expr.args[1], env, indent=indent, into=into)
-            vec2 = self._lower_expr(expr.args[2], env, indent=indent, into=into)
-            vec3 = self._lower_expr(expr.args[3], env, indent=indent, into=into)
-            mask = self._lower_expr(expr.args[4], env, indent=indent, into=into)
+        if expr.name == "vbitsort":
+            destination = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            source = self._lower_expr(expr.args[1], env, indent=indent, into=into)
+            indices = self._lower_expr(expr.args[2], env, indent=indent, into=into)
+            repeat_times = self._lower_expr(expr.args[3], env, indent=indent, into=into)
             into.append(
                 self._indent(indent)
-                + f"{result_name} = pto.vmrgsort4 {vec0.name}, {vec1.name}, {vec2.name}, {vec3.name}, {mask.name} : "
-                + f"{self._render_type(vec0.type)}, {self._render_type(vec1.type)}, {self._render_type(vec2.type)}, "
-                + f"{self._render_type(vec3.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+                + f"pto.vbitsort {destination.name}, {source.name}, {indices.name}, {repeat_times.name} : "
+                + f"{self._render_type(destination.type)}, {self._render_type(source.type)}, "
+                + f"{self._render_type(indices.type)}, {self._render_type(repeat_times.type)}"
             )
-            return _RenderedValue(name=result_name, type=expr.type)
+            return _RenderedValue(name="__void_call__", type=SemanticMetaType(kind="void"))
+
+        if expr.name == "vmrgsort4":
+            destination = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            source0 = self._lower_expr(expr.args[1], env, indent=indent, into=into)
+            source1 = self._lower_expr(expr.args[2], env, indent=indent, into=into)
+            source2 = self._lower_expr(expr.args[3], env, indent=indent, into=into)
+            source3 = self._lower_expr(expr.args[4], env, indent=indent, into=into)
+            count = self._lower_expr(expr.args[5], env, indent=indent, into=into)
+            config = self._lower_expr(expr.args[6], env, indent=indent, into=into)
+            count = self._coerce_rendered_value(count, _I64_TYPE, indent=indent, into=into)
+            config = self._coerce_rendered_value(config, _I64_TYPE, indent=indent, into=into)
+            into.append(
+                self._indent(indent)
+                + f"pto.vmrgsort4 {destination.name}, {source0.name}, {source1.name}, {source2.name}, {source3.name}, "
+                + f"{count.name}, {config.name} : {self._render_type(destination.type)}, {self._render_type(source0.type)}, "
+                + f"{self._render_type(source1.type)}, {self._render_type(source2.type)}, {self._render_type(source3.type)}, "
+                + f"{self._render_type(count.type)}, {self._render_type(config.type)}"
+            )
+            return _RenderedValue(name="__void_call__", type=SemanticMetaType(kind="void"))
 
         if expr.name in {
             "vabs",
@@ -2777,7 +2795,6 @@ class _AuthoringRenderer:
             "vsqz",
             "vexpdiff",
             "vtrc",
-            "vbitsort",
             "vcgadd",
             "vcgmax",
             "vcgmin",

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -161,7 +161,6 @@ _UNARY_VECTOR_OPS = {
     "vsqz",
     "vexpdiff",
     "vtrc",
-    "vbitsort",
     "vcgadd",
     "vcgmax",
     "vcgmin",
@@ -229,7 +228,7 @@ _ADVANCED_VECTOR_ACTIVITY_OPS = (
     | _PREDICATE_MOVEMENT_OPS
     | _CARRY_OPS
     | _REARRANGEMENT_OPS
-    | {"vcvt", "vmrgsort4"}
+    | {"vcvt", "vbitsort", "vmrgsort4"}
 )
 _TENSORVIEW_RANK = 5
 
@@ -3633,6 +3632,8 @@ class _SemanticAnalyzer:
             return self._analyze_rearrangement_op(name, args)
         if name == "vcvt":
             return self._analyze_vcvt(args)
+        if name == "vbitsort":
+            return self._analyze_vbitsort(args)
         if name == "vmrgsort4":
             return self._analyze_vmrgsort4(args)
         if name in _BROADCAST_VECTOR_OPS:
@@ -4423,17 +4424,36 @@ class _SemanticAnalyzer:
             type=self._vreg_type_for_dtype(target_dtype),
         )
 
+    def _analyze_vbitsort(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
+        if len(args) != 4:
+            raise TypeError("pto.vbitsort expects exactly 4 positional arguments in TileLang DSL v1")
+        destination = self._require_pointer_expr(args[0], "pto.vbitsort destination", memory_space="ub")
+        source = self._require_pointer_expr(args[1], "pto.vbitsort source", memory_space="ub")
+        indices = self._require_pointer_expr(args[2], "pto.vbitsort indices", memory_space="ub")
+        self._require_index_typed_expr(args[3])
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vbitsort",
+            args=(destination, source, indices, args[3]),
+            type=None,
+        )
+
     def _analyze_vmrgsort4(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
-        if len(args) != 5:
-            raise TypeError("pto.vmrgsort4 expects exactly 5 positional arguments in TileLang DSL")
-        vec0 = self._require_vreg_expr(args[0], "pto.vmrgsort4 vec0")
-        vec1 = self._require_vreg_expr(args[1], "pto.vmrgsort4 vec1")
-        vec2 = self._require_vreg_expr(args[2], "pto.vmrgsort4 vec2")
-        vec3 = self._require_vreg_expr(args[3], "pto.vmrgsort4 vec3")
-        if not (vec0 == vec1 == vec2 == vec3):
-            raise TypeError("pto.vmrgsort4 requires all vector operands to use the same vector type")
-        self._require_mask_for_vreg(args[4], vec0, "pto.vmrgsort4")
-        return SemanticCallExpr(namespace="pto", name="vmrgsort4", args=args, type=vec0)
+        if len(args) != 7:
+            raise TypeError("pto.vmrgsort4 expects exactly 7 positional arguments in TileLang DSL v1")
+        destination = self._require_pointer_expr(args[0], "pto.vmrgsort4 destination", memory_space="ub")
+        source0 = self._require_pointer_expr(args[1], "pto.vmrgsort4 src0", memory_space="ub")
+        source1 = self._require_pointer_expr(args[2], "pto.vmrgsort4 src1", memory_space="ub")
+        source2 = self._require_pointer_expr(args[3], "pto.vmrgsort4 src2", memory_space="ub")
+        source3 = self._require_pointer_expr(args[4], "pto.vmrgsort4 src3", memory_space="ub")
+        self._require_i64_like_expr(args[5], "pto.vmrgsort4 count")
+        self._require_i64_like_expr(args[6], "pto.vmrgsort4 config")
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vmrgsort4",
+            args=(destination, source0, source1, source2, source3, args[5], args[6]),
+            type=None,
+        )
 
     def _require_dtype_symbol(self, expr: SemanticExpr, context: str) -> ScalarType:
         if not (
@@ -4912,7 +4932,7 @@ class _SemanticAnalyzer:
             is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32}
         ):
             raise TypeError(f"pto.{name} only supports integer vector dtypes in TileLang DSL v1")
-        if name in {"vabs", "vneg", "vmov", "vtrc", "vbitsort", "vcadd", "vcmax", "vcmin"} and not (
+        if name in {"vabs", "vneg", "vmov", "vtrc", "vcadd", "vcmax", "vcmin"} and not (
             (is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32}) or dtype.name in {"f16", "bf16", "f32"}
         ):
             raise TypeError(f"pto.{name} does not support this dtype in TileLang DSL v1")

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -96,7 +96,6 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
         "vsqz",
         "vexpdiff",
         "vtrc",
-        "vbitsort",
         "vbr",
         "vdup",
         "vadd",
@@ -141,7 +140,6 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
         "vsort32",
         "vmrgsort",
         "vcvt",
-        "vmrgsort4",
         "vci",
     }
 )
@@ -165,6 +163,8 @@ ADVANCED_VECSCOPE_PTO_CALLS = frozenset(
         "vdintlv",
         "vintlvv2",
         "vdintlvv2",
+        "vbitsort",
+        "vmrgsort4",
     }
 )
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -323,6 +323,8 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertEqual(get_feature_tier("pto.vsort32"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vldsx2"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vstsx2"), BASIC_TIER)
+        self.assertEqual(get_feature_tier("pto.vbitsort"), ADVANCED_TIER)
+        self.assertEqual(get_feature_tier("pto.vmrgsort4"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("PadMode"), BASIC_TIER)
         self.assertEqual(get_feature_tier("VRegType"), BASIC_TIER)
         self.assertEqual(get_feature_tier("MaskType"), BASIC_TIER)
@@ -2401,11 +2403,9 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             out = pto.vcmin(out, all_mask)
             out = pto.vmov(out, all_mask)
             out = pto.vtrc(out, all_mask)
-            out = pto.vbitsort(out, all_mask)
             out = pto.vprelu(out, vec1, all_mask)
             out = pto.vlrelu(out, alpha, all_mask)
             out = pto.vcvt(out, pto.f32, all_mask)
-            out = pto.vmrgsort4(out, vec1, vec2, vec3, all_mask)
             pto.vsts(out, dst, 0, all_mask)
             return None
 
@@ -2425,11 +2425,9 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.vcmin", text)
         self.assertIn("pto.vmov", text)
         self.assertIn("pto.vtrc", text)
-        self.assertIn("pto.vbitsort", text)
         self.assertIn("pto.vprelu", text)
         self.assertIn("pto.vlrelu", text)
         self.assertIn("pto.vcvt", text)
-        self.assertIn("pto.vmrgsort4", text)
 
     def test_vcvt_supports_keyword_attrs_with_enums(self) -> None:
         @pto.vkernel(
@@ -2462,6 +2460,46 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn('rnd = "R"', text)
         self.assertIn('sat = "SAT"', text)
         self.assertIn('part = "ODD"', text)
+
+    def test_advanced_sort_memory_ops_surface_lower(self) -> None:
+        @pto.vkernel(
+            op="advanced_sort_memory_ops_unique",
+            dtypes=[(pto.f32, pto.f32, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile, idx: pto.Tile):
+            dst_ptr = dst.as_ptr()
+            src_ptr = src.as_ptr()
+            idx_ptr = idx.as_ptr()
+
+            pto.vbitsort(dst_ptr, src_ptr, idx_ptr, 1)
+            pto.vmrgsort4(
+                dst_ptr,
+                src_ptr,
+                pto.addptr(src_ptr, 64),
+                pto.addptr(src_ptr, 128),
+                pto.addptr(src_ptr, 192),
+                pto.i64(64),
+                pto.i64(0),
+            )
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 256), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 256), memory_space=pto.MemorySpace.UB),
+            idx=pto.TileSpecialization(shape=(8, 256), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(
+            text,
+            r"pto\.vbitsort %dst_ptr_\d+, %src_ptr_\d+, %idx_ptr_\d+, %c1 : !pto\.ptr<f32, ub>, !pto\.ptr<f32, ub>, !pto\.ptr<i32, ub>, index",
+        )
+        self.assertRegex(
+            text,
+            r"pto\.vmrgsort4 %dst_ptr_\d+, %src_ptr_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %c\d+_i64, %c\d+_i64 : "
+            r"!pto\.ptr<f32, ub>, !pto\.ptr<f32, ub>, !pto\.ptr<f32, ub>, !pto\.ptr<f32, ub>, !pto\.ptr<f32, ub>, i64, i64",
+        )
 
     def test_vcvt_rejects_legacy_string_spellings(self) -> None:
         with self.assertRaises(TypeError) as ctx:


### PR DESCRIPTION
## Summary
- align TileLang DSL docs for `pto.vbitsort` and `pto.vmrgsort4` with the VPTO pointer-based memory-op semantics
- update semantic analysis and authoring lowering so `vbitsort`/`vmrgsort4` lower as UB pointer ops with no SSA result
- move these two surfaces to advanced tier and add regression coverage for the issue #67 repro shape

## Repro
- issue: #67
- repro cmd: `PYTHONPATH=tilelang-dsl/python python3 lib/TileOps/render_template_mlir.py <issue67_repro.py>`

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest discover -s tilelang-dsl/tests -p 'test_tilelang_dsl_v1.py' -k advanced_sort_memory_ops_surface_lower`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest discover -s tilelang-dsl/tests -p 'test_tilelang_dsl_v1.py' -k stable_starter_surface_groups_map_to_stable_tier`
- `PYTHONPATH=tilelang-dsl/python python3 lib/TileOps/render_template_mlir.py <issue67_repro.py>`

Closes #67
