### PR TITLE
fix(dsl): allow PadValue.eval with static dtype bindings

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3513,14 +3513,10 @@ class _SemanticAnalyzer:
             raise TypeError("`eval()` expects a PadValue descriptor in TileLang DSL v1")
         element_dtype = base.type.element_dtype
         if dtype_expr is not None:
-            if not (
-                isinstance(dtype_expr, SemanticSymbolExpr)
-                and isinstance(dtype_expr.type, SemanticMetaType)
-                and dtype_expr.type.kind == "dtype"
-                and isinstance(dtype_expr.value, ScalarType)
-            ):
+            explicit_dtype = self._try_static_value(dtype_expr)
+            if not isinstance(explicit_dtype, ScalarType):
                 raise TypeError("PadValue.eval(dtype) expects a TileLang scalar dtype symbol in TileLang DSL v1")
-            element_dtype = dtype_expr.value
+            element_dtype = explicit_dtype
         if element_dtype is None:
             raise TypeError(
                 "PadValue.eval() requires either a Tile-bound pad descriptor or an explicit dtype argument "

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2375,6 +2375,33 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIsInstance(scalar_assign.targets[0].type, SemanticScalarType)
         self.assertEqual(scalar_assign.targets[0].type.dtype, pto.f32)
 
+    def test_standalone_pad_value_eval_accepts_static_dtype_binding(self) -> None:
+        @pto.vkernel(op="standalone_pad_value_eval_dtype_binding", dtypes=[(pto.f32,)])
+        def kernel(tile: pto.Tile):
+            dtype = tile.element_type
+            scalar = pto.PadValue.MAX.eval(dtype)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+            )
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        dtype_assign, scalar_assign = semantic_kernel.body[:2]
+
+        self.assertIsInstance(dtype_assign, SemanticAssignStmt)
+        self.assertIsInstance(dtype_assign.value, SemanticSymbolExpr)
+        self.assertEqual(dtype_assign.value.value, pto.f32)
+
+        self.assertIsInstance(scalar_assign, SemanticAssignStmt)
+        self.assertIsInstance(scalar_assign.value, SemanticLiteralExpr)
+        self.assertAlmostEqual(scalar_assign.value.value, pto.PadValue.MAX.eval(pto.f32))
+        self.assertIsInstance(scalar_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(scalar_assign.targets[0].type.dtype, pto.f32)
+
     def test_unsigned_integer_constants_lower_with_signless_arith_types(self) -> None:
         @pto.vkernel(op="tile_pad_value_ui32_max_eval_unique", dtypes=[(pto.ui32,)])
         def kernel(tile: pto.Tile):


### PR DESCRIPTION
## Summary
- allow `PadValue.eval(dtype)` to accept any statically resolvable TileLang scalar dtype expression, not just direct symbols like `pto.f32`
- fix the `dtype = dst.element_type; pto.PadValue.MAX.eval(dtype)` pattern used by the `pto.tpartmin` TileLang template
- add a regression test for static dtype bindings and include a minimal `issue_160_repro.pto` / `tpartmin.py` repro pair

## Repro
- issue: mouliangyu/PTOAS#160
- follow-up failure mode after the first fix:
  `PadValue.eval(dtype) expects a TileLang scalar dtype symbol in TileLang DSL v1`
- concrete pattern:
  ```python
  dtype = dst.element_type
  pad_scalar = pto.PadValue.MAX.eval(dtype)
  ```

## Validation
- `PYTHONPATH=/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_standalone_pad_value_eval_accepts_static_dtype_binding`
- manual `expand_helper` repro for `lib/TileOps/tpartmin.py` now succeeds for `f32` 64x64 tiles and emits the expected `arith.constant ... : f32`

Refs mouliangyu/PTOAS#160
