### PR TITLE
fix(dsl): require hex strings for integer bit patterns

### DIFF
--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -37,6 +37,37 @@ Integer sign semantics are part of the DSL type surface. `pto.si16`,
 `pto.ui16`, and `pto.i16` are distinct scalar dtypes and lower to `si16`,
 `ui16`, and `i16` respectively in VPTO IR.
 
+### Integer Literal Guidance
+
+For ordinary integer constants, prefer plain integer literals instead of
+string forms.
+
+```python
+count = pto.i32(1024)
+delta = pto.i16(-12)
+min_i32 = pto.i32(-2147483648)
+unsigned_hi = pto.ui16(32768)
+```
+
+Integer string literals are reserved for explicit bit-pattern authoring. They
+must use hex form.
+
+```python
+# Use hex strings only when you intentionally want fixed-width bit-pattern
+# interpretation at the target dtype width.
+hi_bit = pto.i32("0x80000000")   # -2147483648
+all_ones = pto.i16("0xFFFF")     # -1
+unsigned_hi = pto.ui16("0x8000") # 32768
+```
+
+Rules:
+- Prefer plain integer literals such as `pto.i32(1024)` or `pto.i16(-12)` for normal integer authoring.
+- Integer string literals must use hex bit-pattern form such as `"0xFFFF"`.
+- Ordinary integer strings such as `"1024"` or `"-12"` are rejected; write them as integer literals instead.
+- For signed and signless integer dtypes (`pto.i*`, `pto.si*`), hex strings use two's-complement interpretation at the target dtype width.
+- For unsigned integer dtypes (`pto.ui*`), hex strings keep their unsigned value.
+- Hex strings must fit within the target bit width. For example, `pto.i16("0x10000")` is rejected because the literal exceeds 16 bits.
+
 ### Floating-Point Literal Forms
 
 `pto.f16(...)`, `pto.bf16(...)`, and `pto.f32(...)` accept multiple literal forms.

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -1,3 +1,13 @@
+<!--
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+-->
+
 ## Type System
 
 ### Scalar Types

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4234,12 +4234,26 @@ class _SemanticAnalyzer:
         context: str,
     ) -> int:
         text = literal.strip().lower()
+        bits = integer_bitwidth(target_dtype)
+        signedness = integer_signedness(target_dtype)
+        assert bits is not None
+        signless_or_signed = signedness != "unsigned"
+        if not text.startswith("0x"):
+            raise TypeError(
+                f"{context} string literals must use hex bit-pattern form like \"0xFF\" in TileLang DSL v1"
+            )
         try:
-            parsed = int(text, 0)
+            parsed = int(text, 16)
         except ValueError as exc:
             raise TypeError(
-                f"{context} string literal {literal!r} is not a valid integer literal"
+                f"{context} string literal {literal!r} is not a valid hex bit-pattern"
             ) from exc
+        if parsed >= (1 << bits):
+            raise TypeError(
+                f"{context} bit-pattern literal {literal!r} exceeds {bits}-bit width for {target_dtype.name}"
+            )
+        if signless_or_signed and parsed >= (1 << (bits - 1)):
+            parsed -= 1 << bits
         return self._check_integer_literal_range(parsed, target_dtype, context)
 
     def _check_integer_literal_range(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -4007,16 +4007,33 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("pto.i32 value must be a scalar or index value", str(ctx.exception))
 
-    def test_scalar_constructor_accepts_integer_string_literals(self) -> None:
-        @pto.vkernel(op="scalar_constructor_integer_string_literals_unique", dtypes=[(pto.f32,)])
+    def test_scalar_constructor_accepts_integer_hex_bit_pattern_strings(self) -> None:
+        @pto.vkernel(op="scalar_constructor_integer_hex_bit_patterns_unique", dtypes=[(pto.f32,)])
         def kernel(inp: pto.TensorView):
             x = pto.i16("0x7FFF")
             y = pto.i32("0x7FFFFFFF")
+            z = pto.i16("0x8000")
+            a = pto.i32("0x80000000")
+            b = pto.ui16("0x8000")
             return None
 
         text = kernel.mlir_text()
         self.assertIn("= arith.constant 32767 : i16", text)
         self.assertIn("= arith.constant 2147483647 : i32", text)
+        self.assertIn("= arith.constant -32768 : i16", text)
+        self.assertIn("= arith.constant -2147483648 : i32", text)
+        self.assertIn("= arith.constant 32768 : i16", text)
+
+    def test_scalar_constructor_rejects_non_hex_integer_string_literals(self) -> None:
+        @pto.vkernel(op="scalar_constructor_non_hex_integer_strings_unique", dtypes=[(pto.f32,)])
+        def kernel(inp: pto.TensorView):
+            x = pto.i32("1024")
+            return None
+
+        with self.assertRaises(TypeError) as ctx:
+            kernel.mlir_text()
+
+        self.assertIn("string literals must use hex bit-pattern form", str(ctx.exception))
 
     def test_scalar_constructor_rejects_out_of_range_integer_literal(self) -> None:
         @pto.vkernel(op="scalar_constructor_oob_int_unique", dtypes=[(pto.f32,)])
@@ -4032,13 +4049,13 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
     def test_scalar_constructor_rejects_out_of_range_integer_string_literal(self) -> None:
         @pto.vkernel(op="scalar_constructor_oob_integer_string_unique", dtypes=[(pto.f32,)])
         def kernel(inp: pto.TensorView):
-            x = pto.i16("0x8000")
+            x = pto.i16("0x10000")
             return None
 
         with self.assertRaises(TypeError) as ctx:
             kernel.mlir_text()
 
-        self.assertIn("out of range for i16", str(ctx.exception))
+        self.assertIn("exceeds 16-bit width for i16", str(ctx.exception))
 
     def test_inferred_vecscope_propagates_bindings_to_constexpr_if(self) -> None:
         @pto.vkernel(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import tempfile
 import unittest
 from unittest import mock


### PR DESCRIPTION
## Summary
- restrict integer string constructors to hex bit-pattern strings only
- reject ordinary integer strings such as `"1024"` and require plain integer literals for normal integer constants
- document the stricter integer literal guidance in the TileLang DSL user guide

## Validation
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1 -k scalar_constructor -v`

Closes #174
