### PR TITLE
feat(tilelang-dsl): support idx_dtype(0) constructor syntax

### DIFF
--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -43,6 +43,15 @@ y: pto.i32 = 1024      # Type annotation
 z = pto.ui16(7)        # Explicit unsigned 16-bit constant
 ```
 
+Static dtype bindings can also be called like constructors. This is useful when
+the dtype comes from compile-time metadata such as `element_type`:
+
+```python
+idx_dtype = tile.element_type
+zero_idx = idx_dtype(0)
+v_col = idx_dtype(col)
+```
+
 Integer sign semantics are part of the DSL type surface. `pto.si16`,
 `pto.ui16`, and `pto.i16` are distinct scalar dtypes and lower to `si16`,
 `ui16`, and `i16` respectively in VPTO IR.

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -61,6 +61,27 @@ _SUPPORTED_TEMPLATE_PTO_CALLS = frozenset(
     | ADVANCED_TOPLEVEL_PTO_CALLS
 )
 
+_DSL_DTYPE_NAMES = frozenset(
+    {
+        "i1",
+        "i8",
+        "si8",
+        "ui8",
+        "i16",
+        "si16",
+        "ui16",
+        "i32",
+        "si32",
+        "ui32",
+        "i64",
+        "si64",
+        "ui64",
+        "f16",
+        "bf16",
+        "f32",
+    }
+)
+
 
 _INLINE_PROC_REGISTRY: dict[tuple[str, str], "InlineProcDescriptor"] = {}
 
@@ -242,6 +263,7 @@ class _KernelBodyValidator(ast.NodeVisitor):
         self.advanced_enabled = advanced_enabled
         self.module_name = module_name
         self._vecscope_depth = 0
+        self._static_dtype_bindings: set[str] = set()
 
     def validate(self) -> None:
         for stmt in self.source_info.function_def.body:
@@ -294,6 +316,22 @@ class _KernelBodyValidator(ast.NodeVisitor):
             self.visit(stmt)
         for stmt in node.orelse:
             self.visit(stmt)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        is_static_dtype = self._expr_is_static_dtype_expr(node.value)
+        for target in node.targets:
+            self._update_static_dtype_bindings(target, is_static_dtype=is_static_dtype)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+        is_static_dtype = node.value is not None and self._expr_is_static_dtype_expr(node.value)
+        self._update_static_dtype_bindings(node.target, is_static_dtype=is_static_dtype)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.value)
+        self._update_static_dtype_bindings(node.target, is_static_dtype=False)
 
     def visit_With(self, node: ast.With) -> None:
         if len(node.items) != 1:
@@ -484,6 +522,9 @@ class _KernelBodyValidator(ast.NodeVisitor):
             if node.func.id == "range":
                 self._validate_call_keywords(node)
                 return
+            if node.func.id in self._static_dtype_bindings:
+                self._validate_call_keywords(node)
+                return
             inline_proc = _find_inline_proc(node.func.id, module_name=self.module_name)
             if inline_proc is not None:
                 _validate_inline_proc_call_surface(self.source_info, node, inline_proc)
@@ -497,6 +538,31 @@ class _KernelBodyValidator(ast.NodeVisitor):
             node,
             "unsupported call surface in TileLang DSL v1",
         )
+
+    def _expr_is_static_dtype_expr(self, node: ast.AST) -> bool:
+        if isinstance(node, ast.Name):
+            return node.id in self._static_dtype_bindings
+        if isinstance(node, ast.Attribute):
+            if (
+                isinstance(node.value, ast.Name)
+                and node.value.id == "pto"
+                and node.attr in _DSL_DTYPE_NAMES
+            ):
+                return True
+            if node.attr == "element_type":
+                return True
+        return False
+
+    def _update_static_dtype_bindings(self, target: ast.expr, *, is_static_dtype: bool) -> None:
+        if isinstance(target, ast.Name):
+            if is_static_dtype:
+                self._static_dtype_bindings.add(target.id)
+            else:
+                self._static_dtype_bindings.discard(target.id)
+            return
+        if isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._update_static_dtype_bindings(element, is_static_dtype=False)
 
 
 def _load_function_source_info(py_fn: Callable[..., Any]) -> _FunctionSourceInfo | None:

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3055,6 +3055,27 @@ class _SemanticAnalyzer:
                 expr,
             )
         if isinstance(expr, FrontendCallExpr):
+            if expr.namespace is None:
+                binding = env.get(expr.name)
+                if (
+                    binding is not None
+                    and isinstance(binding.type, SemanticMetaType)
+                    and binding.type.kind == "dtype"
+                    and isinstance(binding.value, ScalarType)
+                ):
+                    if expr.keywords:
+                        raise TypeError(
+                            f"`{expr.name}` does not support keyword arguments in TileLang DSL v1"
+                        )
+                    args = tuple(
+                        self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                        for arg in expr.args
+                    )
+                    return self._analyze_scalar_constructor_for_dtype(
+                        binding.value,
+                        args,
+                        surface_name=expr.name,
+                    )
             if expr.namespace is None and expr.name in self._inline_proc_nodes:
                 if expr.keywords:
                     raise TypeError(
@@ -4117,17 +4138,29 @@ class _SemanticAnalyzer:
         name: str,
         args: tuple[SemanticExpr, ...],
     ) -> SemanticExpr:
-        if len(args) != 1:
-            raise TypeError(f"pto.{name} expects exactly 1 positional argument in TileLang DSL v1")
+        return self._analyze_scalar_constructor_for_dtype(
+            _DTYPE_SYMBOLS[name],
+            args,
+            surface_name=f"pto.{name}",
+        )
 
-        target_dtype = _DTYPE_SYMBOLS[name]
+    def _analyze_scalar_constructor_for_dtype(
+        self,
+        target_dtype: ScalarType,
+        args: tuple[SemanticExpr, ...],
+        *,
+        surface_name: str,
+    ) -> SemanticExpr:
+        if len(args) != 1:
+            raise TypeError(f"{surface_name} expects exactly 1 positional argument in TileLang DSL v1")
+
         if (
             target_dtype.name in {"f16", "bf16", "f32"}
             and isinstance(args[0], SemanticLiteralExpr)
             and isinstance(args[0].type, SemanticMetaType)
             and args[0].type.kind == "string"
         ):
-            parsed = self._parse_float_literal_string(args[0].value, target_dtype, f"pto.{name} value")
+            parsed = self._parse_float_literal_string(args[0].value, target_dtype, f"{surface_name} value")
             return SemanticLiteralExpr(
                 value=parsed,
                 type=SemanticScalarType(dtype=target_dtype),
@@ -4138,13 +4171,17 @@ class _SemanticAnalyzer:
             and isinstance(args[0].type, SemanticMetaType)
             and args[0].type.kind == "string"
         ):
-            parsed = self._parse_integer_literal_string(args[0].value, target_dtype, f"pto.{name} value")
+            parsed = self._parse_integer_literal_string(
+                args[0].value,
+                target_dtype,
+                f"{surface_name} value",
+            )
             return SemanticLiteralExpr(
                 value=parsed,
                 type=SemanticScalarType(dtype=target_dtype),
             )
 
-        value = self._require_scalar_or_index_expr(args[0], f"pto.{name} value")
+        value = self._require_scalar_or_index_expr(args[0], f"{surface_name} value")
 
         if isinstance(value.type, SemanticScalarType) and value.type.dtype == target_dtype:
             return value
@@ -4166,7 +4203,11 @@ class _SemanticAnalyzer:
                 else:
                     casted = None
                 if casted is not None:
-                    checked = self._check_integer_literal_range(casted, target_dtype, f"pto.{name} value")
+                    checked = self._check_integer_literal_range(
+                        casted,
+                        target_dtype,
+                        f"{surface_name} value",
+                    )
                     return SemanticLiteralExpr(value=checked, type=SemanticScalarType(dtype=target_dtype))
             else:
                 if isinstance(literal_value, (bool, int, float)):
@@ -4177,7 +4218,7 @@ class _SemanticAnalyzer:
 
         return SemanticCallExpr(
             namespace="pto",
-            name=name,
+            name=target_dtype.name,
             args=(value,),
             type=SemanticScalarType(dtype=target_dtype),
         )

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2446,6 +2446,45 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIsInstance(scalar_assign.targets[0].type, SemanticScalarType)
         self.assertEqual(scalar_assign.targets[0].type.dtype, pto.f32)
 
+    def test_static_dtype_binding_supports_constructor_call_surface(self) -> None:
+        @pto.vkernel(op="static_dtype_binding_constructor_unique", dtypes=[(pto.i32,)])
+        def kernel(tile: pto.Tile):
+            idx_dtype = tile.element_type
+            cols = tile.shape[1]
+            zero_idx = idx_dtype(0)
+            v_col = idx_dtype(cols)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 16),
+                memory_space=pto.MemorySpace.UB,
+            )
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        dtype_assign, cols_assign, zero_assign, cast_assign = semantic_kernel.body[:4]
+
+        self.assertIsInstance(dtype_assign, SemanticAssignStmt)
+        self.assertIsInstance(dtype_assign.value, SemanticSymbolExpr)
+        self.assertEqual(dtype_assign.value.value, pto.i32)
+
+        self.assertIsInstance(cols_assign, SemanticAssignStmt)
+        self.assertIsInstance(cols_assign.targets[0].type, SemanticIndexType)
+
+        self.assertIsInstance(zero_assign, SemanticAssignStmt)
+        self.assertIsInstance(zero_assign.value, SemanticLiteralExpr)
+        self.assertEqual(zero_assign.value.value, 0)
+        self.assertIsInstance(zero_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(zero_assign.targets[0].type.dtype, pto.i32)
+
+        self.assertIsInstance(cast_assign, SemanticAssignStmt)
+        self.assertIsInstance(cast_assign.value, SemanticCallExpr)
+        self.assertEqual(cast_assign.value.namespace, "pto")
+        self.assertEqual(cast_assign.value.name, "i32")
+        self.assertIsInstance(cast_assign.targets[0].type, SemanticScalarType)
+        self.assertEqual(cast_assign.targets[0].type.dtype, pto.i32)
+
     def test_unsigned_integer_constants_lower_with_signless_arith_types(self) -> None:
         @pto.vkernel(op="tile_pad_value_ui32_max_eval_unique", dtypes=[(pto.ui32,)])
         def kernel(tile: pto.Tile):


### PR DESCRIPTION
## Summary
- allow static dtype bindings such as `tile.element_type` to be called like scalar constructors
- route `idx_dtype(0)` / `idx_dtype(col)` through the existing scalar constructor semantics
- document the new surface and add DSL regression coverage

## Testing
- `python3 -m unittest discover -s tilelang-dsl/tests -p 'test_tilelang_dsl_v1.py'`
