### PR TITLE
fix(vpto): normalize signed integer vector decls

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -48,9 +48,31 @@ static std::string getElementTypeFragment(Type type);
 static Type getElementTypeFromVectorLike(Type type);
 static std::optional<int64_t> getElementCountFromVectorLike(Type type);
 
+static Type normalizeIntegerTypeForLLVMLowering(Type type, Builder &builder) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    if (!intType.isSignless())
+      return builder.getIntegerType(intType.getWidth());
+    return type;
+  }
+
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    Type normalizedElement =
+        normalizeIntegerTypeForLLVMLowering(vecType.getElementType(), builder);
+    if (normalizedElement == vecType.getElementType())
+      return type;
+    return VectorType::get(vecType.getShape(), normalizedElement,
+                           vecType.getScalableDims());
+  }
+
+  return type;
+}
+
 static Type convertVPTOType(Type type, Builder &builder) {
-  if (auto vecType = dyn_cast<pto::VRegType>(type))
-    return VectorType::get({vecType.getElementCount()}, vecType.getElementType());
+  if (auto vecType = dyn_cast<pto::VRegType>(type)) {
+    Type elementType =
+        normalizeIntegerTypeForLLVMLowering(vecType.getElementType(), builder);
+    return VectorType::get({vecType.getElementCount()}, elementType);
+  }
   if (isa<pto::MaskType>(type))
     return VectorType::get({256}, builder.getI1Type());
   if (isa<pto::AlignType>(type))
@@ -60,7 +82,7 @@ static Type convertVPTOType(Type type, Builder &builder) {
         builder.getContext(),
         static_cast<unsigned>(ptrType.getMemorySpace().getAddressSpace()));
   }
