### PR TITLE
fix(ir): allow A5 integer expanddiv ops to pass verifier (#140)

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3443,10 +3443,11 @@ LogicalResult pto::TColExpandAddOp::verify() {
 }
 LogicalResult pto::TColExpandDivOp::verify() {
   auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
+    bool allowIntegerTypes = (targetArch == PTOArch::A5);
     return verifyTColExpandBinaryLikeOp(getOperation(), getSrc0().getType(),
                                         getSrc1().getType(), getDst().getType(),
                                         targetArch, "tcolexpanddiv",
-                                        /*allowIntegerTypes=*/false);
+                                        /*allowIntegerTypes=*/allowIntegerTypes);
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
   auto verifyA5 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A5); };
@@ -8004,7 +8005,7 @@ void mlir::pto::TRowExpandMinOp::print(OpAsmPrinter &p) {
 }
 
 mlir::LogicalResult mlir::pto::TRowExpandDivOp::verify() {
-  auto verifyCommon = [&]() -> LogicalResult {
+  auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
     Type src0Ty = getSrc0().getType();
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
@@ -8021,15 +8022,21 @@ mlir::LogicalResult mlir::pto::TRowExpandDivOp::verify() {
       return emitOpError("expects src0 and src1 to have the same element type");
     if (!isRowMajorTileBuf(dstTy))
       return emitOpError("expects dst to use row-major layout");
-    auto elemTy = getElemTy(src0Ty).dyn_cast<mlir::FloatType>();
-    if (!elemTy || (!elemTy.isF16() && !elemTy.isF32()))
+    Type elem = getElemTy(src0Ty);
+    bool supported =
+        elem.isF16() || elem.isF32() ||
+        (targetArch == PTOArch::A5 &&
+         (elem.isInteger(8) || elem.isInteger(16) || elem.isInteger(32)));
+    if (!supported) {
+      if (targetArch == PTOArch::A5)
+        return emitOpError(
+            "expects A5 trowexpanddiv element type to be i8/i16/i32/f16/f32");
       return emitOpError("expects element type to be f16 or f32");
+    }
     return mlir::success();
   };
-  auto verifyA2A3 = [&]() -> LogicalResult {
-    return verifyCommon();
-  };
-  auto verifyA5 = [&]() -> LogicalResult { return verifyCommon(); };
+  auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
+  auto verifyA5 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A5); };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 

--- a/test/basic/issue522_expanddiv_a5_int_types.pto
+++ b/test/basic/issue522_expanddiv_a5_int_types.pto
@@ -1,0 +1,51 @@
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=A5
+// RUN: not ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @expanddiv_i8() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @expanddiv_i16() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @expanddiv_i32() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A5-LABEL: AICORE void expanddiv_i8()
+// A5-LABEL: AICORE void expanddiv_i16()
+// A5-LABEL: AICORE void expanddiv_i32()
+// A5: TCOLEXPANDDIV(
+// A5: TROWEXPANDDIV(
+
+// A3: error: 'pto.tcolexpanddiv' op expects tcolexpanddiv element type to be f16 or f32


### PR DESCRIPTION
## Summary
- allow A5 `pto.tcolexpanddiv` to accept integer element types in IR verification
- allow A5 `pto.trowexpanddiv` to accept integer element types in IR verification
- add A5 regression coverage for i8/i16/i32 expanddiv cases

## Validation
- verified `test/basic/issue522_expanddiv_a5_int_types.pto` passes on A5 with current branch
- confirmed issue #140 no longer fails in the IR verifier stage and can proceed to `expand_helper` under `--enable-tile-op-expand`

Fixes #140