### PR TITLE
align(tilelang-dsl): support PartitionTensorView slice binding and lowering

### DIFF
--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -155,11 +155,12 @@ This replaces string literals (`MemorySpace.GM`/`MemorySpace.UB`) with compile-t
 
 ### Public Buffer Types
 
-TileLang uses two public buffer-facing type names in kernel signatures:
+TileLang uses three public buffer-facing type names in kernel signatures:
 
 | Public Type | Description |
 |-------------|-------------|
 | `pto.TensorView` | GM-facing tensor view descriptor used for DMA-oriented data access |
+| `pto.PartitionTensorView` | Logical GM partition (slice) descriptor, corresponding to `!pto.partition_tensor_view<...>` |
 | `pto.Tile` | UB-facing tile buffer value used for tiled compute |
 
 ### TensorView Types
@@ -243,7 +244,7 @@ partition_5d = tensor_view[
 ```
 
 Constraints:
-- Slicing returns a new TensorView representing the logical partition.
+- Slicing returns a new `pto.PartitionTensorView` representing the logical partition.
 - The partition must be within the original tensor bounds.
 - When fewer than 5 slice axes are written, they are right-aligned to the trailing physical axes of the 5D descriptor.
 - `stop` must be explicit on all dimensions.
@@ -251,6 +252,40 @@ Constraints:
 - `step` must be a static positive integer.
 - Dimension 0 may use `step > 1`.
 - Dimension 1 must keep `step == 1` in the current DMA-oriented implementation.
+
+### PartitionTensorView Types
+
+`pto.PartitionTensorView` models a logical partition of GM tensor data and maps to
+`!pto.partition_tensor_view<d0xd1x...xelementType>` in PTO IR.
+Like `TensorView`, it is a descriptor type and does not own storage.
+
+#### PartitionTensorView Type Definition
+
+```python
+@pto.vkernel(target="a5", op="custom_partition", dtypes=[(pto.f32, pto.f32)])
+def kernel(inp: pto.TensorView, out: pto.TensorView):
+    part: pto.PartitionTensorView = inp[0:16, 0:16]
+    p_rows, p_cols = part.shape
+    s_row, s_col = part.strides
+    return None
+```
+
+Important notes:
+- A `PartitionTensorView` carries partition `shape` and `strides` metadata in element units.
+- Element dtype is inherited from the source tensor view.
+- Memory space remains GM.
+- Rank handling follows the same right-aligned 5D contract as `TensorView`.
+- `PartitionTensorView` can be used where DMA-oriented TensorView-like descriptors are accepted.
+- Prefer direct indexing or tuple unpacking for `shape`/`strides` metadata values in current DSL v1 lowering.
+
+#### PartitionTensorView Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `shape` | `tuple[int, ...]` | Partition dimensions |
+| `element_type` | `Type` | Element data type inherited from source tensor view |
+| `strides` | `tuple[int, ...]` | Stride in elements for each dimension |
+| `offset` | `pto.i64` | Byte offset from the base tensor pointer (internal) |
 
 ### Tile Types
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -1178,6 +1178,99 @@ class _AuthoringRenderer:
             raise NotImplementedError("TileLang DSL v1 DMA lowering currently only supports rank-2 TensorView slices")
         return expr.type.extents
 
+    def _materialize_tensor_slice_axis_size(
+        self,
+        slice_axis: object,
+        env: dict[str, _RenderedValue],
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        if slice_axis.extent is not None:
+            return _RenderedValue(
+                name=self._materialize_constant(slice_axis.extent, SemanticIndexType()),
+                type=SemanticIndexType(),
+            )
+        distance = self._emit_binary_value(
+            "sub",
+            self._lower_expr(slice_axis.stop, env, indent=indent, into=into),
+            self._lower_expr(slice_axis.start, env, indent=indent, into=into),
+            SemanticIndexType(),
+            indent=indent,
+            into=into,
+        )
+        step_value = self._static_expr_value(slice_axis.step, default=1)
+        if not isinstance(step_value, int) or step_value <= 0:
+            raise NotImplementedError(
+                "partition_view lowering currently expects a static positive slice step in TileLang DSL v1"
+            )
+        if step_value == 1:
+            return distance
+        numerator = self._emit_binary_value(
+            "add",
+            distance,
+            _RenderedValue(
+                name=self._materialize_constant(step_value - 1, SemanticIndexType()),
+                type=SemanticIndexType(),
+            ),
+            SemanticIndexType(),
+            indent=indent,
+            into=into,
+        )
+        return self._emit_binary_value(
+            "floordiv",
+            numerator,
+            _RenderedValue(
+                name=self._materialize_constant(step_value, SemanticIndexType()),
+                type=SemanticIndexType(),
+            ),
+            SemanticIndexType(),
+            indent=indent,
+            into=into,
+        )
+
+    def _lower_tensor_slice_expr(
+        self,
+        expr: SemanticTensorSliceExpr,
+        env: dict[str, _RenderedValue],
+        *,
+        indent: int,
+        desired_name: str | None,
+        into: list[str] | None,
+    ) -> _RenderedValue:
+        if into is None:
+            into = []
+        tensor_base = self._lower_expr(expr.base, env, indent=indent, into=into)
+        if not isinstance(tensor_base.type, (SemanticTensorViewType, SemanticPartitionTensorViewType)):
+            raise NotImplementedError("partition_view lowering expects a TensorView/PartitionTensorView source")
+
+        offsets: list[_RenderedValue] = []
+        sizes: list[_RenderedValue] = []
+        for axis_slice in expr.slices:
+            offsets.append(self._lower_expr(axis_slice.start, env, indent=indent, into=into))
+            sizes.append(
+                self._materialize_tensor_slice_axis_size(
+                    axis_slice,
+                    env,
+                    indent=indent,
+                    into=into,
+                )
+            )
+
+        result_name = desired_name or self._new_temp()
+        result_type_text = self._render_partition_tensor_view_type(
+            element_dtype=expr.type.element_dtype.name,
+            shape=tuple("?" if dim is None else dim for dim in expr.type.extents),
+        )
+        into.append(
+            self._indent(indent)
+            + f"{result_name} = pto.partition_view {tensor_base.name}, "
+            + f"offsets = [{', '.join(value.name for value in offsets)}], "
+            + f"sizes = [{', '.join(value.name for value in sizes)}] : "
+            + f"{self._render_type(tensor_base.type)} -> {result_type_text}"
+        )
+        return _RenderedValue(name=result_name, type=_RenderedTextualType(result_type_text))
+
     def _resolve_dma_load_padding_profile(self, options: object) -> _DmaLoadPaddingProfile:
         pad_mode_name = self._static_pad_mode_name(getattr(options, "pad_mode", None)) or "PadNull"
         left_padding = self._static_expr_value(getattr(options, "left_padding", None), default=0)
@@ -2365,7 +2458,13 @@ class _AuthoringRenderer:
         if isinstance(expr, SemanticAttributeAccess):
             raise NotImplementedError("bare shape attribute values are not materialized directly")
         if isinstance(expr, SemanticTensorSliceExpr):
-            raise NotImplementedError("TensorView slices are only lowered through DMA statements in TileLang DSL v1")
+            return self._lower_tensor_slice_expr(
+                expr,
+                env,
+                indent=indent,
+                desired_name=desired_name,
+                into=into,
+            )
         if isinstance(expr, SemanticSymbolExpr):
             raise NotImplementedError("symbol expressions are only lowered through specialized TileLang DSL ops")
         raise NotImplementedError(f"unsupported semantic expression {type(expr).__name__}")

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -2442,10 +2442,17 @@ class _SemanticAnalyzer:
         if isinstance(target, FrontendNameTarget):
             if isinstance(value.type, SemanticTupleType):
                 raise ValueError("multi-result call assignment requires tuple binding in TileLang DSL v1")
-            annotated_type = self._annotation_type(annotation, value.type, env)
+            inferred_type: SemanticType = value.type
+            if isinstance(value.type, SemanticTensorSliceType):
+                # Tensor slicing materializes a logical partition descriptor value in IR.
+                inferred_type = SemanticPartitionTensorViewType(
+                    element_dtype=value.type.element_dtype,
+                    rank=value.type.rank,
+                )
+            annotated_type = self._annotation_type(annotation, inferred_type, env)
             binding = self._make_binding(
                 target.name,
-                annotated_type if annotated_type is not None else value.type,
+                annotated_type if annotated_type is not None else inferred_type,
                 "ssa",
                 value=self._binding_value_for_expr(value),
             )
@@ -2546,6 +2553,11 @@ class _SemanticAnalyzer:
                     )
                 return inferred_type
             if annotation_expr.type.kind == "align_type" and isinstance(inferred_type, SemanticAlignType):
+                return inferred_type
+            if (
+                annotation_expr.type.kind == "partition_tensor_view_type"
+                and isinstance(inferred_type, SemanticPartitionTensorViewType)
+            ):
                 return inferred_type
         raise TypeError("unsupported annotated assignment type in TileLang DSL v1")
 
@@ -3048,6 +3060,13 @@ class _SemanticAnalyzer:
                     name=expr.name,
                     value=align,
                     type=SemanticMetaType(kind="align_type"),
+                )
+            if expr.name == "PartitionTensorView":
+                return SemanticSymbolExpr(
+                    namespace=expr.namespace,
+                    name=expr.name,
+                    value=expr.name,
+                    type=SemanticMetaType(kind="partition_tensor_view_type"),
                 )
         if expr.namespace in {"PAT", "pto.PAT", "pto.MaskPattern"}:
             pattern = _PATTERN_SYMBOLS.get(expr.name)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -48,6 +48,7 @@ from tilelang_dsl.semantic import (
     SemanticLowLevelCopyStmt,
     SemanticMaskType,
     SemanticPadValueType,
+    SemanticPartitionTensorViewType,
     SemanticPipeBarrierStmt,
     SemanticPtrType,
     SemanticPredicateStoreStmt,
@@ -1886,6 +1887,46 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertEqual(slice_assign.value.type.rank, 2)
         self.assertEqual(slice_assign.value.type.extents, (16, 32))
         self.assertEqual(slice_assign.value.type.physical_axes, (3, 4))
+
+    def test_tensorview_slice_binding_lowers_to_partition_tensor_view_descriptor(self) -> None:
+        @pto.vkernel(op="tensorview_slice_partition_binding_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            part = inp[0:16, 0:32]
+            rows, cols = part.shape
+            s0, s1 = part.strides
+            if rows != 0 and cols != 0:
+                rows = s0 + s1
+            return None
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(kernel))
+        slice_assign = semantic_kernel.body[0]
+        self.assertIsInstance(slice_assign, SemanticAssignStmt)
+        self.assertIsInstance(slice_assign.targets[0].type, SemanticPartitionTensorViewType)
+        self.assertEqual(slice_assign.targets[0].type.rank, 2)
+
+        text = kernel.mlir_text()
+        self.assertIn(" = pto.partition_view %arg0, offsets = [%c0, %c0], sizes = [%c16, %c32] : ", text)
+        self.assertIn("-> !pto.partition_tensor_view<16x32xf32>", text)
+        self.assertEqual(text.count("pto.get_tensor_view_dim"), 2)
+        self.assertEqual(text.count("pto.get_tensor_view_stride"), 2)
+
+    def test_partition_tensor_view_annotation_accepts_tensorview_slice_binding(self) -> None:
+        @pto.vkernel(op="partition_tensor_view_annotation_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            part: pto.PartitionTensorView = inp[0:8, 0:8]
+            r0, r1 = part.shape
+            return None
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(kernel))
+        slice_assign = semantic_kernel.body[0]
+        self.assertIsInstance(slice_assign, SemanticAssignStmt)
+        self.assertIsInstance(slice_assign.targets[0].type, SemanticPartitionTensorViewType)
+        self.assertEqual(slice_assign.targets[0].type.rank, 2)
+
+        text = kernel.mlir_text()
+        self.assertIn(" = pto.partition_view %arg0, offsets = [%c0, %c0], sizes = [%c8, %c8] : ", text)
+        self.assertIn("-> !pto.partition_tensor_view<8x8xf32>", text)
+        self.assertEqual(text.count("pto.get_tensor_view_dim"), 2)
 
     def test_dynamic_tensorview_shape_profile_supports_runtime_bound_without_high_level_dma(self) -> None:
         @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.f32)])


### PR DESCRIPTION
## Summary
- infer `TensorView` slice assignment targets as `PartitionTensorView` bindings in semantic analysis
- support annotated local binding with `part: pto.PartitionTensorView = ...`
- lower slice expressions into `pto.partition_view` so non-DMA expression paths (for example `part.shape` and `part.strides`) can be materialized
- add regression tests for slice binding and annotation behavior

## Validation
- targeted unittest run with source package path:
  - `PYTHONPATH=tilelang-dsl/python python3 ...`
- verified tests include:
  - `TileLangDSLDescriptorTests.test_tensorview_slice_binding_lowers_to_partition_tensor_view_descriptor`
  - `TileLangDSLDescriptorTests.test_partition_tensor_view_annotation_accepts_tensorview_slice_binding`
  - related existing descriptor/inline_proc regression tests