### PR TITLE
[tilelang-dsl] support pass statement in DSL v1

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -121,6 +121,11 @@ class FrontendStmtNode:
 
 
 @dataclass(frozen=True)
+class FrontendNoOpStmt(FrontendStmtNode):
+    pass
+
+
+@dataclass(frozen=True)
 class FrontendAssignStmt(FrontendStmtNode):
     target: FrontendTargetNode
     value: FrontendExprNode
@@ -510,6 +515,8 @@ def _validate_inline_capture(
     context: _FrontendBuildContext,
 ) -> None:
     allowed = param_names | assigned_names | set(context.global_literal_constants)
+    if isinstance(stmt, FrontendNoOpStmt):
+        return
     if isinstance(stmt, FrontendAssignStmt):
         missing = _collect_name_reads(stmt.value) - allowed
         if missing:
@@ -638,6 +645,8 @@ def _collect_inline_proc_calls_stmt(
     inline_proc_names: set[str],
     into: set[str],
 ) -> None:
+    if isinstance(stmt, FrontendNoOpStmt):
+        return
     if isinstance(stmt, FrontendAssignStmt):
         _collect_inline_proc_calls_expr(stmt.value, inline_proc_names, into)
         return
@@ -1206,6 +1215,8 @@ def _build_stmt_list(nodes: list[ast.stmt] | tuple[ast.stmt, ...], context: _Fro
 
 
 def _build_stmt(node: ast.stmt, context: _FrontendBuildContext) -> FrontendStmtNode:
+    if isinstance(node, ast.Pass):
+        return _attach_source_location(FrontendNoOpStmt(), node, context)
     if isinstance(node, ast.Assign):
         if len(node.targets) != 1:
             raise context.error(node, "multiple assignment targets are not supported in TileLang DSL v1")
@@ -1516,6 +1527,7 @@ __all__ = [
     "FrontendKernelNode",
     "FrontendNameExpr",
     "FrontendNameTarget",
+    "FrontendNoOpStmt",
     "FrontendParameterNode",
     "FrontendReturnStmt",
     "FrontendSliceExpr",

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -29,6 +29,7 @@ from .frontend_ast import (
     FrontendKernelNode,
     FrontendNameExpr,
     FrontendNameTarget,
+    FrontendNoOpStmt,
     FrontendReturnStmt,
     FrontendSliceExpr,
     FrontendSourceLocation,
@@ -1006,6 +1007,9 @@ class _SemanticAnalyzer:
         *,
         allow_outer_lookup: bool,
     ) -> tuple[tuple[SemanticStmt, ...], dict[str, SemanticBinding]]:
+        if isinstance(stmt, FrontendNoOpStmt):
+            # Python `pass` lowers to a frontend no-op and does not materialize semantic IR.
+            return tuple(), dict(env)
         if (
             isinstance(stmt, FrontendExprStmt)
             and isinstance(stmt.expr, FrontendConstantExpr)
@@ -1132,7 +1136,7 @@ class _SemanticAnalyzer:
         self,
         stmt: FrontendStmtNode,
     ) -> bool:
-        return isinstance(stmt, FrontendAssignStmt) or (
+        return isinstance(stmt, FrontendNoOpStmt) or isinstance(stmt, FrontendAssignStmt) or (
             isinstance(stmt, FrontendExprStmt)
             and isinstance(stmt.expr, FrontendCallExpr)
             and stmt.expr.namespace == "pto"

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -24,8 +24,10 @@ from tilelang_dsl.frontend_ast import (
     FrontendCallExpr,
     FrontendExprStmt,
     FrontendForStmt,
+    FrontendIfStmt,
     FrontendStrictVecscopeStmt,
     FrontendVecscopeStmt,
+    FrontendNoOpStmt,
     build_frontend_kernel_node,
 )
 from tilelang_dsl.lowering import AuthoringModule, lower_semantic_kernel
@@ -4762,6 +4764,35 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
 
         self.assertIn("unsupported Python syntax `while`", str(ctx.exception))
         self.assertIn(f"{__file__}:", str(ctx.exception))
+
+    def test_pass_statement_builds_frontend_noop_and_compiles(self) -> None:
+        @pto.vkernel(op="pass_statement_frontend_noop_unique", dtypes=[(pto.f32,)])
+        def kernel(dst: pto.Tile):
+            pass
+            if pto.constexpr(True):
+                pass
+            else:
+                pass
+            return None
+
+        selected = pto.select_kernel(
+            "a5",
+            "pass_statement_frontend_noop_unique",
+            (pto.f32,),
+        )
+        frontend_kernel = build_frontend_kernel_node(selected)
+        self.assertIsInstance(frontend_kernel.body[0], FrontendNoOpStmt)
+        self.assertIsInstance(frontend_kernel.body[1], FrontendIfStmt)
+        if_stmt = frontend_kernel.body[1]
+        self.assertTrue(if_stmt.is_constexpr)
+        self.assertIsInstance(if_stmt.then_body[0], FrontendNoOpStmt)
+        self.assertIsInstance(if_stmt.else_body[0], FrontendNoOpStmt)
+
+        text = selected.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        ).mlir_text()
+        self.assertIn("return", text)
+        self.assertNotIn("scf.if", text)
 
     def test_vreg_annotated_assignment_rejects_mismatched_dtype(self) -> None:
         with self.assertRaises(TypeError) as ctx:


### PR DESCRIPTION
## Summary
- add explicit `ast.Pass` handling in frontend statement builder
- lower `pass` to `FrontendNoOpStmt` as a no-op frontend statement
- treat no-op statements as transparent in inline capture/call-graph traversal
- skip no-op statements during semantic analysis (no semantic IR emitted)
- add regression test for top-level and branch-local `pass`

## Testing
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest -q tilelang-dsl/tests/test_tilelang_dsl_v1.py -k pass_statement_builds_frontend_noop_and_compiles`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest -q tilelang-dsl/tests/test_tilelang_dsl_v1.py -k unsupported_python_syntax_reports_source_location`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest -q tilelang-dsl/tests/test_tilelang_dsl_v1.py -k strict_vecscope_requires_advanced_mode`

Closes #77
