### PR TITLE
feat(dsl): add vbitcast op and TileLang DSL support

### DIFF
--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -250,3 +250,57 @@ for (int i = 0; i < N; i++)
 %int_div = pto.vcvt %floored, %mask {rnd = "Z"}
     : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 ```
+
+---
+
+## `pto.vbitcast`
+
+- **syntax:** `%result = pto.vbitcast %input : !pto.vreg<NxT0> -> !pto.vreg<MxT1>`
+- **semantics:** Bitwise reinterpretation of a vreg vector without changing the underlying bit pattern. This operation performs a pure type cast that preserves the exact bits of each element, changing only their interpretation (e.g., from floating-point to integer).
+
+- **inputs:**
+  `%input` is the source vector register value.
+- **outputs:**
+  `%result` is the reinterpreted vector register value.
+- **constraints and limitations:**
+  1. Both source and result must be `!pto.vreg<...>` types.
+  2. Source and result vectors must have the same total bit width (currently 2048 bits).
+  3. Only integer and floating-point element types are supported.
+
+**Element bit-width equality examples:**
+- `f32<64>` → `i32<64>`  (both 32-bit elements, total 2048 bits)
+- `f16<128>` → `i16<128>` (both 16-bit elements, total 2048 bits)
+- `bf16<128>` → `ui16<128>` (both 16-bit elements, total 2048 bits)
+- `si32<64>` → `ui32<64>` (both 32-bit elements, total 2048 bits)
+- `f32<64>` → `i16<128>` (32-bit/16-bit elements, total 2048 bits)
+
+**Verification:** The operation verifies that:
+1. Both input and result are `!pto.vreg<...>` types.
+2. Total bit width equals 2048 (the fixed vreg size).
+
+**Comparison with `pto.vcvt`:**
+- `pto.vcvt` performs value conversion with rounding, saturation, and lane placement control.
+- `pto.vbitcast` performs bitwise reinterpretation without changing the underlying bit pattern.
+
+**Example: Reinterpreting float as integer for bit manipulation**
+```mlir
+// Prepare a vector of float values
+%fvec = pto.vlds %ub[%lane] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+
+// Reinterpret as integer for bitwise operations
+%ivec = pto.vbitcast %fvec : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+
+// Extract sign bit (bit 31)
+%sign_bits = pto.vand %ivec, %sign_mask, %mask : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+
+// Reinterpret back to float
+%fvec_without_sign = pto.vbitcast %sign_bits : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+```
+
+**Example: Type punning between signed and unsigned integer**
+```mlir
+// Convert signed to unsigned without changing bits
+%signed = pto.vlds %ub[%lane] : !pto.ptr<si32, ub> -> !pto.vreg<64xsi32>
+%unsigned = pto.vbitcast %signed : !pto.vreg<64xsi32> -> !pto.vreg<64xui32>
+// Bits are identical; interpretation changes from signed to unsigned
+```

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -888,7 +888,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 6 | [Unary Vector Ops](isa/06-unary-vector-ops.md) | Single-input element-wise operations | 6 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrelu`, `pto.vnot` |
 | 7 | [Binary Vector Ops](isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
 | 8 | [Vec-Scalar Ops](isa/08-vec-scalar-ops.md) | Vector-scalar operations | 9 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
-| 9 | [Conversion Ops](isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 2 | `pto.vcvt`, `pto.vtrc` |
+| 9 | [Conversion Ops](isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 3 | `pto.vcvt`, `pto.vtrc`, `pto.vbitcast` |
 | 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
 | 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
 | 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
@@ -928,7 +928,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 
 | Operation | Group | Description |
 |-----------|-------|-------------|
-| Type Conversion | 9 | `pto.vcvt` |
+| Type Conversion | 9 | `pto.vcvt`, `pto.vbitcast` |
 | Interleave/Deinterleave | 12 | `pto.vintlv`, `pto.vdintlv` |
 | Interleave/Deinterleave (not A5) | 12 | `pto.vintlvv2`, `pto.vdintlvv2` |
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -935,6 +935,19 @@ def PTO_VcvtOp : PTO_Op<"vcvt", [Pure]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def PTO_VbitcastOp : PTO_Op<"vbitcast", [Pure]> {
+  let arguments = (ins
+    PTO_VectorType:$input
+  );
+  let results = (outs PTO_VectorType:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+}
+
 def PTO_VciOp : PTO_Op<"vci", [Pure]> {
   let arguments = (ins
     AnyInteger:$index,

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -2331,6 +2331,34 @@ LogicalResult VcvtOp::verify() {
   return success();
 }
 
+LogicalResult VbitcastOp::verify() {
+  auto inputType = dyn_cast<VRegType>(getInput().getType());
+  auto resultType = dyn_cast<VRegType>(getResult().getType());
+  if (!inputType || !resultType)
+    return emitOpError("input and result must be !pto.vreg<...>");
+
+  auto getStorageBits = [](VRegType type) -> std::optional<int64_t> {
+    Type elementType = type.getElementType();
+    if (auto intType = dyn_cast<IntegerType>(elementType))
+      return type.getElementCount() * static_cast<int64_t>(intType.getWidth());
+    if (auto floatType = dyn_cast<FloatType>(elementType))
+      return type.getElementCount() *
+             static_cast<int64_t>(floatType.getWidth());
+    return std::nullopt;
+  };
+
+  auto inputBits = getStorageBits(inputType);
+  auto resultBits = getStorageBits(resultType);
+  if (!inputBits || !resultBits)
+    return emitOpError("requires integer or floating-point vreg element type");
+  if (*inputBits != *resultBits) {
+    return emitOpError("requires source and result vectors to carry the same "
+                       "total number of bits");
+  }
+
+  return success();
+}
+
 LogicalResult PdintlvB8Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getLhs().getType(),
                                                "lhs type", "b8")) ||

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -4117,6 +4117,27 @@ private:
   LoweringState &state;
 };
 
+class LowerVbitcastOpPattern final
+    : public OpConversionPattern<pto::VbitcastOp> {
+public:
+  explicit LowerVbitcastOpPattern(TypeConverter &typeConverter,
+                                  MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::VbitcastOp>(typeConverter, context) {}
+
+  LogicalResult
+  matchAndRewrite(pto::VbitcastOp op, pto::VbitcastOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to convert vbitcast result type");
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, resultType,
+                                                 adaptor.getInput());
+    return success();
+  }
+};
+
 class LowerVtrcOpPattern final : public OpConversionPattern<pto::VtrcOp> {
 public:
   explicit LowerVtrcOpPattern(TypeConverter &typeConverter, MLIRContext *context,
@@ -4872,6 +4893,7 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerVpreluOpPattern, LowerVaxpyOpPattern,
                LowerVciOpPattern, LowerVexpdiffOpPattern,
                LowerVbitsortOpPattern, LowerVtrcOpPattern, LowerVcvtOpPattern,
+               LowerVbitcastOpPattern,
                LowerPredicateLoadOpPattern<pto::PldiOp>,
                LowerPredicateLoadOpPattern<pto::PldsOp>,
                LowerPredicateStoreOpPattern<pto::PstiOp>,
@@ -4930,6 +4952,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::VintlvOp, pto::VdintlvOp, pto::VpreluOp,
                       pto::VaxpyOp, pto::VciOp, pto::VexpdiffOp,
                       pto::VbitsortOp, pto::VtrcOp, pto::VcvtOp,
+                      pto::VbitcastOp,
                       pto::VcmpOp, pto::VcmpsOp,
                       pto::CopyGmToUbufOp, pto::CopyUbufToGmOp>();
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });

--- a/test/basic/vbitcast_vpto_llvm.pto
+++ b/test/basic/vbitcast_vpto_llvm.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vbitcast_f32_to_i32_store(%value: f32, %dst: !pto.ptr<i32, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %vec = pto.vdup %value, %mask : f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+      %cast = pto.vbitcast %vec : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+      pto.vsts %cast, %dst[%c0], %mask : !pto.vreg<64xi32>, !pto.ptr<i32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+
+  func.func @vbitcast_f32_to_i16x128_store(%value: f32, %dst: !pto.ptr<i16, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask_f32 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %mask_i16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %vec = pto.vdup %value, %mask_f32 : f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+      %cast = pto.vbitcast %vec : !pto.vreg<64xf32> -> !pto.vreg<128xi16>
+      pto.vsts %cast, %dst[%c0], %mask_i16 : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @vbitcast_f32_to_i32_store(
+// CHECK: %[[VDUP0:[^ ]+]] = call <64 x float> @llvm.hivm.vdups.v64f32.z(
+// CHECK: %[[CAST0:[^ ]+]] = bitcast <64 x float> %[[VDUP0]] to <64 x i32>
+// CHECK: call void @llvm.hivm.vstsx1.v64s32(
+
+// CHECK-LABEL: define void @vbitcast_f32_to_i16x128_store(
+// CHECK: %[[VDUP1:[^ ]+]] = call <64 x float> @llvm.hivm.vdups.v64f32.z(
+// CHECK: %[[CAST1:[^ ]+]] = bitcast <64 x float> %[[VDUP1]] to <128 x i16>
+// CHECK: call void @llvm.hivm.vstsx1.v128s16(

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -102,6 +102,56 @@ lanes1 = pto.elements_per_vreg(pto.f32)  # 64
 Current TileLang DSL v1 vector lowering supports the 8/16/32-bit integer
 families (`i*`, `si*`, `ui*`) plus `f16`, `bf16`, and `f32` element types.
 
+### Vector Type Reinterpretation (vbitcast)
+
+Vector registers support bitwise type reinterpretation via `pto.vbitcast`:
+
+```python
+result = pto.vbitcast(vector, to_type)
+```
+
+Interface summary:
+- `vector`: a vector register value of type `!pto.vreg<NxT0>`
+- `to_type`: target element dtype such as `pto.i32`, `pto.ui32`, `pto.f16`, `pto.bf16`, `pto.f32`
+- return: a new vector register `!pto.vreg<MxT1>` whose element count is inferred from the fixed 256-byte vreg width
+
+Constraints:
+- `vector` must be a vreg value; scalar values, pointers, `Tile`, and `TensorView` are rejected
+- `to_type` must be a DSL-supported vreg element dtype
+- `vbitcast` preserves the total register storage size, so only reinterpretations with the same total bit count are allowed
+- the operation has no mask, rounding, saturation, or lane-placement parameters
+
+Lane count is recomputed from `to_type`:
+- `!pto.vreg<64xf32> + pto.i32 -> !pto.vreg<64xi32>`
+- `!pto.vreg<64xf32> + pto.f16 -> !pto.vreg<128xf16>`
+- `!pto.vreg<128xbf16> + pto.ui16 -> !pto.vreg<128xui16>`
+
+```python
+# Float to integer bitwise reinterpretation
+fvec = pto.vlds(ub_ptr, lane)  # !pto.vreg<64xf32>
+ivec = pto.vbitcast(fvec, pto.i32)      # !pto.vreg<64xi32>
+
+# Signed to unsigned integer reinterpretation
+signed_vec = pto.vlds(ptr, lane)     # !pto.vreg<64xsi32>
+unsigned_vec = pto.vbitcast(signed_vec, pto.ui32)  # !pto.vreg<64xui32>
+
+# Element size change (32-bit to 16-bit)
+f32_vec = pto.vlds(ptr, lane)    # !pto.vreg<64xf32>
+f16_vec = pto.vbitcast(f32_vec, pto.f16)  # !pto.vreg<128xf16>
+```
+
+Pythonic syntax sugar via `astype()` method:
+
+```python
+ivec = fvec.astype(pto.i32)          # Float to integer
+unsigned_vec = signed_vec.astype(pto.ui32)  # Signed to unsigned
+f16_vec = f32_vec.astype(pto.f16)    # 32-bit to 16-bit
+```
+
+`astype()` on a vector register is syntax sugar for `pto.vbitcast(...)`. In other words, it is a bit reinterpretation API, not a numeric conversion API.
+
+**Note**: `vbitcast` preserves the exact bit pattern (type punning), unlike `vcvt` which performs value conversion with rounding/saturation. Use `vcvt` when you want numeric conversion semantics; use `vbitcast` when you want the bits to stay unchanged.
+
 ### Typed Masks
 
 Masks are typed by their bit granularity:

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -820,6 +820,7 @@ _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
     "vtrc": frozenset({"rnd"}),
     "vlds": frozenset({"dist"}),
     "vsts": frozenset({"dist"}),
+    "vbitcast": frozenset(),
 }
 
 

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -423,6 +423,19 @@ class _KernelBodyValidator(ast.NodeVisitor):
                     node,
                     "surface `as_ptr` requires advanced=True in TileLang DSL v1",
                 )
+            if node.func.attr == "astype":
+                if node.keywords:
+                    raise self.source_info.error(
+                        node,
+                        "`astype` does not support keyword arguments in TileLang DSL v1",
+                    )
+                if len(node.args) != 1:
+                    raise self.source_info.error(
+                        node,
+                        "`astype()` expects exactly 1 positional argument (target dtype) in TileLang DSL v1",
+                    )
+                # Type checking will be done during semantic analysis
+                return
             if node.func.value.id == "pto" and node.func.attr == "tpl":
                 self._validate_call_keywords(node)
                 return

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2916,6 +2916,15 @@ class _AuthoringRenderer:
             )
             return _RenderedValue(name=result_name, type=expr.type)
 
+        if expr.name == "vbitcast":
+            value = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            into.append(
+                self._indent(indent)
+                + f"{result_name} = pto.vbitcast {value.name} : "
+                + f"{self._render_type(value.type)} -> {self._render_type(expr.type)}"
+            )
+            return _RenderedValue(name=result_name, type=expr.type)
+
         if expr.name == "vbitsort":
             destination = self._lower_expr(expr.args[0], env, indent=indent, into=into)
             source = self._lower_expr(expr.args[1], env, indent=indent, into=into)

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3089,6 +3089,17 @@ class _SemanticAnalyzer:
                     for arg in expr.args[1:]
                 )
                 return self._analyze_eval_method(base, args)
+            if expr.namespace is None and expr.name == "astype":
+                if expr.keywords:
+                    raise TypeError("method call `astype` does not support keyword arguments in TileLang DSL v1")
+                if not expr.args:
+                    raise TypeError("`astype()` expects a receiver in TileLang DSL v1")
+                base = self._analyze_expr(expr.args[0], env, allow_outer_lookup=allow_outer_lookup)
+                args = tuple(
+                    self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                    for arg in expr.args[1:]
+                )
+                return self._analyze_astype_method(base, args)
             if expr.namespace not in {None, "pto"} and expr.name == "eval":
                 if expr.keywords:
                     raise TypeError("method call `eval` does not support keyword arguments in TileLang DSL v1")
@@ -3117,6 +3128,22 @@ class _SemanticAnalyzer:
                     )
                 base = SemanticBindingRef(binding=binding, type=binding.type)
                 return self._analyze_as_ptr_method(base)
+            if expr.namespace not in {None, "pto"} and expr.name == "astype":
+                if expr.keywords:
+                    raise TypeError("method call `astype` does not support keyword arguments in TileLang DSL v1")
+                binding = env.get(expr.namespace)
+                if binding is None:
+                    if allow_outer_lookup:
+                        raise ValueError(f"unknown name '{expr.namespace}'")
+                    raise ValueError(
+                        f"implicit capture of '{expr.namespace}' is not allowed in pto.strict_vecscope"
+                    )
+                base = SemanticBindingRef(binding=binding, type=binding.type)
+                args = tuple(
+                    self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                    for arg in expr.args
+                )
+                return self._analyze_astype_method(base, args)
             if expr.namespace == "pto" and expr.name == "vlds":
                 return self._analyze_vlds_frontend_call(
                     expr,
@@ -3545,6 +3572,23 @@ class _SemanticAnalyzer:
             )
         raise TypeError("`as_ptr()` expects a TensorView/PartitionTensorView or Tile value in TileLang DSL v1")
 
+    def _analyze_astype_method(self, base: SemanticExpr, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
+        """Analyze vreg.astype(dtype) method call."""
+        if len(args) != 1:
+            raise TypeError("`astype()` expects exactly 1 positional argument (target dtype) in TileLang DSL v1")
+        # Verify target dtype is a valid dtype symbol
+        target_dtype = self._require_dtype_symbol(args[0], "astype target dtype")
+        # Verify base is a vector register
+        if not isinstance(base.type, SemanticVRegType):
+            raise TypeError("`astype()` expects a vector register value in TileLang DSL v1")
+        # Convert to pto.vbitcast call, pass original dtype expression as second argument
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vbitcast",
+            args=(base, args[0]),
+            type=self._vreg_type_for_dtype(target_dtype),
+        )
+
     def _valid_shape_expr(self, base: SemanticExpr) -> SemanticExpr:
         base_type = base.type
         if not isinstance(base_type, (SemanticTensorViewType, SemanticPartitionTensorViewType, SemanticTileType)):
@@ -3898,6 +3942,8 @@ class _SemanticAnalyzer:
             return self._analyze_rearrangement_op(name, args)
         if name == "vcvt":
             return self._analyze_vcvt(args)
+        if name == "vbitcast":
+            return self._analyze_vbitcast(args)
         if name == "vtrc":
             return self._analyze_vtrc(args)
         if name == "vbitsort":
@@ -4977,6 +5023,22 @@ class _SemanticAnalyzer:
                 else SemanticLiteralExpr(value="R", type=SemanticMetaType(kind="string")),
             ),
             type=vector,
