### PR TITLE
fix(dsl): support PadValue.eval(dtype) in TileLang kernels

### DIFF
--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -382,11 +382,18 @@ pad2 = pto.PadValue.custom_f32("0xBF800000")  # float32 bit pattern for -1.0f
 ```
 
 Notes:
-- `PadValue.encoded` exposes the host-side uint64 payload. `PadValue.value` is intentionally unavailable to avoid confusion with kernel-side `.eval()`.
+- `PadValue.encoded` exposes the host-side uint64 payload. `PadValue.value` is intentionally unavailable to avoid confusion with `.eval(...)` scalar materialization.
 - `PadValue.text` exposes the standard textual spelling for built-ins such as `null` and `zero`.
 - Custom pad values currently model an `f32` payload. In DSL v1, materializing a custom pad into a scalar is only supported for floating tile element dtypes.
 - `PadValue.NULL` does not denote a usable scalar fill constant. Calling `tile.pad_value.eval()` or `tile.config.pad_value.eval()` when the enum is `NULL` is a frontend error.
 - **DMA padding**: When performing GM→UB DMA transfers with padding enabled (via `enable_ub_pad=True` in `pto.copy_gm_to_ubuf`), the pad value must be configured explicitly using `pto.set_mov_pad_val`. Tile `PadValue` descriptors are not automatically translated to hardware register configurations in TileLang DSL v1. See [Pad Fill Semantics](08-sync-dma-operations.md#pad-fill-semantics) for usage details.
+
+Host-side code can materialize a scalar with an explicit dtype:
+
+```python
+pad_max_f32 = pto.PadValue.MAX.eval(pto.f32)
+pad_min_i16 = pto.PadValue.MIN.eval(pto.i16)
+```
 
 #### Tile Shape Concepts
 
@@ -426,6 +433,12 @@ rank = tile.rank                      # 2
 
 For dtype-dependent fill seeds, prefer `tile.pad_value.eval()` over handwritten
 `if dtype == ...` ladders.
+
+For standalone `PadValue` symbols that are not bound to a tile, pass the target dtype explicitly:
+
+```python
+pad_scalar = pto.PadValue.MAX.eval(pto.f32)
+```
 
 ```python
 @pto.vkernel(op="fill_pad_value", dtypes=[(pto.AnyType,)])

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -335,7 +335,7 @@ pto.set_mov_pad_val(pad_value: ScalarType) -> None
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pad_value` | `ScalarType` | Scalar value used for padding. Supported types: `pto.i8`, `pto.i16`, `pto.i32`, `pto.f16`, `pto.bf16`, `pto.f32`. The value's bit pattern is encoded into the hardware pad register. For standard pad values, use `PadValue.eval()` to obtain the appropriate scalar: `0` or `0.0` for `PadValue.ZERO`, dtype-aware maximum for `PadValue.MAX`, dtype-aware minimum for `PadValue.MIN`. |
+| `pad_value` | `ScalarType` | Scalar value used for padding. Supported types: `pto.i8`, `pto.i16`, `pto.i32`, `pto.f16`, `pto.bf16`, `pto.f32`. The value's bit pattern is encoded into the hardware pad register. For standard pad values, use `PadValue.eval(...)` to obtain the appropriate scalar: `0` or `0.0` for `PadValue.ZERO`, dtype-aware maximum for `PadValue.MAX`, dtype-aware minimum for `PadValue.MIN`. |
 
 **Returns**: None (side-effect operation)
 
@@ -379,6 +379,12 @@ if pto.constexpr(pad_desc != pto.PadValue.NULL):
         ub_stride=256,
         enable_ub_pad=True,
     )
+```
+
+Using a standalone `PadValue` with an explicit dtype:
+```python
+pad_scalar = pto.PadValue.MAX.eval(pto.f32)
+pto.set_mov_pad_val(pto.f32(pad_scalar))
 ```
 
 **Important**: You are responsible for ensuring the pad register is properly configured before any `pto.copy_gm_to_ubuf` operation with `enable_ub_pad=True`. The pad register configuration persists until changed by another `pto.set_mov_pad_val` call.

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -398,10 +398,10 @@ class _KernelBodyValidator(ast.NodeVisitor):
                     node,
                     "`eval` does not support keyword arguments in TileLang DSL v1",
                 )
