### PR TITLE
fix(ptoas): make vpto backend own tile op expansion

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -818,8 +818,7 @@ void ExpandTileOpPass::runOnOperation() {
 
   if (tilelangPath.empty()) {
     mod.emitError(
-        "ExpandTileOp requires a non-empty tilelang-path when "
-        "--enable-tile-op-expand is set");
+        "ExpandTileOp requires a non-empty tilelang-path on the VPTO backend");
     signalPassFailure();
     return;
   }

--- a/test/dsl/expand_tile_op_tilelang_tadds.pto
+++ b/test/dsl/expand_tile_op_tilelang_tadds.pto
@@ -5,6 +5,7 @@
 
 // Test ExpandTileOp expansion for pto.tadds in the VPTO pipeline.
 //
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
 // RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --emit-vpto %s -o - | FileCheck %s
 
 // CHECK: func.func @TADDS()

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -200,7 +200,8 @@ static llvm::cl::opt<bool> enableInsertSync("enable-insert-sync",
 static llvm::cl::opt<bool> enableTileOpExpand(
     "enable-tile-op-expand",
     llvm::cl::desc(
-        "Enable Tile-to-Vector lowering path (memref->tile_buf recovery)"),
+        "Deprecated compatibility flag. TileOp expansion is controlled by "
+        "--pto-backend=vpto."),
     llvm::cl::init(false));
 
 #ifndef PTOAS_DEFAULT_TILELANG_PATH
@@ -1121,31 +1122,29 @@ static LogicalResult prepareVPTOForEmission(ModuleOp module) {
 
 static LogicalResult lowerPTOToVPTOBackend(ModuleOp module) {
   PassManager backendPM(module.getContext());
-  if (enableTileOpExpand) {
-    // TileOp Expand path:
-    //   1. MemrefToTileBuf: recover tile_buf from memref
-    //   2. ExpandTileOp: instantiate TileLang DSL templates, replace tile ops
-    //      with func.call to template functions (tile_buf params)
-    //   3. InlineLibCall: inline template function bodies
-    //   4. FoldTileBufIntrinsics: fold tile_buf_addr / tile_valid_rows /
-    //      tile_valid_cols to concrete memref/constant values
-    backendPM.addPass(pto::createMemrefToTileBufPass());
+  // TileOp Expand path:
+  //   1. MemrefToTileBuf: recover tile_buf from memref
+  //   2. ExpandTileOp: instantiate TileLang DSL templates, replace tile ops
+  //      with func.call to template functions (tile_buf params)
+  //   3. InlineLibCall: inline template function bodies
+  //   4. FoldTileBufIntrinsics: fold tile_buf_addr / tile_valid_rows /
+  //      tile_valid_cols to concrete memref/constant values
+  backendPM.addPass(pto::createMemrefToTileBufPass());
 
-    pto::ExpandTileOpOptions expandOpts;
-    expandOpts.tilelangPath = tilelangPath;
-    expandOpts.tilelangPkgPath = tilelangPkgPath;
-    backendPM.addPass(pto::createExpandTileOpPass(expandOpts));
+  pto::ExpandTileOpOptions expandOpts;
+  expandOpts.tilelangPath = tilelangPath;
+  expandOpts.tilelangPkgPath = tilelangPkgPath;
+  backendPM.addPass(pto::createExpandTileOpPass(expandOpts));
 
-    backendPM.addPass(pto::createPTOInlineLibCallPass());
-    backendPM.addNestedPass<mlir::func::FuncOp>(
-        pto::createFoldTileBufIntrinsicsPass());
-    // FoldTileBufIntrinsics materializes many constant branch conditions.
-    // Clean them up immediately on the TileOp expansion path before the
-    // authoring-stage VPTO verifier and let the existing CSE passes remove the
-    // resulting dead values later in the pipeline.
-    backendPM.addPass(mlir::createSCCPPass());
-    backendPM.addPass(mlir::createCanonicalizerPass());
-  }
+  backendPM.addPass(pto::createPTOInlineLibCallPass());
+  backendPM.addNestedPass<mlir::func::FuncOp>(
+      pto::createFoldTileBufIntrinsicsPass());
+  // FoldTileBufIntrinsics materializes many constant branch conditions.
+  // Clean them up immediately on the TileOp expansion path before the
+  // authoring-stage VPTO verifier and let the existing CSE passes remove the
+  // resulting dead values later in the pipeline.
+  backendPM.addPass(mlir::createSCCPPass());
+  backendPM.addPass(mlir::createCanonicalizerPass());
   if (failed(applyConfiguredPassManagerCLOptions(backendPM,
                                                  "VPTO backend lowering")))
     return failure();


### PR DESCRIPTION
## Summary
- make TileOp expansion on the VPTO path depend on `--pto-backend=vpto` instead of `--enable-tile-op-expand`
- keep `--enable-tile-op-expand` as a deprecated compatibility flag with no behavioral effect
- extend the tadds VPTO regression to cover both plain `vpto` and the legacy compatibility flag

## Validation
- `ninja -C build ptoas`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto test/dsl/expand_tile_op_tilelang_tadds.pto -o - | FileCheck test/dsl/expand_tile_op_tilelang_tadds.pto`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --emit-vpto test/dsl/expand_tile_op_tilelang_tadds.pto -o - | FileCheck test/dsl/expand_tile_op_tilelang_tadds.pto`

Closes #162