### PR TITLE
feat(tileop): Add unary tileop templates

### DIFF
--- a/lib/TileOps/tabs_template.py
+++ b/lib/TileOps/tabs_template.py
@@ -1,0 +1,19 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tabs"
+)
+def template_tabs(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vabs(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/tabs_template.py
+++ b/lib/TileOps/tabs_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.tabs"""
+
 import tilelang_dsl as pto
 
 

--- a/lib/TileOps/texp_template.py
+++ b/lib/TileOps/texp_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.texp"""
+
 import tilelang_dsl as pto
 
 # TODO: Add implementation for HIGH_PRECISION type

--- a/lib/TileOps/texp_template.py
+++ b/lib/TileOps/texp_template.py
@@ -1,6 +1,6 @@
 import tilelang_dsl as pto
 
-
+# TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
     op="pto.texp"

--- a/lib/TileOps/texp_template.py
+++ b/lib/TileOps/texp_template.py
@@ -1,0 +1,19 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.texp"
+)
+def template_texp(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vexp(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/tlog_template.py
+++ b/lib/TileOps/tlog_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.tlog"""
+
 import tilelang_dsl as pto
 
 # TODO: Add implementation for HIGH_PRECISION type

--- a/lib/TileOps/tlog_template.py
+++ b/lib/TileOps/tlog_template.py
@@ -1,6 +1,6 @@
 import tilelang_dsl as pto
 
-
+# TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
     op="pto.tlog"

--- a/lib/TileOps/tlog_template.py
+++ b/lib/TileOps/tlog_template.py
@@ -1,0 +1,19 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tlog"
+)
+def template_tlog(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vln(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/tneg_template.py
+++ b/lib/TileOps/tneg_template.py
@@ -1,0 +1,19 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tneg"
+)
+def template_tneg(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vneg(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/tneg_template.py
+++ b/lib/TileOps/tneg_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.tneg"""
+
 import tilelang_dsl as pto
 
 

--- a/lib/TileOps/tnot_template.py
+++ b/lib/TileOps/tnot_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.tnot"""
+
 import tilelang_dsl as pto
 
 

--- a/lib/TileOps/tnot_template.py
+++ b/lib/TileOps/tnot_template.py
@@ -1,0 +1,20 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tnot",
+    dtypes=[(pto.AnyInt, pto.AnyInt)]
+)
+def template_tnot(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vnot(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/trecip_template.py
+++ b/lib/TileOps/trecip_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.trecip"""
+
 import tilelang_dsl as pto
 
 # TODO: Add implementation for HIGH_PRECISION type

--- a/lib/TileOps/trecip_template.py
+++ b/lib/TileOps/trecip_template.py
@@ -1,0 +1,25 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.trecip"
+)
+def template_trecip(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            if pto.constexpr(dtype == pto.f16):
+                one_scalar = pto.f16(1.0)
+            else:
+                one_scalar = pto.f32(1.0)
+            one = pto.vbr(one_scalar)
+            # one = pto.vbr(dtype(1.0))
+            result = pto.vdiv(one, vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/trecip_template.py
+++ b/lib/TileOps/trecip_template.py
@@ -3,7 +3,8 @@ import tilelang_dsl as pto
 # TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
-    op="pto.trecip"
+    op="pto.trecip",
+    dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32)]
 )
 def template_trecip(src: pto.Tile, dst: pto.Tile):
     dtype = dst.element_type

--- a/lib/TileOps/trecip_template.py
+++ b/lib/TileOps/trecip_template.py
@@ -1,6 +1,6 @@
 import tilelang_dsl as pto
 
-
+# TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
     op="pto.trecip"

--- a/lib/TileOps/trsqrt_template.py
+++ b/lib/TileOps/trsqrt_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.trsqrt"""
+
 import tilelang_dsl as pto
 
 # TODO: Add implementation for HIGH_PRECISION type

--- a/lib/TileOps/trsqrt_template.py
+++ b/lib/TileOps/trsqrt_template.py
@@ -1,0 +1,25 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.trsqrt"
+)
+def template_trsqrt(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            if pto.constexpr(dtype == pto.f16):
+                one_scalar = pto.f16(1.0)
+            else:
+                one_scalar = pto.f32(1.0)
+            one = pto.vbr(one_scalar)
+            sqrt_result = pto.vsqrt(vinput, mask)
+            result = pto.vdiv(one, sqrt_result, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/trsqrt_template.py
+++ b/lib/TileOps/trsqrt_template.py
@@ -3,7 +3,8 @@ import tilelang_dsl as pto
 # TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
-    op="pto.trsqrt"
+    op="pto.trsqrt",
+    dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32)]
 )
 def template_trsqrt(src: pto.Tile, dst: pto.Tile):
     dtype = dst.element_type

--- a/lib/TileOps/trsqrt_template.py
+++ b/lib/TileOps/trsqrt_template.py
@@ -1,6 +1,6 @@
 import tilelang_dsl as pto
 
-
+# TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
     op="pto.trsqrt"

--- a/lib/TileOps/tsqrt_template.py
+++ b/lib/TileOps/tsqrt_template.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""TileLang DSL template for pto.tsqrt"""
+
 import tilelang_dsl as pto
 
 # TODO: Add implementation for HIGH_PRECISION type

--- a/lib/TileOps/tsqrt_template.py
+++ b/lib/TileOps/tsqrt_template.py
@@ -1,0 +1,19 @@
+import tilelang_dsl as pto
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tsqrt"
+)
+def template_tsqrt(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            result = pto.vsqrt(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
+    return

--- a/lib/TileOps/tsqrt_template.py
+++ b/lib/TileOps/tsqrt_template.py
@@ -1,6 +1,6 @@
 import tilelang_dsl as pto
 
-
+# TODO: Add implementation for HIGH_PRECISION type
 @pto.vkernel(
     target="a5",
     op="pto.tsqrt"

--- a/test/basic/expand_tile_op_tilelang_tabs.pto
+++ b/test/basic/expand_tile_op_tilelang_tabs.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.tabs should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TABS
+// CHECK-NOT: pto.tabs ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vabs
+// CHECK: pto.vsts
+
+module {
+  func.func @TABS() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tabs ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_texp.pto
+++ b/test/basic/expand_tile_op_tilelang_texp.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.texp should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TEXP
+// CHECK-NOT: pto.texp ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vexp
+// CHECK: pto.vsts
+
+module {
+  func.func @TEXP() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.texp ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_tlog.pto
+++ b/test/basic/expand_tile_op_tilelang_tlog.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.tlog should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TLOG
+// CHECK-NOT: pto.tlog ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vln
+// CHECK: pto.vsts
+
+module {
+  func.func @TLOG() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tlog ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_tneg.pto
+++ b/test/basic/expand_tile_op_tilelang_tneg.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.tneg should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TNEG
+// CHECK-NOT: pto.tneg ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vmuls
+// CHECK: pto.vsts
+
+module {
+  func.func @TNEG() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tneg ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_tnot.pto
+++ b/test/basic/expand_tile_op_tilelang_tnot.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.tnot should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TNOT
+// CHECK-NOT: pto.tnot ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vnot
+// CHECK: pto.vsts
+
+module {
+  func.func @TNOT() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tnot ins(%a: !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_trecip.pto
+++ b/test/basic/expand_tile_op_tilelang_trecip.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.trecip should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TRECIP
+// CHECK-NOT: pto.trecip ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vrec
+// CHECK: pto.vsts
+
+module {
+  func.func @TRECIP() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trecip ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                     blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_trsqrt.pto
+++ b/test/basic/expand_tile_op_tilelang_trsqrt.pto
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.trsqrt should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TRSQRT
+// CHECK-NOT: pto.trsqrt ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vsqrt
+// CHECK: pto.vrec
+// CHECK: pto.vsts
+
+module {
+  func.func @TRSQRT() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trsqrt ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/expand_tile_op_tilelang_tsqrt.pto
+++ b/test/basic/expand_tile_op_tilelang_tsqrt.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+//
+// Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After the full tile-op-expand path on the VPTO backend, the original
+// pto.tsqrt should be lowered to vector-style VPTO IR.
+// CHECK: func.func @TSQRT
+// CHECK-NOT: pto.tsqrt ins
+// CHECK: pto.vecscope
+// CHECK: pto.castptr
+// CHECK: pto.vlds
+// CHECK: pto.vsqrt
+// CHECK: pto.vsts
+
+module {
+  func.func @TSQRT() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_buf = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsqrt ins(%a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%tile_buf: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                           blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -140,6 +140,7 @@ set(ALL_TESTCASES
     tnot
     trecip
     trsqrt
+    tsqrt
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -133,6 +133,7 @@ set(ALL_TESTCASES
     tcvt
     tload
     softmax
+    tabs
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -138,6 +138,7 @@ set(ALL_TESTCASES
     tlog
     tneg
     tnot
+    trecip
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -139,6 +139,7 @@ set(ALL_TESTCASES
     tneg
     tnot
     trecip
+    trsqrt
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -136,6 +136,7 @@ set(ALL_TESTCASES
     tabs
     texp
     tlog
+    tneg
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -134,6 +134,7 @@ set(ALL_TESTCASES
     tload
     softmax
     tabs
+    texp
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ALL_TESTCASES
     texp
     tlog
     tneg
+    tnot
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/CMakeLists.txt
@@ -135,6 +135,7 @@ set(ALL_TESTCASES
     softmax
     tabs
     texp
+    tlog
 )
 
 if((TEST_CASE IN_LIST ALL_TESTCASES) OR (TEST_CASE STREQUAL "all"))

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(tabs)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/cases.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for tabs ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/gen_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    input = np.random.randn(*shape).astype(dtype)
+
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.abs(input[:vr, :vc]).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TABS_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTABS_f32_16x64(void *a, void *b, void *stream) {
+    TABS_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TABS_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTABS_f32_32x32(void *a, void *b, void *stream) {
+    TABS_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TABS_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTABS_f16_16x64(void *a, void *b, void *stream) {
+    TABS_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TABS_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTABS_f16_32x32(void *a, void *b, void *stream) {
+    TABS_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/main.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang tabs ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTABS_f32_16x64(void *a, void *b, void *stream);
+void LaunchTABS_f32_32x32(void *a, void *b, void *stream);
+void LaunchTABS_f16_16x64(void *a, void *b, void *stream);
+void LaunchTABS_f16_32x32(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTABS_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTABS_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTABS_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTABS_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./tabs [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/tabs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/tabs.pto
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.tabs: tload(a) + tabs(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TABS_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tabs ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TABS_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tabs ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TABS_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tabs ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TABS_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tabs ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(texp)

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/cases.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for texp ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/gen_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    input = np.random.randn(*shape).astype(dtype)
+
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.exp(input[:vr, :vc]).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TEXP_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTEXP_f32_16x64(void *a, void *b, void *stream) {
+    TEXP_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TEXP_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTEXP_f32_32x32(void *a, void *b, void *stream) {
+    TEXP_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TEXP_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTEXP_f16_16x64(void *a, void *b, void *stream) {
+    TEXP_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TEXP_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTEXP_f16_32x32(void *a, void *b, void *stream) {
+    TEXP_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/main.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang texp ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTEXP_f32_16x64(void *a, void *b, void *stream);
+void LaunchTEXP_f32_32x32(void *a, void *b, void *stream);
+void LaunchTEXP_f16_16x64(void *a, void *b, void *stream);
+void LaunchTEXP_f16_32x32(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTEXP_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTEXP_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTEXP_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTEXP_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./texp [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/texp.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/texp.pto
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.texp: tload(a) + texp(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TEXP_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.texp ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TEXP_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.texp ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TEXP_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.texp ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TEXP_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.texp ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(tlog)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/cases.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for tlog ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/gen_data.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    # Generate positive random values for log (log requires positive inputs)
+    input = np.random.uniform(0.1, 10.0, size=shape).astype(dtype)
+
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.log(input[:vr, :vc]).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TLOG_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTLOG_f32_16x64(void *a, void *b, void *stream) {
+    TLOG_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TLOG_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTLOG_f32_32x32(void *a, void *b, void *stream) {
+    TLOG_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TLOG_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTLOG_f16_16x64(void *a, void *b, void *stream) {
+    TLOG_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TLOG_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTLOG_f16_32x32(void *a, void *b, void *stream) {
+    TLOG_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/main.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang tlog ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTLOG_f32_16x64(void *a, void *b, void *stream);
+void LaunchTLOG_f32_32x32(void *a, void *b, void *stream);
+void LaunchTLOG_f16_16x64(void *a, void *b, void *stream);
+void LaunchTLOG_f16_32x32(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTLOG_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTLOG_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTLOG_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTLOG_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./tlog [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/tlog.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/tlog.pto
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.tlog: tload(a) + tlog(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TLOG_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tlog ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TLOG_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tlog ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TLOG_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tlog ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TLOG_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tlog ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(tneg)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/cases.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for tneg ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+    {
+        "name": "i32_32x32",
+        "dtype": np.int32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 0,
+    },
+    {
+        "name": "i16_64x16",
+        "dtype": np.int16,
+        "shape": (64, 16),
+        "valid_shape": (64, 16),
+        "eps": 0,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/gen_data.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    # Random values (no constraints for neg)
+    input = np.random.randn(*shape).astype(dtype)
+
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.negative(input[:vr, :vc]).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/launch.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TNEG_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTNEG_f32_16x64(void *a, void *b, void *stream) {
+    TNEG_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TNEG_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTNEG_f32_32x32(void *a, void *b, void *stream) {
+    TNEG_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TNEG_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTNEG_f16_16x64(void *a, void *b, void *stream) {
+    TNEG_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TNEG_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTNEG_f16_32x32(void *a, void *b, void *stream) {
+    TNEG_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 4: i32 32x32
+extern "C" __global__ AICORE void TNEG_i32_32x32(__gm__ int32_t *a, __gm__ int32_t *b);
+
+void LaunchTNEG_i32_32x32(void *a, void *b, void *stream) {
+    TNEG_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b);
+}
+
+// Case 5: i16 64x16
+extern "C" __global__ AICORE void TNEG_i16_64x16(__gm__ int16_t *a, __gm__ int16_t *b);
+
+void LaunchTNEG_i16_64x16(void *a, void *b, void *stream) {
+    TNEG_i16_64x16<<<1, nullptr, stream>>>((__gm__ int16_t *)a, (__gm__ int16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/main.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang tneg ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTNEG_f32_16x64(void *a, void *b, void *stream);
+void LaunchTNEG_f32_32x32(void *a, void *b, void *stream);
+void LaunchTNEG_f16_16x64(void *a, void *b, void *stream);
+void LaunchTNEG_f16_32x32(void *a, void *b, void *stream);
+void LaunchTNEG_i32_32x32(void *a, void *b, void *stream);
+void LaunchTNEG_i16_64x16(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTNEG_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTNEG_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTNEG_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTNEG_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+    {"i32_32x32", LaunchTNEG_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i16_64x16", LaunchTNEG_i16_64x16, 64, 16, 64, 16, sizeof(int16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./tneg [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/tneg.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/tneg.pto
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.tneg: tload(a) + tneg(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TNEG_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TNEG_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TNEG_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TNEG_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+
+  // Case 4: i32 32x32 (1024 elements)
+  func.func @TNEG_i32_32x32(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xi32> -> !pto.partition_tensor_view<1x1x1x32x32xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xi32> -> !pto.partition_tensor_view<1x1x1x32x32xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=i32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
+    return
+  }
+
+  // Case 5: i16 64x16 (1024 elements)
+  func.func @TNEG_i16_64x16(%a_ptr: !pto.ptr<i16>, %b_ptr: !pto.ptr<i16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c16],
+      strides = [%c1024, %c1024, %c1024, %c16, %c1]
+      : !pto.tensor_view<1x1x1x64x16xi16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c16],
+      strides = [%c1024, %c1024, %c1024, %c16, %c1]
+      : !pto.tensor_view<1x1x1x64x16xi16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c16]
+      : !pto.tensor_view<1x1x1x64x16xi16> -> !pto.partition_tensor_view<1x1x1x64x16xi16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c16]
+      : !pto.tensor_view<1x1x1x64x16xi16> -> !pto.partition_tensor_view<1x1x1x64x16xi16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x64x16xi16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tneg ins(%a : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%b : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=16, v_row=64, v_col=16,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x64x16xi16>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(tnot)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/cases.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for tnot ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.int8, np.int16, np.int32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol), 0 for exact match.
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "int8_64x64",   
+        "dtype": np.int8,   
+        "shape": (64, 64), 
+        "valid_shape": (64, 64), 
+        "eps": 0
+    },
+    {
+        "name": "uint8_60x60",  
+        "dtype": np.uint8,  
+        "shape": (64, 64), 
+        "valid_shape": (60, 60), 
+        "eps": 0
+    },
+    {
+        "name": "int16_64x64",  
+        "dtype": np.int16,  
+        "shape": (64, 64), 
+        "valid_shape": (64, 64), 
+        "eps": 0
+    },
+    {
+        "name": "uint16_60x60", 
+        "dtype": np.uint16, 
+        "shape": (64, 64), 
+        "valid_shape": (60, 60), 
+        "eps": 0
+    },
+    {
+        "name": "int32_64x64",  
+        "dtype": np.int32,  
+        "shape": (64, 64), 
+        "valid_shape": (64, 64), 
+        "eps": 0
+    },
+    {
+        "name": "uint32_60x60", 
+        "dtype": np.uint32, 
+        "shape": (64, 64), 
+        "valid_shape": (60, 60), 
+        "eps": 0
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/gen_data.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    dtype_info = np.iinfo(dtype)
+    input = np.random.randint(dtype_info.min, dtype_info.max, size=shape, dtype=dtype)
+    golden = np.bitwise_not(input).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/launch.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: int8 64x64
+extern "C" __global__ AICORE void TNOT_int8_64x64(__gm__ int8_t *a, __gm__ int8_t *b);
+
+void LaunchTNOT_int8_64x64(void *a, void *b, void *stream) {
+    TNOT_int8_64x64<<<1, nullptr, stream>>>((__gm__ int8_t *)a, (__gm__ int8_t *)b);
+}
+
+// Case 1: uint8 60x60
+extern "C" __global__ AICORE void TNOT_uint8_60x60(__gm__ uint8_t *a, __gm__ uint8_t *b);
+
+void LaunchTNOT_uint8_60x60(void *a, void *b, void *stream) {
+    TNOT_uint8_60x60<<<1, nullptr, stream>>>((__gm__ uint8_t *)a, (__gm__ uint8_t *)b);
+}
+
+// Case 2: int16 64x64
+extern "C" __global__ AICORE void TNOT_int16_64x64(__gm__ int16_t *a, __gm__ int16_t *b);
+
+void LaunchTNOT_int16_64x64(void *a, void *b, void *stream) {
+    TNOT_int16_64x64<<<1, nullptr, stream>>>((__gm__ int16_t *)a, (__gm__ int16_t *)b);
+}
+
+// Case 3: uint16 60x60
+extern "C" __global__ AICORE void TNOT_uint16_60x60(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTNOT_uint16_60x60(void *a, void *b, void *stream) {
+    TNOT_uint16_60x60<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 4: int32 64x64
+extern "C" __global__ AICORE void TNOT_int32_64x64(__gm__ int32_t *a, __gm__ int32_t *b);
+
+void LaunchTNOT_int32_64x64(void *a, void *b, void *stream) {
+    TNOT_int32_64x64<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b);
+}
+
+// Case 5: uint32 60x60
+extern "C" __global__ AICORE void TNOT_uint32_60x60(__gm__ uint32_t *a, __gm__ uint32_t *b);
+
+void LaunchTNOT_uint32_60x60(void *a, void *b, void *stream) {
+    TNOT_uint32_60x60<<<1, nullptr, stream>>>((__gm__ uint32_t *)a, (__gm__ uint32_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/main.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang tnot ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTNOT_int8_64x64(void *a, void *b, void *stream);
+void LaunchTNOT_uint8_60x60(void *a, void *b, void *stream);
+void LaunchTNOT_int16_64x64(void *a, void *b, void *stream);
+void LaunchTNOT_uint16_60x60(void *a, void *b, void *stream);
+void LaunchTNOT_int32_64x64(void *a, void *b, void *stream);
+void LaunchTNOT_uint32_60x60(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"int8_64x64",   LaunchTNOT_int8_64x64,   64, 64, 64, 64, sizeof(int8_t)},
+    {"uint8_60x60",  LaunchTNOT_uint8_60x60,  64, 64, 60, 60, sizeof(uint8_t)},
+    {"int16_64x64",  LaunchTNOT_int16_64x64,  64, 64, 64, 64, sizeof(int16_t)},
+    {"uint16_60x60", LaunchTNOT_uint16_60x60, 64, 64, 60, 60, sizeof(uint16_t)},
+    {"int32_64x64",  LaunchTNOT_int32_64x64,  64, 64, 64, 64, sizeof(int32_t)},
+    {"uint32_60x60", LaunchTNOT_uint32_60x60, 64, 64, 60, 60, sizeof(uint32_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr) 
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr) 
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr) 
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0) 
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./tnot [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/tnot.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/tnot.pto
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.tnot: tload(a) + tnot(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: int8 64x64 (valid 64x64)
+  func.func @TNOT_int8_64x64(%a_ptr: !pto.ptr<i8>, %b_ptr: !pto.ptr<i8>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi8>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi8>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi8> -> !pto.partition_tensor_view<1x1x1x64x64xi8>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi8> -> !pto.partition_tensor_view<1x1x1x64x64xi8>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x64x64xi8>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=i8, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xi8>)
+    return
+  }
+
+  // Case 1: uint8 64x64 (valid 60x60) - partition_view sizes = valid_shape
+  func.func @TNOT_uint8_60x60(%a_ptr: !pto.ptr<ui8>, %b_ptr: !pto.ptr<ui8>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c60   = arith.constant 60   : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui8>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui8>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui8> -> !pto.partition_tensor_view<1x1x1x60x60xui8>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui8> -> !pto.partition_tensor_view<1x1x1x60x60xui8>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x60x60xui8>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=ui8, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x60x60xui8>)
+    return
+  }
+
+  // Case 2: int16 64x64 (valid 64x64)
+  func.func @TNOT_int16_64x64(%a_ptr: !pto.ptr<i16>, %b_ptr: !pto.ptr<i16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi16> -> !pto.partition_tensor_view<1x1x1x64x64xi16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi16> -> !pto.partition_tensor_view<1x1x1x64x64xi16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x64x64xi16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=i16, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xi16>)
+    return
+  }
+
+  // Case 3: uint16 64x64 (valid 60x60) - partition_view sizes = valid_shape
+  func.func @TNOT_uint16_60x60(%a_ptr: !pto.ptr<ui16>, %b_ptr: !pto.ptr<ui16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c60   = arith.constant 60   : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui16> -> !pto.partition_tensor_view<1x1x1x60x60xui16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui16> -> !pto.partition_tensor_view<1x1x1x60x60xui16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x60x60xui16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=ui16, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x60x60xui16>)
+    return
+  }
+
+  // Case 4: int32 64x64 (valid 64x64)
+  func.func @TNOT_int32_64x64(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi32> -> !pto.partition_tensor_view<1x1x1x64x64xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x64x64xi32> -> !pto.partition_tensor_view<1x1x1x64x64xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x64x64xi32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=i32, rows=64, cols=64, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xi32>)
+    return
+  }
+
+  // Case 5: uint32 64x64 (valid 60x60) - partition_view sizes = valid_shape
+  func.func @TNOT_uint32_60x60(%a_ptr: !pto.ptr<ui32>, %b_ptr: !pto.ptr<ui32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c60   = arith.constant 60   : index
+    %c64   = arith.constant 64   : index
+    %c4096 = arith.constant 4096 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c64, %c64],
+      strides = [%c4096, %c4096, %c4096, %c64, %c1]
+      : !pto.tensor_view<1x1x1x64x64xui32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui32> -> !pto.partition_tensor_view<1x1x1x60x60xui32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c60, %c60]
+      : !pto.tensor_view<1x1x1x64x64xui32> -> !pto.partition_tensor_view<1x1x1x60x60xui32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x60x60xui32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tnot ins(%a : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%b : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=ui32, rows=64, cols=64, v_row=60, v_col=60,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x60x60xui32>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(trecip)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/cases.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for trecip ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f32_64x64_pad",
+        "dtype": np.float32,
+        "shape": (66, 72),
+        "valid_shape": (64, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_58x70",
+        "dtype": np.float32,
+        "shape": (66, 72),
+        "valid_shape": (58, 70),
+        "eps": 1e-6,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/gen_data.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    # Avoid 0 for reciprocal, use range [0.1, 10.0]
+    input = np.random.uniform(0.1, 10.0, size=shape).astype(dtype)
+
+    # reciprocal = 1/x
+    golden = np.reciprocal(input).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/launch.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TRECIP_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRECIP_f32_16x64(void *a, void *b, void *stream) {
+    TRECIP_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TRECIP_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRECIP_f32_32x32(void *a, void *b, void *stream) {
+    TRECIP_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TRECIP_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTRECIP_f16_16x64(void *a, void *b, void *stream) {
+    TRECIP_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TRECIP_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTRECIP_f16_32x32(void *a, void *b, void *stream) {
+    TRECIP_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 4: f32 66x72, valid 64x64 (pad)
+extern "C" __global__ AICORE void TRECIP_f32_64x64_pad(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRECIP_f32_64x64_pad(void *a, void *b, void *stream) {
+    TRECIP_f32_64x64_pad<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 5: f32 66x72, valid 58x70 (non-square valid)
+extern "C" __global__ AICORE void TRECIP_f32_58x70(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRECIP_f32_58x70(void *a, void *b, void *stream) {
+    TRECIP_f32_58x70<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/main.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang trecip ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTRECIP_f32_16x64(void *a, void *b, void *stream);
+void LaunchTRECIP_f32_32x32(void *a, void *b, void *stream);
+void LaunchTRECIP_f16_16x64(void *a, void *b, void *stream);
+void LaunchTRECIP_f16_32x32(void *a, void *b, void *stream);
+void LaunchTRECIP_f32_64x64_pad(void *a, void *b, void *stream);
+void LaunchTRECIP_f32_58x70(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTRECIP_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTRECIP_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTRECIP_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTRECIP_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+    {"f32_64x64_pad", LaunchTRECIP_f32_64x64_pad, 66, 72, 64, 64, sizeof(float)},
+    {"f32_58x70", LaunchTRECIP_f32_58x70, 66, 72, 58, 70, sizeof(float)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost(&srcHost, fileSize);
+    aclrtMallocHost(&dstHost, fileSize);
+
+    aclrtMalloc(&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./trecip [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/trecip.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/trecip.pto
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.trecip: 1/x (reciprocal)
+// trecip = vdiv(1.0, x)
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64
+  func.func @TRECIP_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32
+  func.func @TRECIP_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64
+  func.func @TRECIP_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32
+  func.func @TRECIP_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+
+  // Case 4: f32 66x72, valid 64x64 (pad case)
+  func.func @TRECIP_f32_64x64_pad(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c64   = arith.constant 64   : index
+    %c66   = arith.constant 66   : index
+    %c72   = arith.constant 72   : index
+    %c4752 = arith.constant 4752 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c66, %c72],
+      strides = [%c4752, %c4752, %c4752, %c72, %c1]
+      : !pto.tensor_view<1x1x1x66x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c66, %c72],
+      strides = [%c4752, %c4752, %c4752, %c72, %c1]
+      : !pto.tensor_view<1x1x1x66x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x66x72xf32> -> !pto.partition_tensor_view<1x1x1x64x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c64, %c64]
+      : !pto.tensor_view<1x1x1x66x72xf32> -> !pto.partition_tensor_view<1x1x1x64x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x64x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=64, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xf32>)
+    return
+  }
+
+  // Case 5: f32 66x72, valid 58x70 (non-square valid)
+  func.func @TRECIP_f32_58x70(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c58   = arith.constant 58   : index
+    %c70   = arith.constant 70   : index
+    %c66   = arith.constant 66   : index
+    %c72   = arith.constant 72   : index
+    %c4752 = arith.constant 4752 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c66, %c72],
+      strides = [%c4752, %c4752, %c4752, %c72, %c1]
+      : !pto.tensor_view<1x1x1x66x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c66, %c72],
+      strides = [%c4752, %c4752, %c4752, %c72, %c1]
+      : !pto.tensor_view<1x1x1x66x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c58, %c70]
+      : !pto.tensor_view<1x1x1x66x72xf32> -> !pto.partition_tensor_view<1x1x1x58x70xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c58, %c70]
+      : !pto.tensor_view<1x1x1x66x72xf32> -> !pto.partition_tensor_view<1x1x1x58x70xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x58x70xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trecip ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=66, cols=72, v_row=58, v_col=70,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x58x70xf32>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(trsqrt)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/cases.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for trsqrt ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/gen_data.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    # Positive values for rsqrt (1/sqrt(x) requires sqrt(x) > 0)
+    input = np.random.uniform(0.1, 100.0, size=shape).astype(dtype)
+
+    # rsqrt = 1 / sqrt(x)
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.reciprocal(np.sqrt(input[:vr, :vc])).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TRSQRT_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRSQRT_f32_16x64(void *a, void *b, void *stream) {
+    TRSQRT_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TRSQRT_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRSQRT_f32_32x32(void *a, void *b, void *stream) {
+    TRSQRT_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TRSQRT_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTRSQRT_f16_16x64(void *a, void *b, void *stream) {
+    TRSQRT_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TRSQRT_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTRSQRT_f16_32x32(void *a, void *b, void *stream) {
+    TRSQRT_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/main.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang trsqrt ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTRSQRT_f32_16x64(void *a, void *b, void *stream);
+void LaunchTRSQRT_f32_32x32(void *a, void *b, void *stream);
+void LaunchTRSQRT_f16_16x64(void *a, void *b, void *stream);
+void LaunchTRSQRT_f16_32x32(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTRSQRT_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTRSQRT_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTRSQRT_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTRSQRT_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./trsqrt [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/trsqrt.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/trsqrt.pto
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.trsqrt: 1/sqrt(x)
+// trsqrt = vsqrt(x) -> vdiv(1.0, sqrt_result)
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TRSQRT_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TRSQRT_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TRSQRT_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TRSQRT_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/CMakeLists.txt
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+pto_tilelang_vec_st(tsqrt)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/cases.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+"""Single source of truth for tsqrt ST test cases.
+
+Each case defines:
+  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
+  - dtype:       numpy dtype (e.g. np.float32).
+  - shape:       (rows, cols) — allocated tile dimensions.
+  - valid_shape: (valid_rows, valid_cols) — effective computation region.
+  - eps:         tolerance for numpy.allclose (atol and rtol).
+
+gen_data.py and compare.py both import this list to avoid redundant definitions.
+"""
+
+import numpy as np
+
+CASES = [
+    {
+        "name": "f32_16x64",
+        "dtype": np.float32,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f32_32x32",
+        "dtype": np.float32,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-6,
+    },
+    {
+        "name": "f16_16x64",
+        "dtype": np.float16,
+        "shape": (16, 64),
+        "valid_shape": (16, 64),
+        "eps": 1e-3,
+    },
+    {
+        "name": "f16_32x32",
+        "dtype": np.float16,
+        "shape": (32, 32),
+        "valid_shape": (32, 32),
+        "eps": 1e-3,
+    },
+]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import os
+import sys
+import numpy as np
+
+from cases import CASES
+from st_common import result_cmp, style_fail, style_pass, validate_cases
+
+
+def main():
+    validate_cases(CASES)
+    case_filter = sys.argv[1] if len(sys.argv) > 1 else None
+
+    all_passed = True
+    for case in CASES:
+        if case_filter is not None and case["name"] != case_filter:
+            continue
+
+        case_dir = case["name"]
+        shape = case["shape"]
+        vr, vc = case["valid_shape"]
+
+        golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
+        output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)
+
+        ok = result_cmp(golden[:vr, :vc], output[:vr, :vc], case["eps"])
+        if ok:
+            print(style_pass(f"[INFO] {case['name']}: compare passed"))
+        else:
+            print(style_fail(f"[ERROR] {case['name']}: compare failed"))
+            all_passed = False
+
+    if not all_passed:
+        sys.exit(2)
+    print(style_pass("[INFO] all cases passed"))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/gen_data.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# coding=utf-8
+
+import numpy as np
+from cases import CASES
+from st_common import validate_cases, setup_case_rng, save_case_data
+
+validate_cases(CASES)
+
+for case in CASES:
+    setup_case_rng(case)
+
+    dtype = case["dtype"]
+    shape = case["shape"]
+    valid_shape = case["valid_shape"]
+
+    # Generate positive random values for sqrt
+    input = np.random.uniform(0.1, 100.0, size=shape).astype(dtype)
+
+    golden = np.zeros(shape, dtype=dtype)
+    vr, vc = valid_shape
+    golden[:vr, :vc] = np.sqrt(input[:vr, :vc]).astype(dtype, copy=False)
+
+    save_case_data(case["name"], {"input": input, "golden": golden})
+    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// Case 0: f32 16x64
+extern "C" __global__ AICORE void TSQRT_f32_16x64(__gm__ float *a, __gm__ float *b);
+
+void LaunchTSQRT_f32_16x64(void *a, void *b, void *stream) {
+    TSQRT_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 1: f32 32x32
+extern "C" __global__ AICORE void TSQRT_f32_32x32(__gm__ float *a, __gm__ float *b);
+
+void LaunchTSQRT_f32_32x32(void *a, void *b, void *stream) {
+    TSQRT_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}
+
+// Case 2: f16 16x64
+extern "C" __global__ AICORE void TSQRT_f16_16x64(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTSQRT_f16_16x64(void *a, void *b, void *stream) {
+    TSQRT_f16_16x64<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}
+
+// Case 3: f16 32x32
+extern "C" __global__ AICORE void TSQRT_f16_32x32(__gm__ uint16_t *a, __gm__ uint16_t *b);
+
+void LaunchTSQRT_f16_32x32(void *a, void *b, void *stream) {
+    TSQRT_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/main.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Host driver for TileLang tsqrt ST — case-table driven.
+// Each case launches a different kernel variant, reads/writes from per-case subdirectory.
+// Numerical comparison is done externally by compare.py.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+
+using namespace PtoTestCommon;
+
+// Kernel launch wrappers (defined in launch.cpp)
+void LaunchTSQRT_f32_16x64(void *a, void *b, void *stream);
+void LaunchTSQRT_f32_32x32(void *a, void *b, void *stream);
+void LaunchTSQRT_f16_16x64(void *a, void *b, void *stream);
+void LaunchTSQRT_f16_32x32(void *a, void *b, void *stream);
+
+using LaunchFn = void (*)(void *, void *, void *);
+
+struct TestCase {
+    const char *name;
+    LaunchFn    launch;
+    size_t      rows;       // allocated tile rows
+    size_t      cols;       // allocated tile cols
+    size_t      validRows;  // effective computation rows  (<= rows)
+    size_t      validCols;  // effective computation cols  (<= cols)
+    size_t      elemSize;   // bytes per element
+};
+
+static const TestCase kCases[] = {
+    {"f32_16x64", LaunchTSQRT_f32_16x64, 16, 64, 16, 64, sizeof(float)},
+    {"f32_32x32", LaunchTSQRT_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f16_16x64", LaunchTSQRT_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
+    {"f16_32x32", LaunchTSQRT_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+};
+static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
+
+static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
+    int rc = 0;
+    const size_t elemCount = tc.rows * tc.cols;
+    const size_t fileSize  = elemCount * tc.elemSize;
+
+    std::printf("[INFO] === case: %s (shape=%zux%zu, valid=%zux%zu) ===\n",
+                tc.name, tc.rows, tc.cols, tc.validRows, tc.validCols);
+
+    // Per-case data directory
+    std::string caseDir = std::string("./") + tc.name;
+    size_t srcFileSize = fileSize;
+
+    void *srcHost = nullptr, *dstHost = nullptr;
+    void *srcDevice = nullptr, *dstDevice = nullptr;
+
+    aclrtMallocHost((void **)(&srcHost), fileSize);
+    aclrtMallocHost((void **)(&dstHost), fileSize);
+
+    aclrtMalloc((void **)&srcDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&dstDevice, fileSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!ReadFile((caseDir + "/input.bin").c_str(), srcFileSize, srcHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to read %s/input.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (rc == 0) {
+        aclrtMemcpy(srcDevice, fileSize, srcHost, fileSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+        tc.launch(srcDevice, dstDevice, stream);
+
+        aclrtSynchronizeStream(stream);
+        aclrtMemcpy(dstHost, fileSize, dstDevice, fileSize, ACL_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    if (rc == 0 && !WriteFile((caseDir + "/output.bin").c_str(), dstHost, fileSize)) {
+        std::fprintf(stderr, "[ERROR] failed to write %s/output.bin\n", caseDir.c_str());
+        rc = 1;
+    }
+
+    if (srcDevice != nullptr)
+        aclrtFree(srcDevice);
+    if (dstDevice != nullptr)
+        aclrtFree(dstDevice);
+    if (srcHost != nullptr)
+        aclrtFreeHost(srcHost);
+    if (dstHost != nullptr)
+        aclrtFreeHost(dstHost);
+
+    if (rc == 0)
+        std::printf("[INFO] case %s done\n", tc.name);
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    // Optional case filter: ./tsqrt [case_name]
+    const char *caseFilter = (argc > 1) ? argv[1] : nullptr;
+
+    int rc = 0;
+    int deviceId = 0;
+    aclrtStream stream = nullptr;
+
+    aclInit(nullptr);
+    if (const char *envDevice = std::getenv("ACL_DEVICE_ID")) {
+        deviceId = std::atoi(envDevice);
+    }
+    aclrtSetDevice(deviceId);
+    aclrtCreateStream(&stream);
+
+    for (size_t i = 0; i < kNumCases; ++i) {
+        if (caseFilter != nullptr && std::strcmp(kCases[i].name, caseFilter) != 0) {
+            continue;
+        }
+        int ret = RunCase(kCases[i], deviceId, stream);
+        if (ret != 0) {
+            std::fprintf(stderr, "[ERROR] case %s failed\n", kCases[i].name);
+            rc = 1;
+            break;
+        }
+    }
+
+    if (stream != nullptr)
+        aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+
+    return rc;
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/tsqrt.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/tsqrt.pto
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang ST kernels for pto.tsqrt: tload(a) + tsqrt(a)->b + tstore(b).
+// Multiple cases with different shapes in a single module.
+// Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
+// to produce LLVM IR.
+
+module {
+  // Case 0: f32 16x64 (1024 elements)
+  func.func @TSQRT_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  // Case 1: f32 32x32 (1024 elements)
+  func.func @TSQRT_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+
+  // Case 2: f16 16x64 (1024 elements)
+  func.func @TSQRT_f16_16x64(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 64   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf16> -> !pto.partition_tensor_view<1x1x1x16x64xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x64xf16>)
+    return
+  }
+
+  // Case 3: f16 32x32 (1024 elements)
+  func.func @TSQRT_f16_32x32(%a_ptr: !pto.ptr<f16>, %b_ptr: !pto.ptr<f16>) {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c1024 = arith.constant 1024 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+              outs(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tsqrt ins(%a : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%b : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
+    return
+  }
+}


### PR DESCRIPTION
添加一元运算的 TileOP 模板、编译测试文件和 ST 测试文件

当前包含：TABS、TEXP、TLOG、TNEG、TNOT、TRECIP、TRSQRT、TSQRT
不含：TCVT