### PR TITLE
fix(dsl): support module-level literal constants in kernels (#62)

### DIFF
--- a/tilelang-dsl/docs/user_guide/06-control-flow.md
+++ b/tilelang-dsl/docs/user_guide/06-control-flow.md
@@ -106,7 +106,7 @@ Important semantics:
 - Helper calls support positional arguments and keyword arguments.
 - Helper calls can appear in statement and expression positions.
 - Helper definitions can use trailing `return <expr>` to return values.
-- Implicit capture is rejected; pass required values as explicit arguments.
+- Implicit capture is rejected except module-level globals whose current bound value is `bool`/`int`/`float`/`str`; pass other required values as explicit arguments.
 - Recursive/mutually-recursive helper call graphs are rejected.
 - `*args`, `**kwargs`, and keyword-only parameters are unsupported in current version.
 

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -208,6 +208,8 @@ class _FrontendBuildContext:
     selected_op: str | None
     advanced_enabled: bool
     inline_procs: dict[str, _FrontendInlineProc]
+    global_literal_constants: dict[str, Any]
+    local_bindings: frozenset[str]
     active_inline_proc_stack: tuple[str, ...] = ()
     vecscope_depth: int = 0
 
@@ -223,6 +225,8 @@ class _FrontendBuildContext:
             selected_op=self.selected_op,
             advanced_enabled=self.advanced_enabled,
             inline_procs=self.inline_procs,
+            global_literal_constants=self.global_literal_constants,
+            local_bindings=self.local_bindings,
             active_inline_proc_stack=self.active_inline_proc_stack,
             vecscope_depth=self.vecscope_depth + 1,
         )
@@ -234,9 +238,123 @@ class _FrontendBuildContext:
             selected_op=self.selected_op,
             advanced_enabled=self.advanced_enabled,
             inline_procs=self.inline_procs,
+            global_literal_constants=self.global_literal_constants,
+            local_bindings=_collect_source_local_bindings(source_info),
             active_inline_proc_stack=(*self.active_inline_proc_stack, name),
             vecscope_depth=self.vecscope_depth,
         )
