### PR TITLE
[PTOAS] wire MLIR IR printing through ptoas pipelines

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -70,8 +70,7 @@ std::unique_ptr<Pass> createPTOValidateVPTOIRPass();
 std::unique_ptr<Pass> createPTOValidateVPTOEmissionIRPass();
 std::unique_ptr<Pass> createLowerPTOToVPTOPass();
 std::unique_ptr<Pass> createLowerPTOToVPTOPass(StringRef loweringStrategy);
-// Declare register function
-void registerPTOPasses();
+void registerPTOViewToMemrefPass();
 
 std::unique_ptr<Pass> createMemrefToTileBufPass();
 std::unique_ptr<Pass> createExpandTileOpPass();

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -336,6 +336,12 @@ struct InferPTOLayoutPass
     : public PassWrapper<InferPTOLayoutPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InferPTOLayoutPass)
 
+  StringRef getArgument() const final { return "pto-infer-layout"; }
+
+  StringRef getDescription() const final {
+    return "Infer GlobalTensor layout (ND/DN/NZ) for make_tensor_view";
+  }
+
   void runOnOperation() override {
     func::FuncOp func = getOperation();
     auto setLayout = [&](Operation *op, Layout layout, bool inferred) {

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -27,6 +27,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
@@ -3139,6 +3140,10 @@ struct PTOViewToMemrefPass
 
 std::unique_ptr<Pass> createPTOViewToMemrefPass() {
   return std::make_unique<PTOViewToMemrefPass>();
+}
+
+void registerPTOViewToMemrefPass() {
+  PassRegistration<PTOViewToMemrefPass>();
 }
 
 } // namespace pto

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -4873,6 +4873,11 @@ static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
   pm.addPass(createConvertFuncToLLVMPass());
   pm.addPass(createConvertControlFlowToLLVMPass());
   pm.addPass(createReconcileUnrealizedCastsPass());
+  if (failed(mlir::applyPassManagerCLOptions(pm))) {
+    diagOS << "VPTO LLVM emission failed: unable to apply MLIR pass manager "
+              "command-line options\n";
+    return failure();
+  }
   if (failed(pm.run(clonedModule))) {
     diagOS << "VPTO LLVM emission failed: official lowering pipeline failed\n";
     return failure();

--- a/test/basic/mlir_print_ir_debug.pto
+++ b/test/basic/mlir_print_ir_debug.pto
@@ -1,0 +1,30 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-resolve-reserved-buffers %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=MAIN
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-ptr-normalize %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=VPTO
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: i32) attributes { pto.tilelang.instance } {
+    %0 = func.call @__tl_inline_add1_i32(%arg0) : (i32) -> i32
+    func.call @__tl_inline_sink_i32(%0) : (i32) -> ()
+    return
+  }
+
+  func.func private @__tl_inline_add1_i32(%x: i32) -> i32 attributes { pto.tilelang.inline_proc } {
+    %c1 = arith.constant 1 : i32
+    %v = arith.addi %x, %c1 : i32
+    return %v : i32
+  }
+
+  func.func private @__tl_inline_sink_i32(%x: i32) attributes { pto.tilelang.inline_proc } {
+    %c2 = arith.constant 2 : i32
+    %t = arith.addi %x, %c2 : i32
+    return
+  }
+}
+
+// MAIN: // -----// IR Dump After
+// MAIN-SAME: (pto-resolve-reserved-buffers)
+// MAIN: func.func @kernel
+
+// VPTO: // -----// IR Dump After
+// VPTO-SAME: (vpto-ptr-normalize)
+// VPTO: func.func @kernel

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -59,6 +59,16 @@ static void printPTOASVersion(llvm::raw_ostream &os) {
   os << "ptoas " << PTOAS_RELEASE_VERSION << "\n";
 }
 
