### PR TITLE
fix(dsl): support integer string scalar literals

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4147,6 +4147,17 @@ class _SemanticAnalyzer:
                 value=parsed,
                 type=SemanticScalarType(dtype=target_dtype),
             )
+        if (
+            is_integer_dtype(target_dtype)
+            and isinstance(args[0], SemanticLiteralExpr)
+            and isinstance(args[0].type, SemanticMetaType)
+            and args[0].type.kind == "string"
+        ):
+            parsed = self._parse_integer_literal_string(args[0].value, target_dtype, f"pto.{name} value")
+            return SemanticLiteralExpr(
+                value=parsed,
+                type=SemanticScalarType(dtype=target_dtype),
+            )
 
         value = self._require_scalar_or_index_expr(args[0], f"pto.{name} value")
 
@@ -4170,20 +4181,8 @@ class _SemanticAnalyzer:
                 else:
                     casted = None
                 if casted is not None:
-                    bits = integer_bitwidth(target_dtype)
-                    signedness = integer_signedness(target_dtype)
-                    assert bits is not None
-                    if signedness == "unsigned":
-                        min_value = 0
-                        max_value = (1 << bits) - 1
-                    else:
-                        min_value = -(1 << (bits - 1))
-                        max_value = (1 << (bits - 1)) - 1
-                    if casted < min_value or casted > max_value:
-                        raise TypeError(
-                            f"pto.{name} value {casted} is out of range for {target_dtype.name} in TileLang DSL v1"
-                        )
-                    return SemanticLiteralExpr(value=casted, type=SemanticScalarType(dtype=target_dtype))
+                    checked = self._check_integer_literal_range(casted, target_dtype, f"pto.{name} value")
+                    return SemanticLiteralExpr(value=checked, type=SemanticScalarType(dtype=target_dtype))
             else:
                 if isinstance(literal_value, (bool, int, float)):
                     return SemanticLiteralExpr(
@@ -4227,6 +4226,42 @@ class _SemanticAnalyzer:
             raise TypeError(
                 f"{context} string literal {literal!r} is not a valid float literal"
             ) from exc
+
+    def _parse_integer_literal_string(
+        self,
+        literal: str,
+        target_dtype: ScalarType,
+        context: str,
+    ) -> int:
+        text = literal.strip().lower()
+        try:
+            parsed = int(text, 0)
+        except ValueError as exc:
+            raise TypeError(
+                f"{context} string literal {literal!r} is not a valid integer literal"
+            ) from exc
+        return self._check_integer_literal_range(parsed, target_dtype, context)
+
+    def _check_integer_literal_range(
+        self,
+        value: int,
+        target_dtype: ScalarType,
+        context: str,
+    ) -> int:
+        bits = integer_bitwidth(target_dtype)
+        signedness = integer_signedness(target_dtype)
+        assert bits is not None
+        if signedness == "unsigned":
+            min_value = 0
+            max_value = (1 << bits) - 1
+        else:
+            min_value = -(1 << (bits - 1))
+            max_value = (1 << (bits - 1)) - 1
+        if value < min_value or value > max_value:
+            raise TypeError(
+                f"{context} {value} is out of range for {target_dtype.name} in TileLang DSL v1"
+            )
+        return value
 
     def _float_from_bit_pattern(
         self,

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -4007,6 +4007,17 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("pto.i32 value must be a scalar or index value", str(ctx.exception))
 
+    def test_scalar_constructor_accepts_integer_string_literals(self) -> None:
+        @pto.vkernel(op="scalar_constructor_integer_string_literals_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            x = pto.i16("0x7FFF")
+            y = pto.i32("0x7FFFFFFF")
+            return None
+
+        text = kernel.mlir_text()
+        self.assertIn("= arith.constant 32767 : i16", text)
+        self.assertIn("= arith.constant 2147483647 : i32", text)
+
     def test_scalar_constructor_rejects_out_of_range_integer_literal(self) -> None:
         @pto.vkernel(op="scalar_constructor_oob_int_unique", dtypes=[(pto.f32,)])
         def kernel(inp: pto.TensorView):
@@ -4017,6 +4028,17 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             kernel.mlir_text()
 
         self.assertIn("out of range for i8", str(ctx.exception))
+
+    def test_scalar_constructor_rejects_out_of_range_integer_string_literal(self) -> None:
+        @pto.vkernel(op="scalar_constructor_oob_integer_string_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            x = pto.i16("0x8000")
+            return None
+
+        with self.assertRaises(TypeError) as ctx:
+            kernel.mlir_text()
+
+        self.assertIn("out of range for i16", str(ctx.exception))
 
     def test_inferred_vecscope_propagates_bindings_to_constexpr_if(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- accept integer string literals such as `pto.i16("0x7FFF")` and `pto.i32("0x7FFFFFFF")` in TileLang DSL scalar constructors
- reuse one shared integer range checker for both numeric and string literal paths
- add regression tests for accepted integer string literals and out-of-range failures

## Validation
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1 -k scalar_constructor -v`

Closes #174
