### PR TITLE
fix(tilelang-dsl): support i64 vregs in DSL v1

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -1815,7 +1815,7 @@ class _AuthoringRenderer:
 
     def _mask_granularity_for_dtype(self, dtype: ScalarType) -> str:
         int_bits = integer_bitwidth(dtype)
-        if dtype.name == "f32" or int_bits == 32:
+        if dtype.name == "f32" or int_bits in {32, 64}:
             return "b32"
         if dtype.name in {"f16", "bf16"} or int_bits == 16:
             return "b16"

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -5813,7 +5813,7 @@ class _SemanticAnalyzer:
 
     def _mask_granularity_for_dtype(self, dtype: ScalarType) -> str:
         int_bits = integer_bitwidth(dtype)
-        if dtype.name == "f32" or int_bits == 32:
+        if dtype.name == "f32" or int_bits in {32, 64}:
             return "b32"
         if dtype.name in {"f16", "bf16"} or int_bits == 16:
             return "b16"
@@ -5823,7 +5823,7 @@ class _SemanticAnalyzer:
 
     def _vreg_type_for_dtype(self, dtype: ScalarType) -> SemanticVRegType:
         width = bytewidth(dtype)
-        if width not in {1, 2, 4}:
+        if width not in {1, 2, 4, 8}:
             raise TypeError(f"dtype `{dtype.name}` is not supported by vlds/vsts in TileLang DSL v1")
         return SemanticVRegType(element_dtype=dtype, lanes=256 // width)
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -175,6 +175,7 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.bytewidth(pto.si16), 2)
         self.assertEqual(pto.bytewidth(pto.ui64), 8)
         self.assertEqual(pto.get_lanes(pto.ui32), 64)
+        self.assertEqual(pto.get_lanes(pto.i64), 32)
         self.assertEqual(pto.elements_per_vreg(pto.si8), 256)
         self.assertEqual(repr(pto.align), "align")
 
@@ -2932,6 +2933,43 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             text,
             r"= pto\.vcvt %[^,\s]+(?: \{[^}]+\})? : !pto\.vreg<[^>]+> -> !pto\.vreg<[^>]+>",
         )
+
+    def test_vcvt_i32_to_i64_reuses_b32_mask_and_emits_i64_vreg(self) -> None:
+        @pto.vkernel(
+            op="vcvt_i32_to_i64_unique",
+            dtypes=[(pto.i64, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            src_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+            dst_mask = pto.make_mask(pto.i64, pto.PAT.ALL)
+            vec = pto.vlds(src, 0, dist="UNPK_B32")
+            out = pto.vcvt(
+                vec,
+                pto.i64,
+                src_mask,
+                part=pto.VcvtPartMode.EVEN,
+            )
+            pto.vsts(out, dst, 0, dst_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 32), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        vecscope = next(stmt for stmt in semantic_kernel.body if isinstance(stmt, SemanticVecscopeStmt))
+        store_stmt = next(stmt for stmt in vecscope.body if isinstance(stmt, SemanticVectorStoreStmt))
+        self.assertIsInstance(store_stmt.mask.type, SemanticMaskType)
+        self.assertEqual(store_stmt.mask.type.granularity, "b32")
+
+        text = specialized.mlir_text()
+        self.assertIn("!pto.mask<b32>", text)
+        self.assertIn('dist = "UNPK_B32"', text)
+        self.assertRegex(text, r"!pto\.vreg<32xi64>")
+        self.assertIn('part = "EVEN"', text)
+        self.assertIn("pto.vsts", text)
 
     def test_vtrc_defaults_to_round_nearest(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- allow TileLang DSL v1 to materialize `i64` vector register types and keep their mask granularity on `b32`
- update authoring lowering to treat 64-bit vector families like the existing 32-bit mask path
- add regression coverage for `i32 -> i64` `vcvt`, asserting `!pto.vreg<32xi64>` plus `!pto.mask<b32>`

## Validation
- `PYTHONPATH=tilelang-dsl/python:. python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py -k vcvt_i32_to_i64_reuses_b32_mask_and_emits_i64_vreg`
- `PYTHONPATH=tilelang-dsl/python:. python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py -k package_exports_surface`

## Notes
- This PR intentionally does **not** modify `lib/TileOps/tcvt_template.py`.
- The `tcvt i32 -> i64` template pattern from issue #151 still needs an explicit `NORM_B32` store path and `b32`-slot tail mask accounting; I will leave the recommended DSL form in the linked issue thread.

Refs #151
