### PR TITLE
fix(tilelang-dsl): align vcvt contract and bf16->f16 support

### DIFF
--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -136,6 +136,7 @@ as `32 -> 16` or `16 -> 32` style conversions.
 
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>`
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>`
+- `%dst = pto.vcvt %src, %mask {rnd, sat} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xf16>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 
@@ -182,7 +183,7 @@ per-form entries above as the source of truth.
 | `si64` |  |  |  |  |  |  |  |  |  |  |
 | `f16` | Y | Y |  | Y |  | Y |  |  | Y |  |
 | `f32` |  |  |  | Y |  | Y | Y | Y |  | Y |
-| `bf16` |  |  |  |  |  | Y |  |  | Y |  |
+| `bf16` |  |  |  |  |  | Y |  | Y | Y |  |
 
 ---
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -640,8 +640,10 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
   case VcvtElemKind::F16:
     switch (dst) {
     case VcvtElemKind::F32:
-    case VcvtElemKind::S32:
       return VcvtContract{/*requiresRnd=*/false, /*requiresSat=*/false,
+                          /*requiresPart=*/true};
+    case VcvtElemKind::S32:
+      return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/false,
                           /*requiresPart=*/true};
     case VcvtElemKind::S16:
       return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/true,

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -657,6 +657,9 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
     }
   case VcvtElemKind::BF16:
     switch (dst) {
+    case VcvtElemKind::F16:
+      return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/true,
+                          /*requiresPart=*/false};
     case VcvtElemKind::F32:
       return VcvtContract{/*requiresRnd=*/false, /*requiresSat=*/false,
                           /*requiresPart=*/true};

--- a/lib/PTO/Transforms/PTOToVPTOLowering.cpp
+++ b/lib/PTO/Transforms/PTOToVPTOLowering.cpp
@@ -1747,6 +1747,7 @@ enum class VPTOCvtLoweringKind {
   Vtrc,
   F32ToBF16,
   F16ToF32,
+  BF16ToF16,
   BF16ToF32,
 };
 
@@ -1758,6 +1759,8 @@ static FailureOr<VPTOCvtLoweringKind> classifyA5CvtLowering(Type srcElemType,
     return VPTOCvtLoweringKind::F32ToBF16;
   if (srcElemType.isF16() && dstElemType.isF32())
     return VPTOCvtLoweringKind::F16ToF32;
+  if (srcElemType.isBF16() && dstElemType.isF16())
+    return VPTOCvtLoweringKind::BF16ToF16;
   if (srcElemType.isBF16() && dstElemType.isF32())
     return VPTOCvtLoweringKind::BF16ToF32;
   return failure();
@@ -4756,7 +4759,7 @@ LogicalResult lowerTCVT(TCvtOp op, PatternRewriter &rewriter) {
       classifyA5CvtLowering(contract.elementType, dstElementType);
   if (failed(loweringKind))
     return op.emitOpError(
-        "current tcvt lowering supports only f32->f32, f32->bf16, f16->f32, and bf16->f32");
+        "current tcvt lowering supports only f32->f32, f32->bf16, f16->f32, bf16->f16, and bf16->f32");
 
   FailureOr<StringAttr> roundMode = stringifyA5RoundMode(op, rewriter);
   if (failed(roundMode))
@@ -4856,6 +4859,17 @@ LogicalResult lowerTCVT(TCvtOp op, PatternRewriter &rewriter) {
     Value converted = rewriter.create<pto::VcvtOp>(
         op.getLoc(), dstVecType, loaded.getResult(), StringAttr(),
         StringAttr(), rewriter.getStringAttr("PART_EVEN"));
+    rewriter.create<pto::VstsOp>(
+        op.getLoc(), converted, dstBuffer, offset, StringAttr(),
+        buildAllPredicateMask(rewriter, op.getLoc(), dstElementType));
+    break;
+  }
+  case VPTOCvtLoweringKind::BF16ToF16: {
+    auto loaded =
+        rewriter.create<pto::VldsOp>(op.getLoc(), srcVecType, srcBuffer, offset, StringAttr());
+    Value converted = rewriter.create<pto::VcvtOp>(
+        op.getLoc(), dstVecType, loaded.getResult(), *roundMode,
+        rewriter.getStringAttr("RS_ENABLE"), StringAttr());
     rewriter.create<pto::VstsOp>(
         op.getLoc(), converted, dstBuffer, offset, StringAttr(),
         buildAllPredicateMask(rewriter, op.getLoc(), dstElementType));

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -117,6 +117,7 @@ struct VcvtContract {
   bool requiresSat;
   bool requiresPart;
   unsigned maskBitWidth;
+  bool satBeforeRnd = false;
 };
 
 static Value getI64Constant(OpBuilder &builder, Location loc, uint64_t value) {
@@ -471,6 +472,9 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
     }
   case VcvtElemKind::BF16:
     switch (dst) {
+    case VcvtElemKind::F16:
+      return VcvtContract{"llvm.hivm.vcvtff.bf162f16.x", true, true, false, 16,
+                          true};
     case VcvtElemKind::F32:
       return VcvtContract{"llvm.hivm.vcvtff.bf162f32.x", false, false, true, 16};
     case VcvtElemKind::S32:
@@ -4075,7 +4079,7 @@ public:
     callArgs.push_back(*mask);
     argTypes.push_back((*mask).getType());
 
-    if ((*contract).requiresRnd) {
+    auto appendRndArg = [&]() -> LogicalResult {
       auto roundMode =
           op.getRndAttr() ? parseRoundModeImmediate(*op.getRnd()) : std::nullopt;
       if (!roundMode)
@@ -4083,9 +4087,10 @@ public:
       Value roundValue = getI32Constant(rewriter, op.getLoc(), *roundMode);
       callArgs.push_back(roundValue);
       argTypes.push_back(roundValue.getType());
-    }
+      return success();
+    };
 
-    if ((*contract).requiresSat) {
+    auto appendSatArg = [&]() -> LogicalResult {
       auto saturation =
           op.getSatAttr() ? parseSaturationImmediate(*op.getSat()) : std::nullopt;
       if (!saturation)
@@ -4093,6 +4098,19 @@ public:
       Value satValue = getI32Constant(rewriter, op.getLoc(), *saturation);
       callArgs.push_back(satValue);
       argTypes.push_back(satValue.getType());
+      return success();
+    };
+
+    if ((*contract).satBeforeRnd) {
+      if ((*contract).requiresSat && failed(appendSatArg()))
+        return failure();
+      if ((*contract).requiresRnd && failed(appendRndArg()))
+        return failure();
+    } else {
+      if ((*contract).requiresRnd && failed(appendRndArg()))
+        return failure();
+      if ((*contract).requiresSat && failed(appendSatArg()))
+        return failure();
     }
 
     if ((*contract).requiresPart) {

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1382,6 +1382,14 @@ family.
   A5 `vcvt` type matrix, width-changing packing rules, and attribute-sensitive
   forms, refer to
   [`../vpto_spec/vpto-spec-current.md`](../vpto_spec/vpto-spec-current.md).
+- Attribute requirements are type-pair specific. The DSL enforces the same
+  per-form contract as VPTO, so some pairs require attributes while others
+  reject them.
+- Examples:
+  `f32 -> si32` requires `rnd` and `sat`;
+  `f16 -> si32` requires `rnd` and `part`, and rejects `sat`;
+  `f16 -> f32` requires `part`;
+  `si32 -> f32` requires `rnd`.
 - VPTO does not define a `mask_b64` form. Conversions that produce `si64`
   results still use the typed mask granularity of the source vector family.
 - Width-changing conversions continue to follow VPTO packing semantics even on
@@ -1396,6 +1404,14 @@ vec_f32 = pto.vcvt(vec_f16, pto.f32, mask16)
 
 mask32 = pto.make_mask(pto.f32, PAT.ALL)
 vec_i32 = pto.vcvt(vec_f32, pto.si32, mask32)
+
+vec_i32_wide = pto.vcvt(
+    vec_f16,
+    pto.si32,
+    mask16,
+    rnd=pto.VcvtRoundMode.R,
+    part=pto.VcvtPartMode.EVEN,
+)
 
 vec_f16_narrow = pto.vcvt(
     vec_f32,

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1388,6 +1388,7 @@ family.
 - Examples:
   `f32 -> si32` requires `rnd` and `sat`;
   `f16 -> si32` requires `rnd` and `part`, and rejects `sat`;
+  `bf16 -> f16` requires `rnd` and `sat`;
   `f16 -> f32` requires `part`;
   `si32 -> f32` requires `rnd`.
 - VPTO does not define a `mask_b64` form. Conversions that produce `si64`
@@ -1411,6 +1412,14 @@ vec_i32_wide = pto.vcvt(
     mask16,
     rnd=pto.VcvtRoundMode.R,
     part=pto.VcvtPartMode.EVEN,
+)
+
+vec_f16_from_bf16 = pto.vcvt(
+    vec_bf16,
+    pto.f16,
+    mask16,
+    rnd=pto.VcvtRoundMode.R,
+    sat=pto.VcvtSatMode.SAT,
 )
 
 vec_f16_narrow = pto.vcvt(

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
@@ -4046,6 +4046,7 @@ as `32 -> 16` or `16 -> 32` style conversions.
 
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>`
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>`
+- `%dst = pto.vcvt %src, %mask {rnd, sat} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xf16>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 
@@ -4092,7 +4093,7 @@ per-form entries above as the source of truth.
 | `si64` |  |  |  |  |  |  |  |  |  |  |
 | `f16` | Y | Y |  | Y |  | Y |  |  | Y |  |
 | `f32` |  |  |  | Y |  | Y | Y | Y |  | Y |
