### PR TITLE
fix(dsl): materialize vtrc round mode in tilelang

### DIFF
--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1312,20 +1312,32 @@ pto.vtranspose(dst_ub_ptr, src_ub_ptr, config_word)
 
 Type conversion and specialized operations.
 
-#### `pto.vtrc(vec: VRegType, mask: MaskType) -> VRegType`
+#### `pto.vtrc(vec: VRegType, mask: MaskType, rnd: pto.VcvtRoundMode | None = None) -> VRegType`
 
-**Description**: Truncate vector elements.
+**Description**: Truncate/round float to integer-valued float (stays in float type). This is the TileLang DSL surface for the VPTO `pto.vtrc` operation.
+
+**Attribute Enums**:
+- `pto.VcvtRoundMode`: `R`, `A`, `F`, `C`, `Z`, `O` (note: `vtrc` does not support `O`)
 
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
 | `mask` | `MaskType` | Predicate mask |
+| `rnd` | `pto.VcvtRoundMode` \| `None` | Optional rounding-mode attribute lowered to VPTO `round_mode`. Defaults to `R` if not specified. |
 
 **Returns**:
 | Return Value | Type | Description |
 |--------------|------|-------------|
-| `result` | `VRegType` | Truncated vector |
+| `result` | `VRegType` | Truncated vector with integer-valued float elements |
+
+**Constraints**:
+- Current TileLang DSL v1 accepts exactly two positional arguments: `pto.vtrc(vec, mask)`. Optional `rnd` attribute is exposed as keyword argument: `rnd=...`.
+- The underlying VPTO op syntax is `pto.vtrc %input, %mask, "RND"`.
+- Supported rounding modes are `R` (round to nearest), `A` (round away from zero), `F` (floor), `C` (ceil), `Z` (truncate toward zero).
+- The enum form is preferred. For compatibility, canonical strings such as `"R"`, `"A"`, `"F"`, `"C"`, `"Z"` are also accepted.
+- This op does not change the element type; input and output have the same vector type.
+- Only floating-point element types are supported: `f16`, `bf16`, `f32`.
 
 #### `pto.vcvt(vec: VRegType, to_type: Type, mask: MaskType, rnd: pto.VcvtRoundMode | None = None, sat: pto.VcvtSatMode | None = None, part: pto.VcvtPartMode | None = None) -> VRegType`
 

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -816,6 +816,7 @@ _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
         }
     ),
     "vcvt": frozenset({"rnd", "sat", "part"}),
+    "vtrc": frozenset({"rnd"}),
 }
 
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2890,6 +2890,17 @@ class _AuthoringRenderer:
             )
             return _RenderedValue(name="__void_call__", type=SemanticMetaType(kind="void"))
 
+        if expr.name == "vtrc":
+            value = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            mask = self._lower_expr(expr.args[1], env, indent=indent, into=into)
+            rnd = self._render_string_literal(expr.args[2])
+            into.append(
+                self._indent(indent)
+                + f"{result_name} = pto.vtrc {value.name}, {mask.name}, {rnd} : "
+                + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+            )
+            return _RenderedValue(name=result_name, type=expr.type)
+
         if expr.name in {
             "vabs",
             "vrelu",
@@ -2911,7 +2922,6 @@ class _AuthoringRenderer:
             "vusqz",
             "vsqz",
             "vexpdiff",
-            "vtrc",
             "vcgadd",
             "vcgmax",
             "vcgmin",

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3053,6 +3053,12 @@ class _SemanticAnalyzer:
                     env,
                     allow_outer_lookup=allow_outer_lookup,
                 )
+            if expr.namespace == "pto" and expr.name == "vtrc":
+                return self._analyze_vtrc_frontend_call(
+                    expr,
+                    env,
+                    allow_outer_lookup=allow_outer_lookup,
+                )
             if expr.keywords:
                 raise TypeError(
                     f"call surface `{expr.namespace + '.' if expr.namespace else ''}{expr.name}` "
@@ -3761,6 +3767,8 @@ class _SemanticAnalyzer:
             return self._analyze_rearrangement_op(name, args)
         if name == "vcvt":
             return self._analyze_vcvt(args)
+        if name == "vtrc":
+            return self._analyze_vtrc(args)
         if name == "vbitsort":
             return self._analyze_vbitsort(args)
         if name == "vmrgsort4":
@@ -4537,6 +4545,39 @@ class _SemanticAnalyzer:
             part_explicit="part" in analyzed_keywords,
         )
 