+
+
+_UNSUPPORTED_GLOBAL_LITERAL = object()
+_LOCAL_BINDINGS_CACHE: dict[tuple[str, int, str], frozenset[str]] = {}
+_GLOBAL_NAME_READS_CACHE: dict[tuple[str, int, str], frozenset[str]] = {}
+
+
+def _iter_target_names(node: ast.AST) -> tuple[str, ...]:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for elt in node.elts:
+            names.extend(_iter_target_names(elt))
+        return tuple(names)
+    return ()
+
+
+def _collect_source_global_name_reads(
+    source_info: Any,
+    local_bindings: frozenset[str],
+) -> frozenset[str]:
+    if source_info is None:
+        return frozenset()
+    function_def = source_info.function_def
+    cache_key = (
+        source_info.path,
+        source_info.start_line,
+        function_def.name,
+    )
+    cached = _GLOBAL_NAME_READS_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    global_reads: set[str] = set()
+    for node in ast.walk(function_def):
+        if not isinstance(node, ast.Name) or not isinstance(node.ctx, ast.Load):
+            continue
+        if node.id in local_bindings:
+            continue
+        if node.id.startswith("__"):
+            continue
+        global_reads.add(node.id)
+
+    frozen = frozenset(global_reads)
+    _GLOBAL_NAME_READS_CACHE[cache_key] = frozen
+    return frozen
+
+
+def _collect_function_local_bindings(function_def: ast.FunctionDef) -> set[str]:
+    bindings: set[str] = set()
+    for arg in function_def.args.posonlyargs:
+        bindings.add(arg.arg)
+    for arg in function_def.args.args:
+        bindings.add(arg.arg)
+    for arg in function_def.args.kwonlyargs:
+        bindings.add(arg.arg)
+    if function_def.args.vararg is not None:
+        bindings.add(function_def.args.vararg.arg)
+    if function_def.args.kwarg is not None:
+        bindings.add(function_def.args.kwarg.arg)
+
+    for node in ast.walk(function_def):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                bindings.update(_iter_target_names(target))
+            continue
+        if isinstance(node, ast.AnnAssign):
+            bindings.update(_iter_target_names(node.target))
+            continue
+        if isinstance(node, ast.For):
+            bindings.update(_iter_target_names(node.target))
+            continue
+        if isinstance(node, ast.With):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    bindings.update(_iter_target_names(item.optional_vars))
+            continue
+    return bindings
+
+
+def _collect_source_local_bindings(source_info: Any) -> frozenset[str]:
+    if source_info is None:
+        return frozenset()
+    function_def = source_info.function_def
+    cache_key = (
+        source_info.path,
+        source_info.start_line,
+        function_def.name,
+    )
+    cached = _LOCAL_BINDINGS_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    collected = frozenset(_collect_function_local_bindings(function_def))
+    _LOCAL_BINDINGS_CACHE[cache_key] = collected
+    return collected
+
+
+def _collect_module_literal_constants(
+    source_info: Any,
+    *,
+    module_globals: dict[str, Any] | None,
+    local_bindings: frozenset[str],
+) -> dict[str, Any]:
+    if source_info is None or module_globals is None:
+        return {}
+    literal_constants: dict[str, Any] = {}
+    for name in _collect_source_global_name_reads(source_info, local_bindings):
+        value = module_globals.get(name, _UNSUPPORTED_GLOBAL_LITERAL)
+        if isinstance(value, (bool, int, float, str)):
+            literal_constants[name] = value
+    return literal_constants
 
 
 def _attach_source_location(
@@ -774,6 +892,15 @@ def _build_call_keywords(
 
 def _build_expr(node: ast.AST, context: _FrontendBuildContext) -> FrontendExprNode:
     if isinstance(node, ast.Name):
+        if (
+            node.id in context.global_literal_constants
+            and node.id not in context.local_bindings
+        ):
+            return _attach_source_location(
+                FrontendConstantExpr(value=context.global_literal_constants[node.id]),
+                node,
+                context,
+            )
         return _attach_source_location(FrontendNameExpr(name=node.id), node, context)
     if isinstance(node, ast.Constant):
         return _attach_source_location(FrontendConstantExpr(value=node.value), node, context)
@@ -1241,6 +1368,12 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
         for name, spec in descriptor.specializations
     )
     source_info = descriptor._source_info
+    local_bindings = _collect_source_local_bindings(source_info)
+    global_literal_constants = _collect_module_literal_constants(
+        source_info,
+        module_globals=getattr(descriptor._py_fn, "__globals__", None),
+        local_bindings=local_bindings,
+    )
     sorted_inline_procs = tuple(sorted(descriptor.inline_procs.items(), key=lambda item: item[0]))
     context = _FrontendBuildContext(
         source_info=source_info,
@@ -1255,6 +1388,8 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
             )
             for name, proc in sorted_inline_procs
         },
+        global_literal_constants=global_literal_constants,
+        local_bindings=local_bindings,
     )
     body = ()
     if source_info is not None:

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -204,6 +204,7 @@ class _FrontendInlineProc:
 @dataclass(frozen=True)
 class _FrontendBuildContext:
     source_info: Any
+    module_globals: dict[str, Any] | None
     templates: dict[str, dict[str, str]]
     selected_op: str | None
     advanced_enabled: bool
@@ -221,6 +222,7 @@ class _FrontendBuildContext:
     def nested_vecscope(self) -> "_FrontendBuildContext":
         return _FrontendBuildContext(
             source_info=self.source_info,
+            module_globals=self.module_globals,
             templates=self.templates,
             selected_op=self.selected_op,
             advanced_enabled=self.advanced_enabled,
@@ -232,14 +234,21 @@ class _FrontendBuildContext:
         )
 
     def enter_inline_proc(self, name: str, source_info: Any) -> "_FrontendBuildContext":
+        local_bindings = _collect_source_local_bindings(source_info)
+        global_literal_constants = _collect_module_literal_constants(
+            source_info,
+            module_globals=self.module_globals,
+            local_bindings=local_bindings,
+        )
         return _FrontendBuildContext(
             source_info=source_info,
+            module_globals=self.module_globals,
             templates=self.templates,
             selected_op=self.selected_op,
             advanced_enabled=self.advanced_enabled,
             inline_procs=self.inline_procs,
-            global_literal_constants=self.global_literal_constants,
-            local_bindings=_collect_source_local_bindings(source_info),
+            global_literal_constants=global_literal_constants,
+            local_bindings=local_bindings,
             active_inline_proc_stack=(*self.active_inline_proc_stack, name),
             vecscope_depth=self.vecscope_depth,
         )
@@ -500,7 +509,7 @@ def _validate_inline_capture(
     *,
     context: _FrontendBuildContext,
 ) -> None:
