### PR TITLE
fix(tilelang-dsl): auto-cast mov pad scalars for issue 170

### DIFF
--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -335,7 +335,7 @@ pto.set_mov_pad_val(pad_value: ScalarType) -> None
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pad_value` | `ScalarType` | Scalar value used for padding. Supported types: `pto.i8`, `pto.i16`, `pto.i32`, `pto.f16`, `pto.bf16`, `pto.f32`. The value's bit pattern is encoded into the hardware pad register. For standard pad values, use `PadValue.eval(...)` to obtain the appropriate scalar: `0` or `0.0` for `PadValue.ZERO`, dtype-aware maximum for `PadValue.MAX`, dtype-aware minimum for `PadValue.MIN`. |
+| `pad_value` | `ScalarType` | Scalar value used for padding. Supported types: any 8/16/32-bit integer scalar (`pto.i8`, `pto.si8`, `pto.ui8`, `pto.i16`, `pto.si16`, `pto.ui16`, `pto.i32`, `pto.si32`, `pto.ui32`) plus `pto.f16`, `pto.bf16`, and `pto.f32`. The value's bit pattern is encoded into the hardware pad register. Integer inputs are automatically normalized to the corresponding signless hardware operand width during lowering, so no manual cast is required before calling `pto.set_mov_pad_val`. For standard pad values, use `PadValue.eval(...)` to obtain the appropriate scalar: `0` or `0.0` for `PadValue.ZERO`, dtype-aware maximum for `PadValue.MAX`, dtype-aware minimum for `PadValue.MIN`. |
 
 **Returns**: None (side-effect operation)
 
@@ -384,8 +384,10 @@ if pto.constexpr(pad_desc != pto.PadValue.NULL):
 Using a standalone `PadValue` with an explicit dtype:
 ```python
 pad_scalar = pto.PadValue.MAX.eval(pto.f32)
