### PR TITLE
fix(tilelang-dsl): emit signless arith constants for unsigned scalars

### DIFF
--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -424,6 +424,26 @@ rank = tile.rank                      # 2
 - `tile.pad_value.eval()` with `PadValue.custom_f32(...)` becomes the authored floating scalar
 - `tile.pad_value.eval()` with `PadValue.NULL` raises a frontend error
 
+For dtype-dependent fill seeds, prefer `tile.pad_value.eval()` over handwritten
+`if dtype == ...` ladders.
+
+```python
+@pto.vkernel(op="fill_pad_value", dtypes=[(pto.AnyType,)])
+def fill_pad_value(dst: pto.Tile):
+    pad_scalar = dst.pad_value.eval()
+    pad_vec = pto.vbr(pad_scalar)
+    # ...
+```
+
+Typical materialized values:
+
+- `PadValue.ZERO` -> `0` / `0.0`
+- `PadValue.MAX` -> dtype-aware max, for example `4294967295` for `pto.ui32`
+- `PadValue.MIN` -> dtype-aware min, for example `-2147483648` for `pto.i32` and `0` for `pto.ui32`
+
+This is usually simpler than spelling every dtype case manually with
+`pto.constexpr(dst.element_type == ...)`.
+
 Example: reading pad value from a `Tile`
 
 ```python

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2455,7 +2455,7 @@ class _AuthoringRenderer:
                 into.append(
                     self._indent(indent)
                     + f"{desired_name} = arith.constant {self._format_constant(expr.value, expr.type)} : "
-                    f"{self._render_type(expr.type)}"
+                    f"{self._render_arith_constant_type(expr.type)}"
                 )
                 return _RenderedValue(name=desired_name, type=expr.type)
             return _RenderedValue(
@@ -3525,7 +3525,7 @@ class _AuthoringRenderer:
             into.append(
                 self._indent(indent)
                 + f"{desired_name} = arith.constant {self._format_constant(value, expr.type)} : "
-                f"{self._render_type(expr.type)}"
+                f"{self._render_arith_constant_type(expr.type)}"
             )
             return _RenderedValue(name=desired_name, type=expr.type)
         return _RenderedValue(
@@ -3652,7 +3652,8 @@ class _AuthoringRenderer:
         self._constant_cache[cache_key] = name
         self._constant_lines.append(
             self._indent(4)
-            + f"{name} = arith.constant {self._format_constant(value, ty)} : {self._render_type(ty)}"
+            + f"{name} = arith.constant {self._format_constant(value, ty)} : "
+            f"{self._render_arith_constant_type(ty)}"
         )
         return name
 
@@ -3695,6 +3696,16 @@ class _AuthoringRenderer:
                 return "1" if value else "0"
             return str(value)
         raise NotImplementedError(f"unsupported constant type {ty!r}")
+
+    def _render_arith_constant_type(self, ty: SemanticType) -> str:
+        if isinstance(ty, SemanticScalarType) and is_integer_dtype(ty.dtype):
+            width = integer_bitwidth(ty.dtype)
+            if width is None:
+                raise NotImplementedError(
+                    f"unsupported integer dtype {ty.dtype.name!r} for arith.constant emission"
+                )
+            return f"i{width}"
+        return self._render_type(ty)
 
     def _format_float_constant(self, value: float, dtype_name: str) -> str:
         # Emit stable bit-pattern literals for values that are parse-sensitive

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2352,6 +2352,30 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("PadValue.NULL.eval() is invalid", str(ctx.exception))
 
+    def test_unsigned_integer_constants_lower_with_signless_arith_types(self) -> None:
+        @pto.vkernel(op="tile_pad_value_ui32_max_eval_unique", dtypes=[(pto.ui32,)])
+        def kernel(tile: pto.Tile):
+            scalar = tile.pad_value.eval()
+            explicit = pto.ui32(4294967295)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "pad_value": pto.PadValue.MAX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("dtype=ui32", text)
+        self.assertIn("arith.constant 4294967295 : i32", text)
+        self.assertNotIn("arith.constant 4294967295 : ui32", text)
+
 
     def test_make_mask_vlds_vsts_and_vector_families_lower_inside_strict_vecscope(self) -> None:
         @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.f32)], advanced=True)
@@ -2523,7 +2547,8 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         text = specialized.mlir_text()
         self.assertRegex(text, r"= arith\.floordivsi %in_gate_\d+, %c2_i32 : i32")
         self.assertRegex(text, r"= arith\.remsi %in_gate_\d+, %c7_i32 : i32")
-        self.assertRegex(text, r"= arith\.mulf %tmp_\d+, %c0\.5_f32 : f32")
+        self.assertRegex(text, r"%c0_5_f32 = arith\.constant 0\.5 : f32")
+        self.assertRegex(text, r"= arith\.mulf %tmp_\d+, %c0_5_f32 : f32")
         self.assertRegex(text, r"= arith\.addf %tmp_\d+, %tmp_\d+ : f32")
 
     def test_index_floordiv_lowers_to_divui_instead_of_floordivsi(self) -> None:


### PR DESCRIPTION
## Summary
- emit signless integer types for `arith.constant` when lowering TileLang unsigned scalar literals
- add a regression test for `ui32` pad-value/constant materialization and relax a brittle float-constant assertion
- document the simpler `tile.pad_value.eval()` pattern for dtype-dependent pad seeds

## Repro
- issue: #143
- command: `python test/tilelang_st/script/run_st.py -r sim -v a5 -t tpartmin -c f32_64x64_ful`
- trigger: `pto.ui32(4294967295)` inside the template lowered to an invalid `arith.constant ... : u32`

## Validation
- `PYTHONPATH=build/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_unsigned_integer_constants_lower_with_signless_arith_types tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_scalar_binary_arithmetic_supports_float_and_integer_paths`

Closes #143