-    allowed = param_names | assigned_names
+    allowed = param_names | assigned_names | set(context.global_literal_constants)
     if isinstance(stmt, FrontendAssignStmt):
         missing = _collect_name_reads(stmt.value) - allowed
         if missing:
@@ -1377,6 +1386,7 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
     sorted_inline_procs = tuple(sorted(descriptor.inline_procs.items(), key=lambda item: item[0]))
     context = _FrontendBuildContext(
         source_info=source_info,
+        module_globals=getattr(descriptor._py_fn, "__globals__", None),
         templates=descriptor.templates,
         selected_op=descriptor.selected_op,
         advanced_enabled=descriptor.advanced_enabled,

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -72,6 +72,7 @@ from tilelang_dsl.semantic import (
 )
 
 GLOBAL_TILELANG_LITERAL_BLOCK_SIZE = 32
+INLINE_PROC_GLOBAL_LANE = 0
 
 
 class TileLangDSLPackageTests(unittest.TestCase):
@@ -4417,6 +4418,13 @@ class TileLangDSLInlineProcTests(unittest.TestCase):
         pto.vlds(dst, lane)
         return None
 
+    @pto.inline_proc
+    def _inline_capture_global_literal(dst: pto.Tile):
+        mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+        vec = pto.vlds(dst, INLINE_PROC_GLOBAL_LANE)
+        pto.vsts(vec, dst, INLINE_PROC_GLOBAL_LANE, mask)
+        return None
+
     def test_inline_proc_exports_from_package_surface(self) -> None:
         self.assertTrue(hasattr(pto, "inline_proc"))
         self.assertTrue(hasattr(pto, "InlineProcDescriptor"))
@@ -4527,6 +4535,26 @@ class TileLangDSLInlineProcTests(unittest.TestCase):
 
         self.assertIn("implicit capture of 'lane' is not allowed in inline_proc", str(ctx.exception))
         self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_inline_proc_allows_module_level_literal_capture(self) -> None:
+        @pto.vkernel(op="inline_proc_global_literal_capture_unique", dtypes=[(pto.f32,)])
+        def kernel(dst: pto.Tile):
+            _inline_capture_global_literal(dst)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB)
+        )
+
+        frontend_kernel = build_frontend_kernel_node(specialized)
+        self.assertIn(
+            "_inline_capture_global_literal",
+            {proc.name for proc in frontend_kernel.inline_procs},
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("func.call", text)
+        self.assertIn("arith.constant 0 : index", text)
 
     def test_inline_proc_rejects_kw_only_vararg_and_kwargs(self) -> None:
         with self.assertRaises(pto.TileLangFrontendError) as kw_only_ctx:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -71,6 +71,8 @@ from tilelang_dsl.semantic import (
     analyze_frontend_kernel,
 )
 
+GLOBAL_TILELANG_LITERAL_BLOCK_SIZE = 32
+
 
 class TileLangDSLPackageTests(unittest.TestCase):
     def test_package_exports_surface(self) -> None:
@@ -2987,6 +2989,28 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         text = specialized.mlir_text()
         self.assertIn("= arith.constant 0.0 : f32", text)
         self.assertIn("pto.vbr", text)
+
+    def test_kernel_accepts_module_level_literal_constant_reference(self) -> None:
+        @pto.vkernel(
+            op="module_level_literal_constant_reference_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask, _ = pto.make_mask(pto.f32, GLOBAL_TILELANG_LITERAL_BLOCK_SIZE)
+            vec = pto.vlds(src, 0)
+            out = pto.vadds(vec, pto.f32(0.0), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r"arith\.constant 32 : (index|i64)")
+        self.assertIn("pto.plt_b32", text)
 
     def test_scalar_constructor_call_surfaces_lower(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- support module-level literal constants (`bool/int/float/str`) in TileLang kernel bodies
- resolve global literal names via descriptor function globals while preserving local-binding precedence
- add caching for local/global name analysis to avoid repeated AST traversal overhead
- add regression test for module-level constant reference in kernel lowering

## Repro
- issue: #62
- command: `python3 lib/TileOps/render_template_mlir.py lib/TileOps/issue_62_repro_template.py`

## Validation
- `cd tilelang-dsl && PYTHONPATH=$PWD/python python3 -m unittest tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_kernel_accepts_module_level_literal_constant_reference`
- `cd tilelang-dsl && PYTHONPATH=$PWD/python python3 -m unittest tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vbr_accepts_float_literal_constant`

Closes #62