+    def _analyze_vtrc_frontend_call(
+        self,
+        expr: FrontendCallExpr,
+        env: dict[str, SemanticBinding],
+        *,
+        allow_outer_lookup: bool,
+    ) -> SemanticExpr:
+        if len(expr.args) != 2:
+            raise TypeError(
+                "pto.vtrc expects exactly 2 positional operands `(vec, mask)` "
+                "before optional keyword attrs in TileLang DSL v1"
+            )
+        args = tuple(
+            self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+            for arg in expr.args
+        )
+        analyzed_keywords = {
+            name: self._analyze_expr(value, env, allow_outer_lookup=allow_outer_lookup)
+            for name, value in expr.keywords
+        }
+        allowed_keywords = {"rnd"}
+        unexpected_keywords = sorted(set(analyzed_keywords) - allowed_keywords)
+        if unexpected_keywords:
+            keyword_text = ", ".join(unexpected_keywords)
+            raise TypeError(
+                "pto.vtrc only accepts keyword attr `rnd`; "
+                f"got unsupported keyword(s): {keyword_text}"
+            )
+        return self._analyze_vtrc(
+            args,
+            rnd=self._normalize_vtrc_round_mode(analyzed_keywords.get("rnd")),
+        )
+
     def _analyze_vcvt(
         self,
         args: tuple[SemanticExpr, ...],
@@ -4577,6 +4618,31 @@ class _SemanticAnalyzer:
                 part if part is not None else self._missing_optional_meta_expr(),
             ),
             type=self._vreg_type_for_dtype(target_dtype),
+        )
+
+    def _analyze_vtrc(
+        self,
+        args: tuple[SemanticExpr, ...],
+        *,
+        rnd: SemanticExpr | None = None,
+    ) -> SemanticExpr:
+        if len(args) != 2:
+            raise TypeError("pto.vtrc expects exactly 2 positional arguments in TileLang DSL v1")
+        vector = self._require_vreg_expr(args[0], "pto.vtrc vector")
+        self._require_mask_for_vreg(args[1], vector, "pto.vtrc")
+        if vector.element_dtype not in {f16, bf16, f32}:
+            raise TypeError("pto.vtrc only supports f16/bf16/f32 vector element types in TileLang DSL v1")
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vtrc",
+            args=(
+                args[0],
+                args[1],
+                rnd
+                if rnd is not None
+                else SemanticLiteralExpr(value="R", type=SemanticMetaType(kind="string")),
+            ),
+            type=vector,
         )
 
     def _analyze_vbitsort(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
@@ -4824,6 +4890,19 @@ class _SemanticAnalyzer:
                 "pto.vcvt rnd must be a VcvtRoundMode enum such as "
                 "`pto.VcvtRoundMode.R` or one of the canonical strings "
                 '`"R"`, `"A"`, `"F"`, `"C"`, `"Z"`, `"O"` in TileLang DSL v1'
+            )
+        return SemanticLiteralExpr(value=round_mode, type=SemanticMetaType(kind="string"))
+
+    def _normalize_vtrc_round_mode(self, expr: SemanticExpr | None) -> SemanticExpr | None:
+        normalized = self._normalize_vcvt_round_mode(expr)
+        if normalized is None:
+            return None
+        round_mode = self._require_string_expr(normalized, "pto.vtrc rnd")
+        if round_mode == VcvtRoundMode.O.value:
+            raise TypeError(
+                "pto.vtrc rnd must be one of "
+                '`"R"`, `"A"`, `"F"`, `"C"`, `"Z"` or a matching '
+                "VcvtRoundMode enum in TileLang DSL v1"
             )
         return SemanticLiteralExpr(value=round_mode, type=SemanticMetaType(kind="string"))
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2893,6 +2893,75 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"= pto\.vcvt %[^,\s]+(?: \{[^}]+\})? : !pto\.vreg<[^>]+> -> !pto\.vreg<[^>]+>",
         )
 
+    def test_vtrc_defaults_to_round_nearest(self) -> None:
+        @pto.vkernel(
+            op="vtrc_default_rnd_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vtrc(vec, all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vtrc", text)
+        self.assertIn(', "R" :', text)
+        self.assertRegex(
+            text,
+            r"= pto\.vtrc %[^,\s]+, %[^,\s]+, \"R\" : !pto\.vreg<[^>]+>, !pto\.mask<[^>]+> -> !pto\.vreg<[^>]+>",
+        )
+
+    def test_vtrc_supports_keyword_rnd_with_enums(self) -> None:
+        @pto.vkernel(
+            op="vtrc_keyword_rnd_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vtrc(vec, all_mask, rnd=pto.VcvtRoundMode.F)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vtrc", text)
+        self.assertIn(', "F" :', text)
+
+    def test_vtrc_rejects_round_mode_o(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            @pto.vkernel(
+                op="vtrc_round_mode_o_unique",
+                dtypes=[(pto.f32, pto.f32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = pto.vtrc(vec, all_mask, rnd=pto.VcvtRoundMode.O)
+                pto.vsts(out, dst, 0, all_mask)
+                return None
+
+            kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            ).mlir_text()
+
+        self.assertIn("pto.vtrc rnd must be one of", str(ctx.exception))
+
     def test_advanced_sort_memory_ops_surface_lower(self) -> None:
         @pto.vkernel(
             op="advanced_sort_memory_ops_unique",


### PR DESCRIPTION
## Summary
- materialize TileLang DSL `pto.vtrc` as the full VPTO surface with mask and round mode
- accept optional `rnd=` on the DSL call, default it to `R`, and reject unsupported `O` for `vtrc`
- add TileLang/unit repro coverage plus an ExpandTileOp repro for `pto.tfmods`

## Validation
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vtrc_defaults_to_round_nearest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vtrc_supports_keyword_rnd_with_enums tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vtrc_rejects_round_mode_o`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --vpto-emit-hivm-llvm test/dsl/issue_109_repro.pto -o -`

Closes #109