-            if node.args:
+            if len(node.args) > 1:
                 raise self.source_info.error(
                     node,
-                    "`eval()` does not accept positional arguments in TileLang DSL v1",
+                    "`eval()` accepts at most one positional dtype argument in TileLang DSL v1",
                 )
             return
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3503,18 +3503,32 @@ class _SemanticAnalyzer:
             type=SemanticPadValueType(element_dtype=base_type.element_dtype),
         )
 
-    def _pad_value_eval_expr(self, base: SemanticExpr) -> SemanticExpr:
+    def _pad_value_eval_expr(
+        self,
+        base: SemanticExpr,
+        dtype_expr: SemanticExpr | None = None,
+    ) -> SemanticExpr:
         if not isinstance(base.type, SemanticPadValueType):
             raise TypeError("`eval()` expects a PadValue descriptor in TileLang DSL v1")
-        if base.type.element_dtype is None:
+        element_dtype = base.type.element_dtype
+        if dtype_expr is not None:
+            if not (
+                isinstance(dtype_expr, SemanticSymbolExpr)
+                and isinstance(dtype_expr.type, SemanticMetaType)
+                and dtype_expr.type.kind == "dtype"
+                and isinstance(dtype_expr.value, ScalarType)
+            ):
+                raise TypeError("PadValue.eval(dtype) expects a TileLang scalar dtype symbol in TileLang DSL v1")
+            element_dtype = dtype_expr.value
+        if element_dtype is None:
             raise TypeError(
-                "PadValue.eval() requires a Tile-bound or TileConfig-bound pad descriptor with an owning "
-                "Tile element dtype in TileLang DSL v1"
+                "PadValue.eval() requires either a Tile-bound pad descriptor or an explicit dtype argument "
+                "in TileLang DSL v1"
             )
         pad_value = self._try_static_value(base)
         if not isinstance(pad_value, PadValue):
             raise TypeError("PadValue.eval() expects a statically known PadValue enum in TileLang DSL v1")
-        pad_scalar = pad_value.materialize_scalar(base.type.element_dtype)
+        pad_scalar = pad_value.eval(element_dtype)
         if pad_scalar is None:
             raise TypeError(
                 "PadValue.NULL.eval() is invalid in TileLang DSL v1; "
@@ -3522,7 +3536,7 @@ class _SemanticAnalyzer:
             )
         return SemanticLiteralExpr(
             value=pad_scalar,
-            type=SemanticScalarType(dtype=base.type.element_dtype),
+            type=SemanticScalarType(dtype=element_dtype),
         )
 
     def _analyze_eval_method(
@@ -3530,9 +3544,9 @@ class _SemanticAnalyzer:
         base: SemanticExpr,
         args: tuple[SemanticExpr, ...],
     ) -> SemanticExpr:
-        if args:
-            raise TypeError("`eval()` does not accept positional arguments in TileLang DSL v1")
-        return self._pad_value_eval_expr(base)
+        if len(args) > 1:
+            raise TypeError("`eval()` accepts at most one positional dtype argument in TileLang DSL v1")
+        return self._pad_value_eval_expr(base, args[0] if args else None)
 
     def _tile_config_attr_expr(self, base: SemanticExpr, attr: str) -> SemanticExpr:
         config = self._try_static_value(base)

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -287,7 +287,7 @@ class PadValue:
     def value(self) -> int:
         raise AttributeError(
             "PadValue.value is not available; use PadValue.encoded for host-side payload access "
-            "or pad.eval() for Tile-bound scalar materialization"
+            "or pad.eval(...) for scalar materialization"
         )
 
     @property
@@ -312,9 +312,9 @@ class PadValue:
     def as_float32(self) -> float:
         return _float32_from_bits(self.float32_bits)
 
-    def materialize_scalar(self, dtype: ScalarType) -> int | float | None:
+    def eval(self, dtype: ScalarType) -> int | float | None:
         if not isinstance(dtype, ScalarType):
