### PR TITLE
test(tilelang_st): add self-hosted runner batch entrypoint

### DIFF
--- a/test/tilelang_st/script/run_all_st.py
+++ b/test/tilelang_st/script/run_all_st.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Batch runner for TileLang ST, suitable for CI/self-hosted runner usage."""
+
+import argparse
+import os
+import sys
+import traceback
+
+import run_st
+
+
+SOC_VERSION_MAP = {
+    "a5": "Ascend950PR_9599",
+}
+
+
+def discover_testcases(testcase_root):
+    testcases = []
+    for entry in sorted(os.listdir(testcase_root)):
+        testcase_dir = os.path.join(testcase_root, entry)
+        if not os.path.isdir(testcase_dir):
+            continue
+        pto_file = os.path.join(testcase_dir, f"{entry}.pto")
+        if os.path.isfile(pto_file):
+            testcases.append(entry)
+    return testcases
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run all TileLang ST testcases for CI or local batch validation."
+    )
+    parser.add_argument(
+        "-r", "--run-mode", default="sim",
+        help="Run mode: sim or npu (default: sim)",
+    )
+    parser.add_argument(
+        "-v", "--soc-version", default="a5",
+        help="SoC version: a5 (default: a5)",
+    )
+    parser.add_argument(
+        "-p", "--ptoas-bin", default=None,
+        help="Path to ptoas binary (auto-detected if omitted)",
+    )
+    parser.add_argument(
+        "-t", "--testcase", action="append", default=[],
+        help="Run only selected testcase(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "-w", "--without-build", action="store_true",
+        help="Skip build and reuse the existing build directory.",
+    )
+    parser.add_argument(
+        "--fail-fast", action="store_true",
+        help="Stop immediately after the first failed testcase.",
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List discovered testcases and exit.",
+    )
+    return parser.parse_args()
+
+
+def resolve_selected_testcases(all_testcases, requested):
+    if not requested:
+        return all_testcases
+
+    requested_set = []
+    seen = set()
+    for testcase in requested:
+        if testcase not in seen:
+            requested_set.append(testcase)
+            seen.add(testcase)
+
+    missing = [testcase for testcase in requested_set if testcase not in all_testcases]
+    if missing:
+        raise ValueError(
+            f"Unsupported testcase(s): {', '.join(missing)}; "
+            f"supported: {', '.join(all_testcases)}"
+        )
+    return requested_set
+
+
+def main():
+    args = parse_args()
+
+    if args.soc_version not in SOC_VERSION_MAP:
+        print(
+            f"[ERROR] Unsupported soc-version: {args.soc_version}, "
+            f"supported: {', '.join(sorted(SOC_VERSION_MAP))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    script_path = os.path.abspath(__file__)
+    tilelang_st_root = os.path.dirname(os.path.dirname(script_path))
+    testcase_root = os.path.join(
+        tilelang_st_root, "npu", args.soc_version, "src", "st", "testcase"
+    )
+    target_dir = os.path.dirname(testcase_root)
+
+    if not os.path.isdir(testcase_root):
+        print(f"[ERROR] Testcase root not found: {testcase_root}", file=sys.stderr)
+        sys.exit(1)
+
+    all_testcases = discover_testcases(testcase_root)
+    if not all_testcases:
+        print(f"[ERROR] No testcases found in: {testcase_root}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.list:
+        for testcase in all_testcases:
+            print(testcase)
+        return
+
+    try:
+        selected_testcases = resolve_selected_testcases(all_testcases, args.testcase)
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    ptoas_bin = args.ptoas_bin or run_st.find_ptoas_bin()
+    if not ptoas_bin:
+        print(
+            "[ERROR] Cannot find ptoas binary. Set PTOAS_BIN env or use -p flag.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    ptoas_bin = os.path.abspath(ptoas_bin)
+
+    default_soc_version = SOC_VERSION_MAP[args.soc_version]
+    print(f"[INFO] run_mode={args.run_mode}")
+    print(f"[INFO] soc_version={args.soc_version} ({default_soc_version})")
+    print(f"[INFO] ptoas={ptoas_bin}")
+    print(f"[INFO] target_dir={target_dir}")
+    print(f"[INFO] selected_testcases={', '.join(selected_testcases)}")
+
+    original_dir = os.getcwd()
+    failures = []
+    try:
+        os.chdir(target_dir)
+        run_st.set_env_variables(args.run_mode, default_soc_version)
+
+        if not args.without_build:
+            build_target = "all" if selected_testcases == all_testcases else ";".join(selected_testcases)
+            print(f"[INFO] build requested for {build_target}")
+            run_st.build_project(args.run_mode, default_soc_version, "all", ptoas_bin)
+
+        total = len(selected_testcases)
+        for index, testcase in enumerate(selected_testcases, start=1):
+            print(f"[INFO] [{index}/{total}] running testcase: {testcase}")
+            try:
+                run_st.run_gen_data(testcase)
+                run_st.run_binary(testcase)
+                run_st.run_compare(testcase)
+            except Exception as exc:  # pragma: no cover - CI-side aggregation path
+                failures.append((testcase, str(exc)))
+                print(f"[ERROR] testcase failed: {testcase}")
+                traceback.print_exc()
+                if args.fail_fast:
+                    break
+
+    except Exception as exc:
+        print(f"[ERROR] batch run failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        os.chdir(original_dir)
+
+    passed = len(selected_testcases) - len(failures)
+    print("[INFO] TileLang ST summary")
+    print(f"[INFO] passed={passed} failed={len(failures)} total={len(selected_testcases)}")
+    if failures:
+        for testcase, reason in failures:
+            print(f"[INFO] failed testcase: {testcase} ({reason})")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/script/run_ci.sh
+++ b/test/tilelang_st/script/run_ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/scripts/ptoas_env.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${REPO_ROOT}/scripts/ptoas_env.sh"
+fi
+
+export PYTHONUNBUFFERED=1
+
+exec python3 "${SCRIPT_DIR}/run_all_st.py" "$@"


### PR DESCRIPTION
## Summary
- add a batch TileLang ST runner that discovers and executes all testcases
- add a CI-friendly shell entrypoint for self-hosted GitHub runners
- reuse the existing TileLang ST build/run/compare flow and emit a final summary

## Validation
- python3 test/tilelang_st/script/run_all_st.py --list
- python3 -m py_compile test/tilelang_st/script/run_all_st.py test/tilelang_st/script/run_st.py
- bash -n test/tilelang_st/script/run_ci.sh
- test/tilelang_st/script/run_ci.sh --list