+static LogicalResult applyConfiguredPassManagerCLOptions(
+    PassManager &pm, llvm::StringRef pipelineName,
+    llvm::raw_ostream &diagOS = llvm::errs()) {
+  if (succeeded(mlir::applyPassManagerCLOptions(pm)))
+    return success();
+  diagOS << "Error: failed to apply MLIR pass manager command-line options for "
+         << pipelineName << ".\n";
+  return failure();
+}
+
 static LogicalResult reorderEmitCFunctions(ModuleOp module) {
   SmallVector<emitc::FuncOp> declarations;
   SmallVector<emitc::FuncOp> definitions;
@@ -1125,6 +1135,8 @@ static LogicalResult prepareVPTOForEmission(ModuleOp module) {
   cleanupPM.enableVerifier();
   cleanupPM.addPass(createCanonicalizerPass());
   cleanupPM.addPass(createCSEPass());
+  if (failed(applyConfiguredPassManagerCLOptions(cleanupPM, "VPTO cleanup")))
+    return failure();
   if (failed(cleanupPM.run(module))) {
     llvm::errs() << "Error: VPTO pre-emission cleanup failed.\n";
     return failure();
@@ -1135,6 +1147,9 @@ static LogicalResult prepareVPTOForEmission(ModuleOp module) {
   boundaryPM.addPass(pto::createVPTOPtrNormalizePass());
   boundaryPM.addPass(pto::createVPTOPtrCastCleanupPass());
   boundaryPM.addPass(createReconcileUnrealizedCastsPass());
+  if (failed(applyConfiguredPassManagerCLOptions(boundaryPM,
+                                                 "VPTO ptr normalization")))
+    return failure();
   if (failed(boundaryPM.run(module))) {
     llvm::errs() << "Error: VPTO ptr normalization failed.\n";
     return failure();
@@ -1145,6 +1160,9 @@ static LogicalResult prepareVPTOForEmission(ModuleOp module) {
   prepPM.addNestedPass<func::FuncOp>(createPTOVPTOExpandBridgeOpsPass());
   prepPM.addPass(createCSEPass());
   prepPM.addPass(pto::createPTOValidateVPTOEmissionIRPass());
+  if (failed(applyConfiguredPassManagerCLOptions(prepPM,
+                                                 "VPTO emission preparation")))
+    return failure();
   if (failed(prepPM.run(module))) {
     llvm::errs() << "Error: VPTO emission preparation failed.\n";
     return failure();
@@ -1180,6 +1198,9 @@ static LogicalResult lowerPTOToVPTOBackend(ModuleOp module) {
     backendPM.addPass(mlir::createSCCPPass());
     backendPM.addPass(mlir::createCanonicalizerPass());
   }
+  if (failed(applyConfiguredPassManagerCLOptions(backendPM,
+                                                 "VPTO backend lowering")))
+    return failure();
   if (failed(backendPM.run(module))) {
     llvm::errs() << "Error: backend lowering pass execution failed.\n";
     return failure();
@@ -1257,6 +1278,8 @@ int main(int argc, char **argv) {
   registry.insert<emitc::EmitCDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   mlir::registerAllPasses();
+  ::registerPTOPasses();
+  mlir::pto::registerPTOViewToMemrefPass();
   ::registerPTOInlineLibCall();
   ::registerFoldTileBufIntrinsics();
   ::registerExpandTileOp();
@@ -1513,6 +1536,8 @@ int main(int argc, char **argv) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
 
   pm.addPass(createCSEPass());
+  if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline")))
+    return 1;
 
   module->getOperation()->setAttr("pto.target_arch",
                                   mlir::StringAttr::get(&context, arch));


### PR DESCRIPTION
## Summary
- apply MLIR pass-manager CLI printing options to the main ptoas pipeline and all VPTO sub-pipelines
- register PTO passes needed by `--mlir-print-ir-after=<pass>` so targeted IR dumps work for PTO passes as well
- add a lit test covering targeted IR printing in both the main VPTO path and the LLVM export path

## Testing
- `PTOAS_BUILD_DIR=/home/zhangzhendong/ptoas-workspace/PTOAS/build LLVM_BUILD_DIR=/home/zhangzhendong/ptoas-workspace/llvm-project/build-shared /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/llvm-lit -sv test/basic/mlir_print_ir_debug.pto`

Closes #65
