### PR TITLE
fix(tilelang): preserve typed scalar carrier casts in inline lowering

### DIFF
--- a/lib/PTO/Transforms/PTOLowerToOpLibCalls.cpp
+++ b/lib/PTO/Transforms/PTOLowerToOpLibCalls.cpp
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 #include "PTO/IR/PTO.h"
 
 #include "PTOLowerToOpLibCalls.h"
@@ -201,7 +209,15 @@ FailureOr<bool> mlir::pto::tryCloneOpLibInlineBridgeOp(OpBuilder &builder,
     if (!mappedSrc)
       return failure();
 
-    mapping.map(cast.getResult(0), mappedSrc);
+    Type dstTy = cast.getResult(0).getType();
+    if (mappedSrc.getType() == dstTy) {
+      mapping.map(cast.getResult(0), mappedSrc);
+      return true;
+    }
+
+    auto clonedCast = builder.create<UnrealizedConversionCastOp>(
+        cast.getLoc(), TypeRange{dstTy}, ValueRange{mappedSrc});
+    mapping.map(cast.getResult(0), clonedCast.getResult(0));
     return true;
   }
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2475,16 +2475,12 @@ class _AuthoringRenderer:
         if isinstance(expr, SemanticBindingRef):
             return env.get(expr.binding.name, _RenderedValue(expr.binding.ssa_name, expr.type))
         if isinstance(expr, SemanticLiteralExpr):
-            if desired_name is not None and into is not None:
-                into.append(
-                    self._indent(indent)
-                    + f"{desired_name} = arith.constant {self._format_constant(expr.value, expr.type)} : "
-                    f"{self._render_arith_constant_type(expr.type)}"
-                )
-                return _RenderedValue(name=desired_name, type=expr.type)
-            return _RenderedValue(
-                name=self._materialize_constant(expr.value, expr.type),
-                type=expr.type,
+            return self._lower_literal_expr(
+                expr.value,
+                expr.type,
+                indent=indent,
+                desired_name=desired_name,
+                into=into,
             )
         if isinstance(expr, SemanticSubscriptAccess):
             return self._lower_subscript_access(
@@ -3680,6 +3676,56 @@ class _AuthoringRenderer:
             f"{self._render_arith_constant_type(ty)}"
         )
         return name
+
+    def _signless_integer_scalar_type(self, ty: SemanticType) -> SemanticScalarType | None:
+        if not isinstance(ty, SemanticScalarType) or not is_integer_dtype(ty.dtype):
+            return None
+        signedness = integer_signedness(ty.dtype)
+        if signedness in {None, "signless"}:
+            return None
+        bitwidth = integer_bitwidth(ty.dtype)
+        if bitwidth not in {8, 16, 32, 64}:
+            raise NotImplementedError(
+                f"unsupported integer bitwidth {bitwidth!r} for signless literal lowering"
+            )
+        return SemanticScalarType(dtype=ScalarType(f"i{bitwidth}"))
+
+    def _lower_literal_expr(
+        self,
+        value: object,
+        ty: SemanticType,
+        *,
+        indent: int,
+        desired_name: str | None = None,
+        into: list[str] | None = None,
+    ) -> _RenderedValue:
+        raw_type = self._signless_integer_scalar_type(ty) or ty
+        if desired_name is not None and into is not None and raw_type == ty:
+            into.append(
+                self._indent(indent)
+                + f"{desired_name} = arith.constant {self._format_constant(value, ty)} : "
+                f"{self._render_arith_constant_type(ty)}"
+            )
+            return _RenderedValue(name=desired_name, type=ty)
+
+        if desired_name is not None and into is not None:
+            raw_name = self._new_temp()
+            into.append(
+                self._indent(indent)
+                + f"{raw_name} = arith.constant {self._format_constant(value, raw_type)} : "
+                f"{self._render_arith_constant_type(raw_type)}"
+            )
+            into.append(
+                self._indent(indent)
+                + f"{desired_name} = builtin.unrealized_conversion_cast {raw_name} : "
+                f"{self._render_type(raw_type)} to {self._render_type(ty)}"
+            )
+            return _RenderedValue(name=desired_name, type=ty)
+
+        return _RenderedValue(
+            name=self._materialize_constant(value, ty),
+            type=ty,
+        )
 
     def _constant_name(self, value: object, ty: SemanticType) -> str:
         if isinstance(ty, SemanticIndexType):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2448,6 +2448,32 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("arith.constant 4294967295 : i32", text)
         self.assertNotIn("arith.constant 4294967295 : ui32", text)
 
+    def test_unsigned_pad_value_eval_broadcast_bitcasts_signless_literal(self) -> None:
+        @pto.vkernel(op="tile_pad_value_ui16_vbr_unique", dtypes=[(pto.ui16,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            scalar = tile.pad_value.eval()
+            vec = pto.vbr(scalar)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "pad_value": pto.PadValue.MAX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("dtype=ui16", text)
+        self.assertIn("arith.constant 65535 : i16", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertIn("pto.vbr", text)
+
 
     def test_make_mask_vlds_vsts_and_vector_families_lower_inside_strict_vecscope(self) -> None:
         @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.f32)], advanced=True)


### PR DESCRIPTION
## Summary
- preserve non-identity `builtin.unrealized_conversion_cast` ops when `PTOInlineLibCall` clones helper IR
- keep the issue #166 unsigned pad-scalar path valid after inlining so `pto.vbr` still sees `ui8/ui16/ui32` operands
- avoid regressing existing bridge-cast folding by only bypassing casts when the mapped source type already matches the destination type

## Repro
- issue: #166
- repro cmd: `PYTHONPATH=tilelang-dsl/python build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-insert-sync --enable-tile-op-expand --tilelang-path=lib/TileOps --tilelang-pkg-path=tilelang-dsl/python --vpto-emit-hivm-llvm build/issue_166/unpacked/tpartmin/tpartmin.pto -o -`

## Validation
- `cmake --build build --target ptoas -j$(nproc)`
- `PYTHONPATH=tilelang-dsl/python build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-insert-sync --enable-tile-op-expand --tilelang-path=lib/TileOps --tilelang-pkg-path=tilelang-dsl/python --vpto-emit-hivm-llvm build/issue_166/unpacked/tpartmin/tpartmin.pto -o -`
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_scalar_bitwise_and_shift_ops_lower_for_signed_and_unsigned`
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_unsigned_pad_value_eval_broadcast_bitcasts_signless_literal`

Closes #166
