### PR TITLE
fix(dsl): support valid_shape subscripting and fail-fast unsupported tuple indices

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -3342,6 +3342,20 @@ class _AuthoringRenderer:
         desired_name: str | None,
         into: list[str] | None,
     ) -> _RenderedValue:
+        if isinstance(expr.base, SemanticTupleExpr):
+            if not isinstance(expr.index, SemanticLiteralExpr) or not isinstance(expr.index.value, int):
+                raise NotImplementedError("tuple indices must be integer literals in TileLang DSL v1 lowering")
+            if expr.index.value < 0 or expr.index.value >= len(expr.base.elements):
+                raise NotImplementedError(
+                    f"tuple subscript index {expr.index.value} is out of bounds for tuple length {len(expr.base.elements)}"
+                )
+            return self._lower_expr(
+                expr.base.elements[expr.index.value],
+                env,
+                indent=indent,
+                desired_name=desired_name,
+                into=into,
+            )
         if (
             into is not None
             and isinstance(expr.base, SemanticAttributeAccess)

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3445,17 +3445,32 @@ class _SemanticAnalyzer:
         if isinstance(base.type, SemanticShapeType):
             if not isinstance(index.type, SemanticIndexType):
                 raise TypeError("shape subscript index must be an index value in TileLang DSL v1")
-            if (
-                isinstance(base, SemanticAttributeAccess)
-                and isinstance(base.base, SemanticBindingRef)
-                and isinstance(index, SemanticLiteralExpr)
-                and isinstance(index.value, int)
-            ):
-                if index.value < 0 or index.value >= base.type.rank:
-                    raise TypeError(
-                        f"shape subscript index {index.value} is out of bounds for rank {base.type.rank}"
-                    )
+            if not isinstance(index, SemanticLiteralExpr) or not isinstance(index.value, int):
+                raise TypeError(
+                    "shape/stride/valid_shape subscript index must be an integer literal in TileLang DSL v1"
+                )
+            if index.value < 0 or index.value >= base.type.rank:
+                raise TypeError(
+                    f"shape subscript index {index.value} is out of bounds for rank {base.type.rank}"
+                )
             return SemanticIndexType()
+        if isinstance(base.type, SemanticTupleType):
+            if not isinstance(index.type, SemanticIndexType):
+                raise TypeError("tuple subscript index must be an index value in TileLang DSL v1")
+            if not isinstance(base, SemanticTupleExpr):
+                raise TypeError(
+                    "tuple subscripting currently requires a shape-like tuple expression in TileLang DSL v1"
+                )
+            if not base.type.elements:
+                raise TypeError("cannot subscript an empty tuple in TileLang DSL v1")
+            if not isinstance(index, SemanticLiteralExpr) or not isinstance(index.value, int):
+                raise TypeError("tuple subscript index must be an integer literal in TileLang DSL v1")
+
+            if index.value < 0 or index.value >= len(base.type.elements):
+                raise TypeError(
+                    f"tuple subscript index {index.value} is out of bounds for tuple length {len(base.type.elements)}"
+                )
+            return base.type.elements[index.value]
         if isinstance(base.type, (SemanticTensorViewType, SemanticPartitionTensorViewType)):
             if not isinstance(index, SemanticTupleExpr):
                 raise TypeError("TensorView slicing expects a tuple of slices in TileLang DSL v1")

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3411,6 +3411,45 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"pto\.vsts %summed_\d+, %tmp_\d+\[%c0\], %mask_\d+ : !pto\.vreg<128xf16>, memref<\?x\?xf16, strided<\[\?, \?\], offset: \?>, #pto\.address_space<vec>>, !pto\.mask<b16>",
         )
 