-            raise TypeError("PadValue.materialize_scalar expects a TileLang scalar dtype")
+            raise TypeError("PadValue.eval expects a TileLang scalar dtype")
         if self == PadValue.NULL:
             return None
         if self == PadValue.ZERO:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -205,12 +205,12 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(custom.float32_bits, 0xBF800000)
         self.assertEqual(custom.encoded, pto.PadValue.CustomBase | (0xBF800000 << 32))
         self.assertAlmostEqual(custom.as_float32(), -1.0)
-        self.assertAlmostEqual(custom.materialize_scalar(pto.f32), -1.0)
-        self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.ui16), 0xFFFF)
-        self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.ui16), 0)
-        self.assertEqual(pto.PadValue.MAX.materialize_scalar(pto.i16), 0x7FFF)
-        self.assertEqual(pto.PadValue.MIN.materialize_scalar(pto.i16), -0x8000)
-        self.assertIsNone(pto.PadValue.NULL.materialize_scalar(pto.f16))
+        self.assertAlmostEqual(custom.eval(pto.f32), -1.0)
+        self.assertEqual(pto.PadValue.MAX.eval(pto.ui16), 0xFFFF)
+        self.assertEqual(pto.PadValue.MIN.eval(pto.ui16), 0)
+        self.assertEqual(pto.PadValue.MAX.eval(pto.i16), 0x7FFF)
+        self.assertEqual(pto.PadValue.MIN.eval(pto.i16), -0x8000)
+        self.assertIsNone(pto.PadValue.NULL.eval(pto.f16))
         with self.assertRaises(AttributeError):
             _ = pto.PadValue.ZERO.value
 
@@ -2352,6 +2352,28 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             analyze_frontend_kernel(build_frontend_kernel_node(specialized))
 
         self.assertIn("PadValue.NULL.eval() is invalid", str(ctx.exception))
+
+    def test_standalone_pad_value_eval_accepts_explicit_dtype(self) -> None:
+        @pto.vkernel(op="standalone_pad_value_eval_dtype", dtypes=[(pto.f32,)])
+        def kernel(tile: pto.Tile):
+            scalar = pto.PadValue.MAX.eval(pto.f32)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+            )
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        scalar_assign = semantic_kernel.body[0]
+
+        self.assertIsInstance(scalar_assign, SemanticAssignStmt)
+        self.assertIsInstance(scalar_assign.value, SemanticLiteralExpr)
+        self.assertAlmostEqual(scalar_assign.value.value, pto.PadValue.MAX.eval(pto.f32))
+        self.assertIsInstance(scalar_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(scalar_assign.targets[0].type.dtype, pto.f32)
 
     def test_unsigned_integer_constants_lower_with_signless_arith_types(self) -> None:
         @pto.vkernel(op="tile_pad_value_ui32_max_eval_unique", dtypes=[(pto.ui32,)])


### PR DESCRIPTION
## Summary
- rename the host-side PadValue scalar materialization entrypoint to `PadValue.eval(dtype)`
- extend TileLang DSL v1 frontend/semantic handling so kernels can use standalone pad descriptors like `pto.PadValue.MAX.eval(pto.f32)`
- add regression coverage and a minimal `issue_160_repro.pto` input for the tpartmin case
- update the TileLang DSL docs to recommend the new `eval(dtype)` interface

## Repro
- issue: mouliangyu/PTOAS#160
- minimal repro: `test/dsl/issue_160_repro.pto`
- original failure mode: `unsupported call surface in TileLang DSL v1` while importing a TileLang `pto.tpartmin` template that used `pto.PadValue.MAX.materialize_scalar(pto.f32)`

## Validation
- `PYTHONPATH=/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLPackageTests.test_pad_value_supports_standard_and_custom_payloads tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_tile_config_attributes_bind_as_static_metadata tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_pad_value_eval_requires_non_null_enum tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_standalone_pad_value_eval_accepts_explicit_dtype tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_unsigned_integer_constants_lower_with_signless_arith_types`
- manual expand-helper repro for `pto.tpartmin` with `pto.PadValue.MAX.eval(pto.f32)` now succeeds and emits the expected `arith.constant ... : f32`

Closes mouliangyu/PTOAS#160