-pto.set_mov_pad_val(pto.f32(pad_scalar))
+pto.set_mov_pad_val(pad_scalar)
 ```
+
+For integer tile dtypes such as `pto.ui16` or `pto.si32`, `pad_desc.eval()` can be passed directly to `pto.set_mov_pad_val`. TileLang DSL v1 will automatically insert the required same-width bitcast to the signless hardware operand type during lowering.
 
 **Important**: You are responsible for ensuring the pad register is properly configured before any `pto.copy_gm_to_ubuf` operation with `enable_ub_pad=True`. The pad register configuration persists until changed by another `pto.set_mov_pad_val` call.
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -91,6 +91,17 @@ _I32_TYPE = SemanticScalarType(dtype=ScalarType("i32"))
 _I64_TYPE = SemanticScalarType(dtype=ScalarType("i64"))
 
 
+def _signless_mov_pad_scalar_type(dtype: ScalarType) -> SemanticScalarType | None:
+    bitwidth = integer_bitwidth(dtype)
+    if bitwidth == 8:
+        return SemanticScalarType(dtype=ScalarType("i8"))
+    if bitwidth == 16:
+        return SemanticScalarType(dtype=ScalarType("i16"))
+    if bitwidth == 32:
+        return SemanticScalarType(dtype=ScalarType("i32"))
+    return None
+
+
 def _format_symbol_name(symbol_name: str) -> str:
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_$.]*", symbol_name):
         return f"@{symbol_name}"
@@ -505,6 +516,19 @@ class _AuthoringRenderer:
     ) -> list[str]:
         lines: list[str] = []
         value = self._lower_expr(stmt.value, env, indent=indent, into=lines)
+        if (
+            stmt.name == "set_mov_pad_val"
+            and isinstance(value.type, SemanticScalarType)
+            and is_integer_dtype(value.type.dtype)
+        ):
+            signless_type = _signless_mov_pad_scalar_type(value.type.dtype)
+            if signless_type is not None:
+                value = self._coerce_rendered_value(
+                    value,
+                    signless_type,
+                    indent=indent,
+                    into=lines,
+                )
         lines.append(
             self._indent(indent)
             + f"pto.{stmt.name} {value.name} : {self._render_type(value.type)}"

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -289,9 +289,14 @@ _LOW_LEVEL_DMA_COPY_OPS = {
     "copy_ubuf_to_gm",
     "copy_ubuf_to_ubuf",
 }
-_MOV_PAD_SUPPORTED_SCALAR_DTYPES = frozenset(
-    dtype.name for dtype in (i8, i16, i32, f16, bf16, f32)
-)
+
+
+def _is_supported_mov_pad_scalar_dtype(dtype: ScalarType) -> bool:
+    if is_integer_dtype(dtype):
+        return integer_bitwidth(dtype) in {8, 16, 32}
+    return dtype.name in {"f16", "bf16", "f32"}
+
+
 _COMPARE_SELECT_OPS = {"vcmp", "vcmps", "vsel", "vselr", "vselrv2"}
 _PREDICATE_MOVEMENT_OPS = {
     "pset_b8",
@@ -2126,9 +2131,9 @@ class _SemanticAnalyzer:
             if len(args) != 1:
                 raise TypeError(f"pto.{expr.name} expects exactly 1 positional argument in TileLang DSL")
             scalar = self._require_scalar_expr(args[0], f"pto.{expr.name} pad_value")
-            if scalar.dtype.name not in _MOV_PAD_SUPPORTED_SCALAR_DTYPES:
+            if not _is_supported_mov_pad_scalar_dtype(scalar.dtype):
                 raise TypeError(
-                    "pto.set_mov_pad_val pad_value must be one of i8, i16, i32, f16, bf16, or f32 in TileLang DSL v1"
+                    "pto.set_mov_pad_val pad_value must be an 8/16/32-bit integer or f16/bf16/f32 in TileLang DSL v1"
                 )
             return (
                 SemanticDmaUnaryConfigStmt(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -4745,6 +4745,32 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"pto\.copy_gm_to_ubuf %gm_ptr_\d+, %ub_ptr_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %tmp_\d+, %true, %tmp_\d+, %tmp_\d+, %tmp_\d+",
         )
 
+    def test_set_mov_pad_val_automatically_bitcasts_unsigned_tile_pad_value_to_signless_scalar(self) -> None:
+        @pto.vkernel(op="set_mov_pad_val_tile_pad_bitcast_unique", dtypes=[(pto.ui16,)], advanced=True)
+        def kernel(dst: pto.Tile):
+            pto.set_mov_pad_val(dst.pad_value.eval())
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(
+                shape=(260, 32),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": "row_major",
+                        "s_layout": "none_box",
+                        "s_fractal_size": 512,
+                        "pad_value": "0x2",
+                    }
+                ),
+                valid_shape=(260, 7),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.bitcast", text)
+        self.assertRegex(text, r"pto\.set_mov_pad_val %[^ ]+ : i16")
+
     def test_copy_ubuf_to_gm_keyword_surface_lowers_in_advanced_mode(self) -> None:
         @pto.vkernel(op="tile_to_tensorview_dma_unique", dtypes=[(pto.f32, pto.f32)], advanced=True)
         def kernel(src: pto.Tile, dst: pto.TensorView):
@@ -5945,7 +5971,7 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
             ).mlir_text()
 
         self.assertIn(
-            "pto.set_mov_pad_val pad_value must be one of i8, i16, i32, f16, bf16, or f32",
+            "pto.set_mov_pad_val pad_value must be an 8/16/32-bit integer or f16/bf16/f32",
             str(ctx.exception),
         )
 


### PR DESCRIPTION
## Summary
- allow `pto.set_mov_pad_val` to accept 8/16/32-bit integer scalars in TileLang DSL semantic checks
- auto-insert same-width signless bitcasts during authoring lowering so templates can keep calling `pto.set_mov_pad_val(dst.pad_value.eval())`
- document the updated DMA pad-value behavior and add regression coverage for the `ui16` issue 170 repro path

## Repro
- issue: #170
- repro cmd:
  `PYTHONPATH=/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python:/home/zhangzhendong/ptoas-workspace/PTOAS/build/python python3 -m tilelang_dsl.expand_helper --template-dir /home/zhangzhendong/ptoas-workspace/PTOAS/lib/TileOps --target a5 --op pto.tload --operand-specs '[{"kind":"view","dtype":"ui16","shape":[1,1,1,260,7],"strides":[1820,1820,1820,7,1],"memory_space":"gm"},{"kind":"tile","dtype":"ui16","shape":[260,32],"valid_shape":[260,7],"memory_space":"ub","config":{"b_layout":"row_major","s_layout":"none_box","s_fractal_size":512,"pad_value":"0x3"}}]'`

## Validation
- `PYTHONPATH=/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python:/home/zhangzhendong/ptoas-workspace/PTOAS/build/python python3 - <<'PY' ...` (3 targeted unittest cases for mov-pad lowering/diagnostics)
- `PYTHONPATH=/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python:/home/zhangzhendong/ptoas-workspace/PTOAS/build/python python3 -m tilelang_dsl.expand_helper ... --op pto.tload ...` (issue 170 repro now succeeds and emits `arith.bitcast` + `pto.set_mov_pad_val : i16`)

Closes #170