+    def test_tile_valid_shape_subscript_profile_lowers_to_runtime_bounds_in_advanced_mode(self) -> None:
+        @pto.vkernel(op="tile_valid_shape_subscript_unique", dtypes=[(pto.f16,)], advanced=True)
+        def kernel(dst: pto.Tile):
+            valid_rows = dst.valid_shape[0]
+            valid_cols = dst.valid_shape[1]
+            area = valid_rows * valid_cols
+            if area == 0:
+                area = 1
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(
+                shape=(8, 128),
+                memory_space=pto.MemorySpace.UB,
+                valid_shape=("valid_rows", "valid_cols"),
+            ),
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        self.assertEqual(
+            [(param.name, param.kind) for param in semantic_kernel.parameters],
+            [
+                ("dst", "tile"),
+                ("__valid_shape_dst_0", "tile_valid_shape"),
+                ("__valid_shape_dst_1", "tile_valid_shape"),
+            ],
+        )
+        valid_rows_assign = semantic_kernel.body[0]
+        valid_cols_assign = semantic_kernel.body[1]
+        self.assertIsInstance(valid_rows_assign, SemanticAssignStmt)
+        self.assertIsInstance(valid_cols_assign, SemanticAssignStmt)
+        self.assertIsInstance(valid_rows_assign.targets[0].type, SemanticIndexType)
+        self.assertIsInstance(valid_cols_assign.targets[0].type, SemanticIndexType)
+
+        text = specialized.mlir_text()
+        self.assertIn("valid_shape=(?, ?)", text)
+        self.assertRegex(text, r"%valid_rows_\d+ = pto\.tile_valid_rows %arg0")
+        self.assertRegex(text, r"%valid_cols_\d+ = pto\.tile_valid_cols %arg0")
+
     def test_tile_partial_dynamic_valid_shape_profile_tracks_dynamic_axes_only(self) -> None:
         elem = pto.TypeVar("Elem")
 
@@ -4039,6 +4078,59 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertEqual(text.count("pto.get_tensor_view_stride"), 5)
         self.assertRegex(text, r"%ub_rows_\d+ = arith\.constant 8 : index")
         self.assertRegex(text, r"%ub_cols_\d+ = arith\.constant 64 : index")
+
+    def test_shape_subscript_rejects_non_literal_index_in_semantic(self) -> None:
+        @pto.vkernel(op="shape_dynamic_subscript_reject_unique", dtypes=[(pto.f32,)])
+        def kernel(src: pto.TensorView):
+            axis = src.shape[0]
+            value = src.shape[axis]
+            return None
+
+        with self.assertRaises(TypeError) as ctx:
+            analyze_frontend_kernel(build_frontend_kernel_node(kernel))
+        self.assertIn(
+            "shape/stride/valid_shape subscript index must be an integer literal in TileLang DSL v1",
+            str(ctx.exception),
+        )
+
+    def test_valid_shape_subscript_rejects_non_literal_index_in_semantic(self) -> None:
+        @pto.vkernel(op="valid_shape_dynamic_subscript_reject_unique", dtypes=[(pto.f16,)], advanced=True)
+        def kernel(dst: pto.Tile):
+            axis = 0
+            value = dst.valid_shape[axis]
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(
+                shape=(8, 128),
+                memory_space=pto.MemorySpace.UB,
+                valid_shape=("valid_rows", "valid_cols"),
+            )
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        self.assertIn(
+            "tuple subscript index must be an integer literal in TileLang DSL v1",
+            str(ctx.exception),
+        )
+
+    def test_tuple_call_result_subscript_rejects_in_semantic(self) -> None:
+        @pto.vkernel(op="tuple_call_result_subscript_reject_unique", dtypes=[(pto.f16,)], advanced=True)
+        def kernel(dst: pto.Tile):
+            mask = pto.make_mask(dst.element_type, pto.i32(64))[0]
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        self.assertIn(
+            "tuple subscripting currently requires a shape-like tuple expression in TileLang DSL v1",
+            str(ctx.exception),
+        )
 
     def test_advanced_mode_lowers_compare_predicate_carry_and_rearrangement_families(self) -> None:
         @pto.vkernel(op="advanced_family", dtypes=[(pto.i32, pto.i32, pto.i32, pto.i32)], advanced=True)


### PR DESCRIPTION
## Summary
- fix issue #90 by enabling `dst.valid_shape[0]` / `dst.valid_shape[1]` lowering through tuple subscript handling in DSL v1.
- align frontend semantic checks with current lowering capability: reject non-literal shape/valid_shape/strides subscripts and reject tuple-call-result subscripting that lowering cannot materialize yet.
- add regression coverage for:
  - valid_shape literal subscript success path
  - non-literal subscript fail-fast diagnostics
  - tuple call result subscript fail-fast diagnostics

## Repro
- issue: #90
- repro command:
  - `python3 lib/TileOps/render_template_mlir.py lib/TileOps/issue_90_repro.py`

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest discover -s tilelang-dsl/tests -p "test_tilelang_dsl_v1.py" -k valid_shape_subscript`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest discover -s tilelang-dsl/tests -p "test_tilelang_dsl_v1.py" -k dynamic_valid_shape_profile_lowers_to_runtime_bounds_in_advanced_mode`
- `python3 lib/TileOps/render_template_mlir.py lib/TileOps/issue_90_repro.py > build/issue_90_conservative_verify.log 2>&1`

Closes #90