-  return type;
+  return normalizeIntegerTypeForLLVMLowering(type, builder);
 }
 
 static bool hasVPTOConvertibleType(Type type) {

--- a/test/basic/issue_173_vpto_llvm.pto
+++ b/test/basic/issue_173_vpto_llvm.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o %t.ll
+// RUN: FileCheck %s < %t.ll
+
+// Regression test for issue #173: signed and signless i16 vector stores should
+// share the same LLVM/HIVM declaration after VPTO type conversion.
+module attributes {pto.target_arch = "a5"} {
+  func.func @store_signed_i16(%value: !pto.vreg<128xsi16>, %dst: !pto.ptr<si16, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      pto.vsts %value, %dst[%c0], %mask : !pto.vreg<128xsi16>, !pto.ptr<si16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+
+  func.func @store_signless_i16(%value: !pto.vreg<128xi16>, %dst: !pto.ptr<i16, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      pto.vsts %value, %dst[%c0], %mask : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}
+
+// CHECK-COUNT-1: declare void @llvm.hivm.vstsx1.v128s16(<128 x i16>, ptr addrspace(6), i32, i32, i32, <256 x i1>)
+// CHECK-LABEL: define void @store_signed_i16(
+// CHECK: call void @llvm.hivm.vstsx1.v128s16(<128 x i16> {{.*}}, ptr addrspace(6) {{.*}}, i32 0, i32 1, i32 0, <256 x i1> {{.*}})
+// CHECK-LABEL: define void @store_signless_i16(
+// CHECK: call void @llvm.hivm.vstsx1.v128s16(<128 x i16> {{.*}}, ptr addrspace(6) {{.*}}, i32 0, i32 1, i32 0, <256 x i1> {{.*}})

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/compare.py
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/compare.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# case: vpto/issue-173-vsts-signed-signless
+# family: vpto
+# target_ops: pto.vlds, pto.vsts
+# scenarios: signed-i16, signless-i16, same-module, issue-173-regression
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_bin(golden_path: str, output_path: str) -> bool:
+    if not os.path.exists(golden_path) or not os.path.exists(output_path):
+        return False
+    golden = np.fromfile(golden_path, dtype=np.int16)
+    output = np.fromfile(output_path, dtype=np.int16)
+    return golden.shape == output.shape and np.array_equal(golden, output)
+
+
+def main() -> None:
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = compare_bin("golden_v2.bin", "v2.bin")
+    ok = compare_bin("golden_v4.bin", "v4.bin") and ok
+    if not ok:
+        if strict:
+            print("[ERROR] compare failed")
+            sys.exit(2)
+        print("[WARN] compare failed (non-gating)")
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/golden.py
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/golden.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# case: vpto/issue-173-vsts-signed-signless
+# family: vpto
+# target_ops: pto.vlds, pto.vsts
+# scenarios: signed-i16, signless-i16, same-module, issue-173-regression
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+ELEMS = 1024
+SEED = 173
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    signed = rng.integers(-32768, 32768, size=ELEMS, dtype=np.int16)
+    signless = rng.integers(-32768, 32768, size=ELEMS, dtype=np.int16)
+
+    signed[:16] = np.array(
+        [-32768, -30000, -12345, -1, 0, 1, 2, 3, 7, 15, 127, 255, 1024, 12345, 30000, 32767],
+        dtype=np.int16,
+    )
+    signless[:16] = np.array(
+        [32767, 30000, 12345, 1024, 255, 127, 15, 7, 3, 2, 1, 0, -1, -12345, -30000, -32768],
+        dtype=np.int16,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    signed.tofile(output_dir / "v1.bin")
+    np.zeros(ELEMS, dtype=np.int16).tofile(output_dir / "v2.bin")
+    signless.tofile(output_dir / "v3.bin")
+    np.zeros(ELEMS, dtype=np.int16).tofile(output_dir / "v4.bin")
+    signed.tofile(output_dir / "golden_v2.bin")
+    signless.tofile(output_dir / "golden_v4.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/kernel.pto
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/kernel.pto
@@ -1,0 +1,81 @@
+// -----------------------------------------------------------------------------
+// case: vpto/issue-173-vsts-signed-signless
+// family: vpto
+// target_ops: pto.vlds, pto.vsts
+// scenarios: signed-i16, signless-i16, same-module, issue-173-regression
+// -----------------------------------------------------------------------------
+module attributes {pto.target_arch = "a5"} {
+  func.func @copy_signed_i16_kernel(%arg0: !pto.ptr<si16, gm>,
+                                    %arg1: !pto.ptr<si16, gm>) {
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<si16, ub>
+    %ub_out = pto.castptr %c2048_i64 : i64 -> !pto.ptr<si16, ub>
+
+    %false = arith.constant false
+    pto.set_loop_size_outtoub %c1_i64, %c1_i64 : i64, i64
+    pto.copy_gm_to_ubuf %arg0, %ub_in, %c0_i64, %c32_i64, %c64_i64, %c0_i64, %c0_i64, %false, %c0_i64, %c64_i64, %c64_i64 : !pto.ptr<si16, gm>, !pto.ptr<si16, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      scf.for %offset = %c0 to %c1024 step %c128 {
+        %vec = pto.vlds %ub_in[%offset] : !pto.ptr<si16, ub> -> !pto.vreg<128xsi16>
+        pto.vsts %vec, %ub_out[%offset], %mask : !pto.vreg<128xsi16>, !pto.ptr<si16, ub>, !pto.mask<b16>
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.set_loop_size_ubtoout %c1_i64, %c1_i64 : i64, i64
+    pto.copy_ubuf_to_gm %ub_out, %arg1, %c0_i64, %c32_i64, %c64_i64, %c0_i64, %c64_i64, %c64_i64 : !pto.ptr<si16, ub>, !pto.ptr<si16, gm>, i64, i64, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @copy_signless_i16_kernel(%arg0: !pto.ptr<i16, gm>,
+                                      %arg1: !pto.ptr<i16, gm>) {
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<i16, ub>
+    %ub_out = pto.castptr %c2048_i64 : i64 -> !pto.ptr<i16, ub>
+
+    %false = arith.constant false
+    pto.set_loop_size_outtoub %c1_i64, %c1_i64 : i64, i64
+    pto.copy_gm_to_ubuf %arg0, %ub_in, %c0_i64, %c32_i64, %c64_i64, %c0_i64, %c0_i64, %false, %c0_i64, %c64_i64, %c64_i64 : !pto.ptr<i16, gm>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      scf.for %offset = %c0 to %c1024 step %c128 {
+        %vec = pto.vlds %ub_in[%offset] : !pto.ptr<i16, ub> -> !pto.vreg<128xi16>
+        pto.vsts %vec, %ub_out[%offset], %mask : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.set_loop_size_ubtoout %c1_i64, %c1_i64 : i64, i64
+    pto.copy_ubuf_to_gm %ub_out, %arg1, %c0_i64, %c32_i64, %c64_i64, %c0_i64, %c64_i64, %c64_i64 : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/launch.cpp
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/launch.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// ---------------------------------------------------------------------------
+// PTOAS compatibility layer
+// ---------------------------------------------------------------------------
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+
+#if defined(__CCE_AICORE__) && defined(PTOAS_ENABLE_CCE_PRINT)
+#include <ccelib/print/print.h>
+#endif
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+    uint16_t mrgSortList0;
+    uint16_t mrgSortList1;
+    uint16_t mrgSortList2;
+    uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void copy_signed_i16_kernel(__gm__ int16_t *v1,
+                                                           __gm__ int16_t *v2);
+extern "C" __global__ [aicore] void copy_signless_i16_kernel(
+    __gm__ int16_t *v3, __gm__ int16_t *v4);
+
+void LaunchCopySignedI16Kernel(int16_t *v1, int16_t *v2, void *stream) {
+  copy_signed_i16_kernel<<<1, nullptr, stream>>>((__gm__ int16_t *)v1,
+                                                 (__gm__ int16_t *)v2);
+}
+
+void LaunchCopySignlessI16Kernel(int16_t *v3, int16_t *v4, void *stream) {
+  copy_signless_i16_kernel<<<1, nullptr, stream>>>((__gm__ int16_t *)v3,
+                                                   (__gm__ int16_t *)v4);
+}

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/main.cpp
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/main.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// -----------------------------------------------------------------------------
+// case: vpto/issue-173-vsts-signed-signless
+// family: vpto
+// target_ops: pto.vlds, pto.vsts
+// scenarios: signed-i16, signless-i16, same-module, issue-173-regression
+// -----------------------------------------------------------------------------
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+
+using namespace PtoTestCommon;
+
+#ifndef TMRGSORT_HPP
+struct MrgSortExecutedNumList {
+    uint16_t mrgSortList0;
+    uint16_t mrgSortList1;
+    uint16_t mrgSortList2;
+    uint16_t mrgSortList3;
+};
+#endif
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      const char *_recent = aclGetRecentErrMsg();                                \
+      if (_recent != nullptr && _recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", _recent);             \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+#define FILE_CHECK(expr, path)                                                   \
+  do {                                                                           \
+    if (!(expr)) {                                                               \
+      std::fprintf(stderr, "[ERROR] file operation failed: %s (%s:%d)\n",       \
+                   path, __FILE__, __LINE__);                                    \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchCopySignedI16Kernel(int16_t *v1, int16_t *v2, void *stream);
+void LaunchCopySignlessI16Kernel(int16_t *v3, int16_t *v4, void *stream);
+
+int main() {
+  constexpr size_t elemCount = 1024;
+  constexpr size_t fileSize = elemCount * sizeof(int16_t);
+  size_t inputFileSize = fileSize;
+
+  int16_t *v1Host = nullptr;
+  int16_t *v2Host = nullptr;
+  int16_t *v3Host = nullptr;
+  int16_t *v4Host = nullptr;
+  int16_t *v1Device = nullptr;
+  int16_t *v2Device = nullptr;
+  int16_t *v3Device = nullptr;
+  int16_t *v4Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize));
+  ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSize));
+  ACL_CHECK(aclrtMallocHost((void **)(&v3Host), fileSize));
+  ACL_CHECK(aclrtMallocHost((void **)(&v4Host), fileSize));
+
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v4Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  FILE_CHECK(ReadFile("./v1.bin", inputFileSize, v1Host, fileSize) &&
+                 inputFileSize == fileSize,
+             "./v1.bin");
+  inputFileSize = fileSize;
+  FILE_CHECK(ReadFile("./v2.bin", inputFileSize, v2Host, fileSize) &&
+                 inputFileSize == fileSize,
+             "./v2.bin");
+  inputFileSize = fileSize;
+  FILE_CHECK(ReadFile("./v3.bin", inputFileSize, v3Host, fileSize) &&
+                 inputFileSize == fileSize,
+             "./v3.bin");
+  inputFileSize = fileSize;
+  FILE_CHECK(ReadFile("./v4.bin", inputFileSize, v4Host, fileSize) &&
+                 inputFileSize == fileSize,
+             "./v4.bin");
+
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize, v1Host, fileSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v2Device, fileSize, v2Host, fileSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v3Device, fileSize, v3Host, fileSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v4Device, fileSize, v4Host, fileSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchCopySignedI16Kernel(v1Device, v2Device, stream);
+  LaunchCopySignlessI16Kernel(v3Device, v4Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+
+  ACL_CHECK(aclrtMemcpy(v2Host, fileSize, v2Device, fileSize,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v4Host, fileSize, v4Device, fileSize,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+
+  FILE_CHECK(WriteFile("./v2.bin", v2Host, fileSize), "./v2.bin");
+  FILE_CHECK(WriteFile("./v4.bin", v4Host, fileSize), "./v4.bin");
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFree(v2Device);
+  aclrtFree(v3Device);
+  aclrtFree(v4Device);
+  aclrtFreeHost(v1Host);
+  aclrtFreeHost(v2Host);
+  aclrtFreeHost(v3Host);
+  aclrtFreeHost(v4Host);
+  if (stream != nullptr)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vpto/issue-173-vsts-signed-signless/stub.cpp
+++ b/test/vpto/cases/vpto/issue-173-vsts-signed-signless/stub.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <cstdint>
+
+#ifndef __global__
+#define __global__
+#endif
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+extern "C" __global__ [aicore] void copy_signed_i16_kernel(__gm__ int16_t *v1,
+                                                           __gm__ int16_t *v2) {
+  (void)v1;
+  (void)v2;
+}
+
+extern "C" __global__ [aicore] void copy_signless_i16_kernel(__gm__ int16_t *v3,
+                                                             __gm__ int16_t *v4) {
+  (void)v3;
+  (void)v4;
+}


### PR DESCRIPTION
## Summary
- normalize signed integer vector types to signless in VPTO LLVM emitter before building intrinsic declarations
- add a regression test covering mixed `!pto.vreg<128xsi16>` / `!pto.vreg<128xi16>` stores sharing `llvm.hivm.vstsx1.v128s16`

## Root Cause
`buildVstsCallee()` maps both signed and signless i16 vector stores to the same intrinsic name `llvm.hivm.vstsx1.v128s16`, but the declaration dedup path compared the pre-lowered MLIR `FunctionType` directly. In the mixed case, one declaration carried a signed integer vector type and the other carried a signless integer vector type, so `materializeDecls()` treated them as conflicting even though official LLVM lowering normalizes both to the same `<128 x i16>` declaration.

## Validation
- `/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm test/basic/issue_173_vpto_llvm.pto -o /tmp/issue_173_test_pr.ll && FileCheck test/basic/issue_173_vpto_llvm.pto < /tmp/issue_173_test_pr.ll`
- `/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm test/basic/vbitcast_vpto_llvm.pto -o - | FileCheck test/basic/vbitcast_vpto_llvm.pto`

Fixes #173
