### PR TITLE
fix(dsl): support explicit set_mov_pad_val for DMA padding

### DIFF
--- a/tilelang-dsl/docs/user_guide/01-introduction.md
+++ b/tilelang-dsl/docs/user_guide/01-introduction.md
@@ -15,7 +15,7 @@ The DSL surface is organized into multiple maturity tiers, reflecting the stabil
 | Base vector ops (`make_mask`, `vlds`, `vsts`, `vadd`, `vmuls`, etc.) | `basic` | Default compute skeleton for starter kernels. |
 | `strict_vecscope` | `advanced` | Explicit vector-scope management for expert authoring. |
 | Raw pointer family (`ptr(...)`, `castptr`, `addptr`) | `advanced` | For expert authoring and migration; not required for Quick Start. |
-| DMA family (`copy_*`, `set_loop*_stride_*`, `set_loop_size_*`) | `advanced` | Direct DMA engine control for expert authoring. |
+| DMA family (`copy_*`, `set_loop*_stride_*`, `set_loop_size_*`, pad-fill control) | `advanced` | Direct DMA engine control for expert authoring, including GM→UB padding behavior. |
 | Tile pointer helper (`tile.as_ptr()`) | `advanced` | Expert-only helper when advanced authoring needs explicit typed pointers. |
 
 For the authoritative tier classification, consult `tilelang-dsl/python/tilelang_dsl/support_matrix.py`. For known implementation gaps, refer to `tilelang-dsl/docs/unsupported-features.md`.
@@ -35,7 +35,7 @@ The TileLang DSL provides two distinct authoring modes:
 - Uses **raw pointer semantics** for explicit memory management  
 - Direct pointer operations correspond to `pto.ptr` types in MLIR
 - Explicit pointer arithmetic: `ptr(...)`, `castptr`, `addptr`
-- Manual DMA engine control with low-level copy operations
+- Manual DMA engine control with low-level copy operations and explicit GM→UB padding behavior
 - Requires explicit buffer management and pointer arithmetic
 - Intended for expert users and performance-critical optimizations
 

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -336,6 +336,7 @@ Notes:
 - `PadValue.text` exposes the standard textual spelling for built-ins such as `null` and `zero`.
 - Custom pad values currently model an `f32` payload. In DSL v1, materializing a custom pad into a scalar is only supported for floating tile element dtypes.
 - `PadValue.NULL` does not denote a usable scalar fill constant. Calling `tile.pad_value.eval()` or `tile.config.pad_value.eval()` when the enum is `NULL` is a frontend error.