+        )
+
+    def _analyze_vbitcast(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
+        if len(args) != 2:
+            raise TypeError("pto.vbitcast expects exactly 2 positional arguments in TileLang DSL")
+        vector = self._require_vreg_expr(args[0], "pto.vbitcast vector")
+        target_dtype = self._require_dtype_symbol(args[1], "pto.vbitcast to_type")
+        # No mask for vbitcast (pure type conversion)
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vbitcast",
+            args=(
+                args[0],
+                args[1],
+            ),
+            type=self._vreg_type_for_dtype(target_dtype),
         )
 
     def _analyze_vbitsort(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -142,6 +142,7 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
         "vsort32",
         "vmrgsort",
         "vcvt",
+        "vbitcast",
         "vci",
     }
 )

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3124,6 +3124,138 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("does not accept `part=`", str(ctx.exception))
 
+    def test_vbitcast_supports_direct_interface(self) -> None:
+        @pto.vkernel(
+            op="vbitcast_direct_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            # Load float vector
+            fvec = pto.vlds(src, 0)  # !pto.vreg<64xf32>
+            # Convert to integer via vbitcast
+            ivec = pto.vbitcast(fvec, pto.i32)  # !pto.vreg<64xi32>
+            # Convert back to float
+            fvec2 = pto.vbitcast(ivec, pto.f32)  # !pto.vreg<64xf32>
+            # Store result
+            pto.vsts(fvec2, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vbitcast", text)
+        self.assertRegex(text, r"= pto\.vbitcast %[^:]+ : !pto\.vreg<64xf32> -> !pto\.vreg<64xi32>")
+        self.assertRegex(text, r"= pto\.vbitcast %[^:]+ : !pto\.vreg<64xi32> -> !pto\.vreg<64xf32>")
+
+    def test_vbitcast_supports_astype_syntax_sugar(self) -> None:
+        @pto.vkernel(
+            op="vbitcast_astype_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            # Load float vector
+            fvec = pto.vlds(src, 0)  # !pto.vreg<64xf32>
+            # Convert to integer via astype syntax sugar
+            ivec = fvec.astype(pto.i32)  # !pto.vreg<64xi32>
+            # Convert back to float
+            fvec2 = ivec.astype(pto.f32)  # !pto.vreg<64xf32>
+            # Store result
+            pto.vsts(fvec2, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vbitcast", text)
+        # astype calls should be lowered to vbitcast
+        count = text.count("pto.vbitcast")
+        self.assertGreaterEqual(count, 2)
+
+    def test_vbitcast_rejects_non_vreg_input(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            @pto.vkernel(
+                op="vbitcast_non_vreg_input_unique",
+                dtypes=[(pto.f32, pto.f32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+                # Try to vbitcast a non-vector value
+                scalar = pto.f32(1.0)
+                ivec = pto.vbitcast(scalar, pto.i32)
+                pto.vsts(ivec, dst, 0, all_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("vector register value", str(ctx.exception))
+
+    def test_astype_requires_vector_register(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            @pto.vkernel(
+                op="astype_non_vreg_input_unique",
+                dtypes=[(pto.f32, pto.f32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                # Try to call astype on a non-vector value
+                scalar = pto.f32(1.0)
+                ivec = scalar.astype(pto.i32)
+                all_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+                pto.vsts(ivec, dst, 0, all_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("vector register value", str(ctx.exception))
+
+    def test_vbitcast_supports_element_size_change(self) -> None:
+        @pto.vkernel(
+            op="vbitcast_element_size_change_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            f32_mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            f16_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+            # Load f32 vector (64 elements)
+            f32_vec = pto.vlds(src, 0)  # !pto.vreg<64xf32>
+            # Convert to f16 (128 elements)
+            f16_vec = pto.vbitcast(f32_vec, pto.f16)  # !pto.vreg<128xf16>
+            # Convert back to f32
+            f32_vec2 = pto.vbitcast(f16_vec, pto.f32)  # !pto.vreg<64xf32>
+            # Store result
+            pto.vsts(f32_vec2, dst, 0, f32_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vbitcast", text)
+        self.assertRegex(text, r"= pto\.vbitcast %[^:]+ : !pto\.vreg<64xf32> -> !pto\.vreg<128xf16>")
+        self.assertRegex(text, r"= pto\.vbitcast %[^:]+ : !pto\.vreg<128xf16> -> !pto\.vreg<64xf32>")
+
     def test_index_to_float_scalar_cast_lowers_via_integer_bridge(self) -> None:
         @pto.vkernel(
             op="index_to_float_scalar_cast_unique",


### PR DESCRIPTION
## Summary

This PR adds end-to-end `vbitcast` support across VPTO IR and TileLang DSL.

The change covers:
- VPTO `pto.vbitcast` op definition, verification, and LLVM lowering
- TileLang DSL surface `pto.vbitcast(vector, dtype)`
- Pythonic syntax sugar `vreg.astype(dtype)` lowering to `pto.vbitcast`
- user-facing documentation updates for `vbitcast`
- DSL tests for positive and negative cases

## What Changed

### IR / backend
- add VPTO `pto.vbitcast` op
- verify that input/result are `!pto.vreg<...>` and carry the same total bit width
- lower `pto.vbitcast` to LLVM bitcast in the VPTO LLVM emitter

### TileLang DSL
- add `vbitcast` to the supported vecscope call surface
- add frontend keyword validation entry for `vbitcast`
- add semantic analysis for `pto.vbitcast(vector, dtype)`
- add `vreg.astype(dtype)` and lower it as `pto.vbitcast`
- infer destination vreg lane count from the target dtype while preserving fixed vreg storage width

### Docs
- add ISA docs for `pto.vbitcast`
- complete TileLang type-system docs with:
  - interface signature
  - parameter / return description
  - constraints and examples
  - clarification that `vbitcast` is bit reinterpretation, while `vcvt` is numeric conversion
- sync the design note with the actual DSL interface shape

### Tests
- add DSL tests covering:
  - direct `pto.vbitcast(...)`
  - `astype()` syntax sugar
  - element-width change such as `f32 -> f16`
  - rejection of non-vreg inputs
- fix test assumptions so they validate actual parameter dtype binding and trigger errors at MLIR generation time

## Notes
- `vbitcast` is a pure bit reinterpretation op and does not take mask / rounding / saturation parameters.
- `astype()` here is intentionally bitcast semantics for vreg values, not value conversion semantics.

## Validation

Executed:
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1 -k vbitcast`
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_astype_requires_vector_register`

Close #88 