-| `bf16` |  |  |  |  |  | Y |  |  | Y |  |
+| `bf16` |  |  |  |  |  | Y |  | Y | Y |  |
 
 ---
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -158,6 +158,7 @@ _VCVT_ATTR_CONTRACTS: dict[tuple[str, str], tuple[bool, bool, bool]] = {
     ("f16", "s16"): (True, True, False),
     ("f16", "s8"): (True, True, True),
     ("f16", "u8"): (True, True, True),
+    ("bf16", "f16"): (True, True, False),
     ("bf16", "f32"): (False, False, True),
     ("bf16", "s32"): (True, True, True),
     ("u8", "f16"): (False, False, True),

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -154,7 +154,7 @@ _VCVT_ATTR_CONTRACTS: dict[tuple[str, str], tuple[bool, bool, bool]] = {
     ("f32", "s64"): (True, True, True),
     ("f32", "s32"): (True, True, False),
     ("f16", "f32"): (False, False, True),
-    ("f16", "s32"): (False, False, True),
+    ("f16", "s32"): (True, False, True),
     ("f16", "s16"): (True, True, False),
     ("f16", "s8"): (True, True, True),
     ("f16", "u8"): (True, True, True),

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3316,6 +3316,125 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn('part = "EVEN"', text)
         self.assertNotIn('sat = "SAT"', text)
 
+    def test_vcvt_bf16_to_f16_requires_rnd_and_sat(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_bf16_to_f16_missing_rnd_unique",
+                dtypes=[(pto.f16, pto.bf16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.bf16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = pto.vcvt(
+                    vec,
+                    pto.f16,
+                    src_mask,
+                    sat=pto.VcvtSatMode.SAT,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("requires explicit `rnd=`", str(ctx.exception))
+
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_bf16_to_f16_missing_sat_unique",
+                dtypes=[(pto.f16, pto.bf16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.bf16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = pto.vcvt(
+                    vec,
+                    pto.f16,
+                    src_mask,
+                    rnd=pto.VcvtRoundMode.R,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("requires explicit `sat=`", str(ctx.exception))
+
+    def test_vcvt_bf16_to_f16_rejects_part(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_bf16_to_f16_part_unique",
+                dtypes=[(pto.f16, pto.bf16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.bf16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = pto.vcvt(
+                    vec,
+                    pto.f16,
+                    src_mask,
+                    rnd=pto.VcvtRoundMode.R,
+                    sat=pto.VcvtSatMode.SAT,
+                    part=pto.VcvtPartMode.EVEN,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("does not accept `part=`", str(ctx.exception))
+
+    def test_vcvt_bf16_to_f16_accepts_rnd_and_sat(self) -> None:
+        @pto.vkernel(
+            op="vcvt_bf16_to_f16_attrs_unique",
+            dtypes=[(pto.f16, pto.bf16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            src_mask = pto.make_mask(pto.bf16, pto.PAT.ALL)
+            dst_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vcvt(
+                vec,
+                pto.f16,
+                src_mask,
+                rnd=pto.VcvtRoundMode.R,
+                sat=pto.VcvtSatMode.SAT,
+            )
+            pto.vsts(out, dst, 0, dst_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vcvt", text)
+        self.assertIn('rnd = "R"', text)
+        self.assertIn('sat = "SAT"', text)
+        self.assertNotIn('part = "EVEN"', text)
+
     def test_vbitcast_supports_direct_interface(self) -> None:
         @pto.vkernel(
             op="vbitcast_direct_unique",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3197,6 +3197,125 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("does not accept `part=`", str(ctx.exception))
 
+    def test_vcvt_f16_to_i32_requires_rnd_and_part(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_f16_to_i32_missing_rnd_unique",
+                dtypes=[(pto.i32, pto.f16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0, dist="UNPK_B16")
+                out = pto.vcvt(
+                    vec,
+                    pto.i32,
+                    src_mask,
+                    part=pto.VcvtPartMode.EVEN,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("requires explicit `rnd=`", str(ctx.exception))
+
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_f16_to_i32_missing_part_unique",
+                dtypes=[(pto.i32, pto.f16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0, dist="UNPK_B16")
+                out = pto.vcvt(
+                    vec,
+                    pto.i32,
+                    src_mask,
+                    rnd=pto.VcvtRoundMode.R,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("requires explicit `part=`", str(ctx.exception))
+
+    def test_vcvt_f16_to_i32_rejects_sat(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="vcvt_f16_to_i32_sat_unique",
+                dtypes=[(pto.i32, pto.f16)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+                dst_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0, dist="UNPK_B16")
+                out = pto.vcvt(
+                    vec,
+                    pto.i32,
+                    src_mask,
+                    rnd=pto.VcvtRoundMode.R,
+                    sat=pto.VcvtSatMode.SAT,
+                    part=pto.VcvtPartMode.EVEN,
+                )
+                pto.vsts(out, dst, 0, dst_mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("does not accept `sat=`", str(ctx.exception))
+
+    def test_vcvt_f16_to_i32_accepts_rnd_and_part(self) -> None:
+        @pto.vkernel(
+            op="vcvt_f16_to_i32_attrs_unique",
+            dtypes=[(pto.i32, pto.f16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+            dst_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0, dist="UNPK_B16")
+            out = pto.vcvt(
+                vec,
+                pto.i32,
+                src_mask,
+                rnd=pto.VcvtRoundMode.R,
+                part=pto.VcvtPartMode.EVEN,
+            )
+            pto.vsts(out, dst, 0, dst_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vcvt", text)
+        self.assertIn('rnd = "R"', text)
+        self.assertIn('part = "EVEN"', text)
+        self.assertNotIn('sat = "SAT"', text)
+
     def test_vbitcast_supports_direct_interface(self) -> None:
         @pto.vkernel(
             op="vbitcast_direct_unique",


### PR DESCRIPTION
## Summary
- align the TileLang DSL `vcvt` contract for `f16 -> si32` with the VPTO spec
- add `bf16 -> f16` `vcvt` support in the TileLang tcvt template path
- sync the new `bf16 -> f16` contract entry into the source ISA doc and the v0.3 release spec
- document the type-pair-specific `vcvt` attribute rules in the user guide
- add DSL regression coverage for required `rnd`/`part` and disallowed `sat`

## Validation
- `PYTHONPATH=tilelang-dsl/python:build/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_vcvt_f16_to_i32_requires_rnd_and_part TileLangDSLDescriptorTests.test_vcvt_f16_to_i32_rejects_sat TileLangDSLDescriptorTests.test_vcvt_f16_to_i32_accepts_rnd_and_part TileLangDSLDescriptorTests.test_vcvt_requires_explicit_required_attrs_for_type_pair TileLangDSLDescriptorTests.test_vcvt_rejects_disallowed_attrs_for_type_pair`

## Scope
- this PR focuses on TileLang DSL contract/template/docs updates and does not change the core VPTO lowering pipeline in `lib/PTO/Transforms`

Closes #152