+- **DMA padding**: When performing GM→UB DMA transfers with padding enabled (via `enable_ub_pad=True` in `pto.copy_gm_to_ubuf`), the pad value must be configured explicitly using `pto.set_mov_pad_val`. Tile `PadValue` descriptors are not automatically translated to hardware register configurations in TileLang DSL v1. See [Pad Fill Semantics](08-sync-dma-operations.md#pad-fill-semantics) for usage details.
 
 #### Tile Shape Concepts
 

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -237,7 +237,19 @@ pto.wait_intra_core(0, Event.ID0)
 
 ### DMA Programming [Advanced Tier]
 
-This section contains both DMA configuration operations (setting loop strides and sizes) and DMA execution operations (copying data).
+This section covers Direct Memory Access (DMA) operations for transferring data between Global Memory (GM) and Unified Buffer (UB). DMA operations are performance-critical and require careful configuration of stride parameters and transfer sizes.
+
+**Key Concepts:**
+- **DMA Configuration**: Set stride parameters and loop sizes using `set_loop*_stride_*` and `set_loop_size_*` operations.
+- **DMA Execution**: Perform transfers using `copy_gm_to_ubuf`, `copy_ubuf_to_gm`, and `copy_ubuf_to_ubuf` operations.
+- **GM→UB Padding**: Optionally fill out-of-bounds regions with a specified value when copying from GM to UB. See [Pad Fill Semantics](#pad-fill-semantics) for details.
+
+**Usage Flow:**
+1. Configure DMA parameters (strides, loop sizes)
+2. Execute the DMA transfer operation
+3. Optionally enable padding for GM→UB transfers
+
+**Note**: All DMA operations in this section are part of the **Advanced Tier** and require explicit buffer management and pointer arithmetic. For basic tile-based authoring, refer to the [Basic Authoring Mode](01-introduction.md#basic-vs-advanced-authoring-modes) documentation.
 
 #### Manual Configuration Example
 
@@ -249,6 +261,129 @@ pto.set_loop_size_outtoub(loop1=16, loop2=16)                # Transfer size
 pto.copy_gm_to_ubuf(src=gm_ptr, dst=ub_ptr, n_burst=16, len_burst=128, gm_stride=128, ub_stride=128)
 
 ```
+
+#### Pad Fill Semantics
+
+When copying data from Global Memory (GM) to Unified Buffer (UB), you can enable padding to fill out-of-bounds regions with a specified value. This is useful when the source data dimensions don't perfectly match the destination tile allocation, or when you need to handle boundary conditions in tiled computations.
+
+##### How Padding Works
+
+1. **Configure the hardware pad register**: Call `pto.set_mov_pad_val` to set the pad value in the hardware register. This must be done before any `pto.copy_gm_to_ubuf` operation with padding enabled.
+
+2. **Enable padding in the DMA operation**: Set `enable_ub_pad=True` in the `pto.copy_gm_to_ubuf` call to activate the padded transfer path. The pad value from the hardware register will be used for filling out-of-bounds regions.
+
+3. **Hardware mapping**: The `pto.set_mov_pad_val` operation corresponds directly to the low-level VPTO instruction that configures the hardware pad register. There is no automatic translation from tile `PadValue` descriptors—you must explicitly set the pad register before padded DMA transfers.
+
+##### Example Workflow
+
+Configure the hardware pad register using `pto.set_mov_pad_val`, then perform the DMA transfer with padding enabled:
+
+```python
+# First, configure the hardware pad register with a scalar value
+# For zero fill, use an appropriate scalar type based on your data
+pto.set_mov_pad_val(pto.f32(0.0))  # Zero fill for float32 data
+
+# Then perform the DMA transfer with padding enabled
+pto.copy_gm_to_ubuf(
+    src=gm_ptr,
+    dst=ub_ptr,
+    n_burst=32,
+    len_burst=200,
+    gm_stride=200,
+    ub_stride=256,
+    enable_ub_pad=True,  # Enable padded transfer
+)
+```
+
+##### Accessing Pad Values in Kernel Code
+
+Tile `PadValue` descriptors can be used within kernel code for computation purposes (e.g., initializing vectors with a specific fill value). However, note that **these descriptors are not automatically used for DMA padding**—you must still call `pto.set_mov_pad_val` explicitly to configure the hardware pad register for GM→UB transfers.
+
+To access a pad value from a tile descriptor in kernel code:
+
+```python
+# Get the pad descriptor from the destination tile
+pad_desc = dst.pad_value
+
+# Check if a valid pad value is configured
+if pto.constexpr(pad_desc != pto.PadValue.NULL):
+    # Materialize the scalar value
+    pad_scalar = pad_desc.eval()
+    
+    # Use the scalar value (e.g., for vector duplication)
+    mask = pto.make_mask(pto.f32, PAT.ALL)
+    pad_vector = pto.vdup(pad_scalar, mask)
+```
+
+##### Important Notes
+
+- The `PadValue.NULL` descriptor indicates no pad value is configured. Attempting to call `.eval()` on `PadValue.NULL` will raise a frontend error.
+- Custom pad values currently support only 32-bit float payloads (`PadValue.custom_f32(...)`).
+- Padding only affects GM→UB transfers (`pto.copy_gm_to_ubuf`). UB→GM and UB→UB transfers do not support padding.
+- The padded region is determined by the difference between the tile's `valid_shape` and its full `shape`. Ensure your tile is configured with appropriate dimensions.
+- Tile `PadValue` descriptors are not automatically used for DMA padding. You must call `pto.set_mov_pad_val` explicitly to configure the hardware pad register for padded GM→UB transfers.
+
+##### `pto.set_mov_pad_val` Operation [Advanced Tier]
+
+The `pto.set_mov_pad_val` operation configures the hardware pad register used for GM→UB transfers when padding is enabled. This operation must be called explicitly before any `pto.copy_gm_to_ubuf` operation with `enable_ub_pad=True`, as the TileLang DSL v1 does not automatically translate tile `PadValue` descriptors to hardware register configurations.
+
+**Operation Signature**:
+```python
+pto.set_mov_pad_val(pad_value: ScalarType) -> None
+```
+
+**Parameters**:
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pad_value` | `ScalarType` | Scalar value used for padding. Supported types: `pto.i8`, `pto.i16`, `pto.i32`, `pto.f16`, `pto.bf16`, `pto.f32`. The value's bit pattern is encoded into the hardware pad register. For standard pad values, use `PadValue.eval()` to obtain the appropriate scalar: `0` or `0.0` for `PadValue.ZERO`, dtype-aware maximum for `PadValue.MAX`, dtype-aware minimum for `PadValue.MIN`. |
+
+**Returns**: None (side-effect operation)
+
+**Example**:
+
+Using a scalar value directly:
+```python
+# Configure the hardware pad register for zero fill using an integer scalar
+pto.set_mov_pad_val(pto.i32(0))  # Zero fill for integer types
+
+# Or using a float scalar for floating-point padding
+pto.set_mov_pad_val(pto.f32(0.0))  # Zero fill for float types
+
+# Perform DMA transfer with padding enabled
+pto.copy_gm_to_ubuf(
+    src=gm_ptr,
+    dst=ub_ptr,
+    n_burst=32,
+    len_burst=200,
+    gm_stride=200,
+    ub_stride=256,
+    enable_ub_pad=True,
+)
+```
+
+Using a tile's pad value descriptor:
+```python
+# Get the pad value from a tile configuration
+pad_desc = tile.pad_value  # PadValue enum
+if pto.constexpr(pad_desc != pto.PadValue.NULL):
+    pad_scalar = pad_desc.eval()  # Materializes to a scalar value
+    pto.set_mov_pad_val(pad_scalar)
+    
+    # Perform padded DMA transfer
+    pto.copy_gm_to_ubuf(
+        src=gm_ptr,
+        dst=ub_ptr,
+        n_burst=32,
+        len_burst=200,
+        gm_stride=200,
+        ub_stride=256,
+        enable_ub_pad=True,
+    )
+```
+
+**Important**: You are responsible for ensuring the pad register is properly configured before any `pto.copy_gm_to_ubuf` operation with `enable_ub_pad=True`. The pad register configuration persists until changed by another `pto.set_mov_pad_val` call.
+
+**Future Improvement**: Future versions of TileLang DSL may provide an implicit approach that automatically translates `PadValue` descriptors from tile configurations to hardware register configurations, similar to DMA syntax sugar features.
 
 #### `pto.set_loop2_stride_outtoub(src_stride: pto.i64, dst_stride: pto.i64) -> None`  [Advanced Tier]
 
@@ -390,8 +525,10 @@ The following operations provide direct control over DMA transfers but require m
 **Returns**: None (side-effect operation)
 
 **Notes**:
-- In TileLang DSL, the keyword form above is the recommended public surface.
-- The lowering still maps to the underlying low-level PTO operand ABI in positional order.
+- **Keyword arguments**: The keyword form shown above is the recommended public API surface. Use named arguments for clarity.
+- **Padding control**: Set `enable_ub_pad=True` to enable padded GM→UB transfers. The pad value must be configured separately using `pto.set_mov_pad_val` before the DMA operation (see [Pad Fill Semantics](#pad-fill-semantics) for details).
+- **Pad value source**: When padding is enabled, the fill scalar comes from the hardware pad register configured by `pto.set_mov_pad_val`. You must call this operation explicitly before the DMA transfer.
+- **ABI compatibility**: The lowering preserves the underlying PTO operand order while providing a more ergonomic keyword interface.
 
 **Example**:
 ```python
@@ -403,6 +540,23 @@ pto.copy_gm_to_ubuf(
     gm_stride=128,
     ub_stride=128,
     enable_ub_pad=False,
+)
+```
+
+**Padding Example**:
+```python
+# First configure the hardware pad register with a scalar value
+pto.set_mov_pad_val(pto.f32(0.0))  # Zero fill for float32 data
+
+# Then perform padded DMA transfer
+pto.copy_gm_to_ubuf(
+    src=gm_ptr,
+    dst=ub_ptr,
+    n_burst=32,
+    len_burst=200,
+    gm_stride=200,
+    ub_stride=256,
+    enable_ub_pad=True,
 )
 ```
 

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
@@ -883,7 +883,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | # | Group | Description | Count | Details |
 |---|-------|-------------|-------|---------|
 | 1 | [Pipeline Sync](#isa-01-pipeline-sync) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
-| 2 | [DMA Copy Programming](#isa-02-dma-copy) | DMA configuration and transfer between GM↔UB | 10 | `pto.set_loop*_stride_*`, `pto.set_loop_size_*`, `pto.set_mov_pad_val`, `pto.copy_gm_to_ubuf`, `pto.copy_ubuf_to_ubuf`, `pto.copy_ubuf_to_gm` |
+| 2 | [DMA Copy Programming](#isa-02-dma-copy) | DMA configuration and transfer between GM↔UB | 9 | `pto.set_loop*_stride_*`, `pto.set_loop_size_*`, `pto.copy_gm_to_ubuf`, `pto.copy_ubuf_to_ubuf`, `pto.copy_ubuf_to_gm` |
 | 3 | [Vector Load/Store](#isa-03-vector-load-store) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldsx2`, `pto.vgather2`, `pto.vsts`, `pto.vstsx2`, `pto.vscatter`, etc. |
 | 4 | [Predicate Load/Store](#isa-04-predicate-load-store) | UB↔mask register movement | 5 | `pto.plds`, `pto.pldi`, `pto.psts`, `pto.psti`, `pto.pstu` |
 | 5 | [Materialization & Predicate Ops](#isa-05-materialization-predicate) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
@@ -1609,36 +1609,6 @@ Note: UB stride fields are 21 bits (sufficient for 256KB UB address space), GM s
 
 ---
 
-#### Pad Value Configuration
-
-##### `pto.set_mov_pad_val`
-
-- **syntax:** `pto.set_mov_pad_val %value : T`
-- **supported `T`:** `i8`, `i16`, `i32`, `f16`, `bf16`, `f32`
-- **semantics:** Configure the pad fill value used by GM→UB DMA when `data_select_bit = true`.
-
-This op programs the hardware pad register consumed by `pto.copy_gm_to_ubuf`. The operand is a typed scalar. Its raw bit pattern is encoded into the underlying hardware configuration payload:
-
-- integer inputs use their zero-extended bit pattern
-- floating-point inputs use their bitcast-to-integer bit pattern, then zero-extend to `i64`
-
-This configuration affects only the GM→UB padding path. UB→GM DMA ignores the pad value.
-
-**Parameter Table:**
-
-| Parameter | Description |
-|-----------|-------------|
-| `%value` | Pad fill scalar. Must be one of `i8/i16/i32/f16/bf16/f32`. |
-
-**Example:**
-
-```mlir
-%pad = arith.constant 0 : i16
-pto.set_mov_pad_val %pad : i16
-```
-
----
-
 #### DMA Transfer Execution
 
 ##### `pto.copy_gm_to_ubuf`
@@ -1977,8 +1947,6 @@ UB (128 cols wide, 32B-aligned, padded):
 ```
 
 ```mlir
-%pad = arith.constant 0 : i16
-pto.set_mov_pad_val %pad : i16
 pto.set_loop_size_outtoub %c1_i64, %c1_i64 : i64, i64
 pto.set_loop1_stride_outtoub %c0_i64, %c0_i64 : i64, i64
 pto.set_loop2_stride_outtoub %c0_i64, %c0_i64 : i64, i64

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -778,6 +778,7 @@ _BOOL_OP_NAMES = {
 }
 
 _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
+    "set_mov_pad_val": frozenset({"pad_value"}),
     "set_loop2_stride_outtoub": frozenset({"src_stride", "dst_stride"}),
     "set_loop1_stride_outtoub": frozenset({"src_stride", "dst_stride"}),
     "set_loop_size_outtoub": frozenset({"loop1", "loop2"}),

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -24,6 +24,7 @@ from .semantic import (
     SemanticBindingRef,
     SemanticCallExpr,
     SemanticDmaConfigStmt,
+    SemanticDmaUnaryConfigStmt,
     SemanticDmaLoadStmt,
     SemanticDmaStoreStmt,
     SemanticExpr,
@@ -456,6 +457,8 @@ class _AuthoringRenderer:
             return self._render_i64_pair_stmt("wait_flag_dev", stmt.core_id, stmt.event_id, env, indent=indent)
         if isinstance(stmt, SemanticWaitIntraCoreStmt):
             return self._render_i64_pair_stmt("wait_intra_core", stmt.block_id, stmt.event_id, env, indent=indent)
+        if isinstance(stmt, SemanticDmaUnaryConfigStmt):
+            return self._render_dma_unary_config(stmt, env, indent=indent)
         if isinstance(stmt, SemanticDmaConfigStmt):
             return self._render_dma_config(stmt, env, indent=indent)
         if isinstance(stmt, SemanticLowLevelCopyStmt):
@@ -490,6 +493,21 @@ class _AuthoringRenderer:
         lines.append(
             self._indent(indent)
             + f"pto.{stmt.name} {first.name}, {second.name} : i64, i64"
+        )
+        return lines
+
+    def _render_dma_unary_config(
+        self,
+        stmt: SemanticDmaUnaryConfigStmt,
+        env: dict[str, _RenderedValue],
+        *,
+        indent: int,
+    ) -> list[str]:
+        lines: list[str] = []
+        value = self._lower_expr(stmt.value, env, indent=indent, into=lines)
+        lines.append(
+            self._indent(indent)
+            + f"pto.{stmt.name} {value.name} : {self._render_type(value.type)}"
         )
         return lines
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -268,6 +268,7 @@ _VECTOR_IMMEDIATE_OPS = {"vshift", "vslide"}
 _TERNARY_VECTOR_OPS = {"vaxpy", "vmula"}
 _MULTI_RESULT_VECTOR_OPS = {"vmull", "vldsx2", "vldus", "pstu"}
 _BROADCAST_VECTOR_OPS = {"vbr", "vdup", "vci"}
+_LOW_LEVEL_DMA_UNARY_CONFIG_OPS = {"set_mov_pad_val"}
 _LOW_LEVEL_DMA_CONFIG_OPS = {
     "set_loop2_stride_outtoub",
     "set_loop1_stride_outtoub",
@@ -281,6 +282,9 @@ _LOW_LEVEL_DMA_COPY_OPS = {
     "copy_ubuf_to_gm",
     "copy_ubuf_to_ubuf",
 }
+_MOV_PAD_SUPPORTED_SCALAR_DTYPES = frozenset(
+    dtype.name for dtype in (i8, i16, i32, f16, bf16, f32)
+)
 _COMPARE_SELECT_OPS = {"vcmp", "vcmps", "vsel", "vselr", "vselrv2"}
 _PREDICATE_MOVEMENT_OPS = {"pnot", "psel", "ppack", "punpack"}
 _CARRY_OPS = {"vaddc", "vsubc", "vaddcs", "vsubcs"}
@@ -653,6 +657,12 @@ class SemanticDmaConfigStmt(SemanticStmt):
     name: str
     first: SemanticExpr
     second: SemanticExpr
+
+
+@dataclass(frozen=True)
+class SemanticDmaUnaryConfigStmt(SemanticStmt):
+    name: str
+    value: SemanticExpr
 
 
 @dataclass(frozen=True)
@@ -1559,7 +1569,7 @@ class _SemanticAnalyzer:
         return (
             isinstance(expr, FrontendCallExpr)
             and expr.namespace == "pto"
-            and expr.name in _LOW_LEVEL_DMA_CONFIG_OPS | _LOW_LEVEL_DMA_COPY_OPS
+            and expr.name in _LOW_LEVEL_DMA_UNARY_CONFIG_OPS | _LOW_LEVEL_DMA_CONFIG_OPS | _LOW_LEVEL_DMA_COPY_OPS
         )
 
     def _analyze_dma_stmt(
@@ -1986,6 +1996,21 @@ class _SemanticAnalyzer:
             env,
             allow_outer_lookup=allow_outer_lookup,
         )
+        if expr.name in _LOW_LEVEL_DMA_UNARY_CONFIG_OPS:
+            if len(args) != 1:
+                raise TypeError(f"pto.{expr.name} expects exactly 1 positional argument in TileLang DSL")
+            scalar = self._require_scalar_expr(args[0], f"pto.{expr.name} pad_value")
+            if scalar.dtype.name not in _MOV_PAD_SUPPORTED_SCALAR_DTYPES:
+                raise TypeError(
+                    "pto.set_mov_pad_val pad_value must be one of i8, i16, i32, f16, bf16, or f32 in TileLang DSL v1"
+                )
+            return (
+                SemanticDmaUnaryConfigStmt(
+                    name=expr.name,
+                    value=args[0],
+                ),
+                dict(env),
+            )
         if expr.name in _LOW_LEVEL_DMA_CONFIG_OPS:
             if len(args) != 2:
                 raise TypeError(f"pto.{expr.name} expects exactly 2 positional arguments in TileLang DSL")
@@ -2103,6 +2128,8 @@ class _SemanticAnalyzer:
         def bool_literal(value: bool) -> SemanticLiteralExpr:
             return SemanticLiteralExpr(value=value, type=SemanticScalarType(dtype=i1))
 
+        if expr.name == "set_mov_pad_val":
+            return (analyzed_keywords["pad_value"],)
         if expr.name in {
             "set_loop2_stride_outtoub",
             "set_loop1_stride_outtoub",

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -181,6 +181,7 @@ ADVANCED_TOPLEVEL_PTO_CALLS = frozenset(
     {
         "strict_vecscope",
         "store_scalar",
+        "set_mov_pad_val",
         "copy_gm_to_ubuf",
         "copy_ubuf_to_gm",
         "copy_ubuf_to_ubuf",
@@ -221,6 +222,7 @@ ADVANCED_RAW_POINTER_SURFACES = frozenset(
 )
 ADVANCED_LOW_LEVEL_DMA_SURFACES = frozenset(
     {
+        "pto.set_mov_pad_val",
         "pto.copy_gm_to_ubuf",
         "pto.copy_ubuf_to_gm",
         "pto.copy_ubuf_to_ubuf",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -38,6 +38,7 @@ from tilelang_dsl.semantic import (
     SemanticBinaryExpr,
     SemanticCallExpr,
     SemanticDmaConfigStmt,
+    SemanticDmaUnaryConfigStmt,
     SemanticExprStmt,
     SemanticForStmt,
     SemanticGetBufStmt,
@@ -431,6 +432,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertIn("pto.strict_vecscope", ADVANCED_EXPLICIT_VECSCOPE_SURFACES)
         self.assertIn("pto.ptr", ADVANCED_RAW_POINTER_SURFACES)
         self.assertIn("pto.castptr", ADVANCED_RAW_POINTER_SURFACES)
+        self.assertIn("pto.set_mov_pad_val", ADVANCED_LOW_LEVEL_DMA_SURFACES)
         self.assertIn("pto.copy_ubuf_to_ubuf", ADVANCED_LOW_LEVEL_DMA_SURFACES)
         self.assertIn("pto.tile_with_strides", ADVANCED_TILE_HELPER_SURFACES)
 
@@ -440,6 +442,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertEqual(get_feature_tier("pto.castptr"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.load_scalar"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.store_scalar"), ADVANCED_TIER)
+        self.assertEqual(get_feature_tier("pto.set_mov_pad_val"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.copy_ubuf_to_ubuf"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.tile_with_strides"), ADVANCED_TIER)
 
@@ -3870,6 +3873,41 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"pto\.copy_gm_to_ubuf %gm_ptr_\d+, %ub_ptr_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %false, %tmp_\d+, %tmp_\d+, %tmp_\d+",
         )
 
+    def test_set_mov_pad_val_lowers_in_advanced_mode(self) -> None:
+        @pto.vkernel(op="set_mov_pad_val_dma_unique", dtypes=[(pto.f32, pto.f32)], advanced=True)
+        def kernel(inp: pto.TensorView, dst: pto.Tile):
+            gm_ptr = inp.as_ptr()
+            ub_ptr = dst.as_ptr()
+
+            pto.set_mov_pad_val(pad_value=pto.f32(0.0))
+            pto.set_loop2_stride_outtoub(src_stride=4096, dst_stride=2048)
+            pto.set_loop1_stride_outtoub(src_stride=1024, dst_stride=512)
+            pto.set_loop_size_outtoub(loop1=1, loop2=1)
+            pto.copy_gm_to_ubuf(
+                src=gm_ptr,
+                dst=ub_ptr,
+                n_burst=1,
+                len_burst=64,
+                gm_stride=128,
+                ub_stride=128,
+                enable_ub_pad=True,
+            )
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        self.assertTrue(any(isinstance(stmt, SemanticDmaUnaryConfigStmt) for stmt in semantic_kernel.body))
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r"pto\.set_mov_pad_val %[^ ]+ : f32")
+        self.assertRegex(
+            text,
+            r"pto\.copy_gm_to_ubuf %gm_ptr_\d+, %ub_ptr_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %true, %tmp_\d+, %tmp_\d+, %tmp_\d+",
+        )
+
     def test_copy_ubuf_to_gm_keyword_surface_lowers_in_advanced_mode(self) -> None:
         @pto.vkernel(op="tile_to_tensorview_dma_unique", dtypes=[(pto.f32, pto.f32)], advanced=True)
         def kernel(src: pto.Tile, dst: pto.TensorView):
@@ -4918,6 +4956,23 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
                 return None
 
         self.assertIn("advanced family surface `pto.vreduce`", str(ctx.exception))
+
+    def test_set_mov_pad_val_rejects_unsupported_scalar_dtype(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(op="set_mov_pad_val_bad_dtype_unique", dtypes=[(pto.f32,)], advanced=True)
+            def kernel(dst: pto.Tile):
+                pto.set_mov_pad_val(pto.i64(0))
+                return None
+
+            kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB)
+            ).mlir_text()
+
+        self.assertIn(
+            "pto.set_mov_pad_val pad_value must be one of i8, i16, i32, f16, bf16, or f32",
+            str(ctx.exception),
+        )
 
     def test_unsupported_python_syntax_reports_source_location(self) -> None:
         with self.assertRaises(pto.TileLangFrontendError) as ctx:


### PR DESCRIPTION
## Summary
- add explicit advanced DMA surface support for `pto.set_mov_pad_val`
- lower the new op through semantic analysis and authoring-form MLIR emission
- align the TileLang DSL docs and tests with the explicit pad-register workflow for GM->UB padding

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest discover -s tilelang-dsl/tests -p 'test_tilelang_dsl_v1.py'`

## Issue
Closes #86