### PR TITLE
Support more part modes and membar types

### DIFF
--- a/docs/isa/01-pipeline-sync.md
+++ b/docs/isa/01-pipeline-sync.md
@@ -116,21 +116,30 @@ The `mode` parameter controls how `get_buf` and `rls_buf` interact with pipeline
 ### `pto.mem_bar`
 
 - **syntax:** `pto.mem_bar "BARRIER_TYPE"`
-- **semantics:** Intra-vector-pipe memory fence within `__VEC_SCOPE__`. Required when UB addresses alias between vector load/store operations.
+- **semantics:** Shared-memory (UB address space) memory fence within `__VEC_SCOPE__`. Required when UB addresses alias between memory operations. The barrier type selects which classes of prior instructions must complete before which classes of subsequent instructions may proceed.
 
 ```c
 mem_bar(barrier_type);
 ```
 
-**Barrier types:**
+**Barrier types** are organized into three families by the scope of prior vs. subsequent instructions:
 
-| Type | Semantics |
-|------|-----------|
-| `VV_ALL` | All prior vector ops complete before subsequent |
-| `VST_VLD` | All prior vector stores visible before subsequent loads |
-| `VLD_VST` | All prior vector loads complete before subsequent stores |
+| Family | Barrier type | Prior instructions | Subsequent instructions |
+|--------|-------------|-------------------|------------------------|
+| **VV** (vector→vector) | `VV_ALL` | All vector load/store | All vector load/store |
+| | `VST_VLD` | All vector store | All vector load |
+| | `VLD_VST` | All vector load | All vector store |
+| | `VST_VST` | All vector store | All vector store |
+| **VS** (vector→scalar) | `VS_ALL` | All vector load/store | All scalar load/store |
+| | `VST_LD` | All vector store | All scalar load |
+| | `VLD_ST` | All vector load | All scalar store |
+| | `VST_ST` | All vector store | All scalar store |
+| **SV** (scalar→vector) | `SV_ALL` | All scalar load/store | All vector load/store |
+| | `ST_VLD` | All scalar store | All vector load |
+| | `LD_VST` | All scalar load | All vector store |
+| | `ST_VST` | All scalar store | All vector store |
 
-**Example:** Ensure stores are visible before loads to same UB region:
+**Example:** Ensure vector stores are visible before subsequent vector loads to the same UB region:
 ```mlir
 pto.vsts %v0, %ub[%c0] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>
 pto.mem_bar "VST_VLD"

--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -94,13 +94,26 @@ for (int i = 0; i < min(N, M); i++)
 ### Part Modes
 
 Use `part` when a width-changing conversion writes only one half of each wider
-destination lane group. This is typically used in even/odd placement forms such
-as `32 -> 16` or `16 -> 32` style conversions.
+destination lane group.
+
+- `Part` (`PART_EVEN`, `PART_ODD`)
+  - Used by ordinary width-changing conversions.
+  - Typical cases include `32 -> 16`, `16 -> 32`, and other even/odd packing
+    or unpacking forms.
+- `Part_T` (`PART_P0`, `PART_P1`, `PART_P2`, `PART_P3`)
+  - Used by lower-level packed placement forms.
+  - Typical cases include `32 -> 8`, packed fp8/fp4 conversion paths, and
+    other flows where the result is written into one of four sub-parts before a
+    later merge or compact step.
 
 | Mode | Description |
 |------|-------------|
 | `EVEN` | Output to even-indexed lanes |
 | `ODD` | Output to odd-indexed lanes |
+| `P0` | Output to sub-part 0 in 4-way packed placement forms |
+| `P1` | Output to sub-part 1 in 4-way packed placement forms |
+| `P2` | Output to sub-part 2 in 4-way packed placement forms |
+| `P3` | Output to sub-part 3 in 4-way packed placement forms |
 
 ---
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -560,6 +560,24 @@ static std::optional<StringRef> normalizeEvenOddPartToken(StringRef token) {
   return std::nullopt;
 }
 
+static std::optional<StringRef> normalizePacked4PartToken(StringRef token) {
+  if (token == "P0" || token == "PART_P0")
+    return StringRef("P0");
+  if (token == "P1" || token == "PART_P1")
+    return StringRef("P1");
+  if (token == "P2" || token == "PART_P2")
+    return StringRef("P2");
+  if (token == "P3" || token == "PART_P3")
+    return StringRef("P3");
+  return std::nullopt;
+}
+
+static std::optional<StringRef> normalizeVcvtPartToken(StringRef token) {
+  if (auto normalized = normalizeEvenOddPartToken(token))
+    return normalized;
+  return normalizePacked4PartToken(token);
+}
+
 namespace {
 
 enum class VcvtElemKind {
@@ -580,6 +598,11 @@ struct VcvtContract {
   bool requiresRnd;
   bool requiresSat;
   bool requiresPart;
+};
+
+enum class VcvtPartFamily {
+  EvenOdd,
+  Packed4,
 };
 
 static VcvtElemKind classifyVcvtElemType(Type type) {
@@ -626,6 +649,27 @@ static std::optional<unsigned> getVcvtElemBitWidth(VcvtElemKind kind) {
     return std::nullopt;
   }
   return std::nullopt;
+}
+
+static std::optional<VcvtPartFamily> classifyVcvtPartFamily(unsigned srcBits,
+                                                            unsigned dstBits) {
+  unsigned largerBits = std::max(srcBits, dstBits);
+  unsigned smallerBits = std::min(srcBits, dstBits);
+  if (largerBits == smallerBits * 2)
+    return VcvtPartFamily::EvenOdd;
+  if (largerBits == smallerBits * 4)
+    return VcvtPartFamily::Packed4;
+  return std::nullopt;
+}
+
+static bool isValidVcvtPartForFamily(StringRef part, VcvtPartFamily family) {
+  switch (family) {
+  case VcvtPartFamily::EvenOdd:
+    return part == "EVEN" || part == "ODD";
+  case VcvtPartFamily::Packed4:
+    return part == "P0" || part == "P1" || part == "P2" || part == "P3";
+  }
+  return false;
 }
 
 static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
@@ -2310,8 +2354,7 @@ ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
                                       normalizeRoundModeToken)) ||
       failed(normalizeNamedStringAttr("rnd", "rnd", normalizeRoundModeToken)) ||
       failed(normalizeNamedStringAttr("sat", "sat", normalizeSaturationToken)) ||
-      failed(
-          normalizeNamedStringAttr("part", "part", normalizeEvenOddPartToken)))
+      failed(normalizeNamedStringAttr("part", "part", normalizeVcvtPartToken)))
     return failure();
 
   result.addAttributes(attrs);
@@ -2371,8 +2414,20 @@ LogicalResult VcvtOp::verify() {
 
   if (getPartAttr()) {
     StringRef part = *getPart();
-    if (!normalizeEvenOddPartToken(part))
-      return emitOpError("part must be EVEN or ODD");
+    auto normalizedPart = normalizeVcvtPartToken(part);
+    if (!normalizedPart)
+      return emitOpError("part must be one of EVEN/ODD/P0/P1/P2/P3");
+    auto partFamily = classifyVcvtPartFamily(*inputElemBits, *resultElemBits);
+    if (!partFamily)
+      return emitOpError("part attr is not supported for this vcvt width relation");
+    if (!isValidVcvtPartForFamily(*normalizedPart, *partFamily)) {
+      switch (*partFamily) {
+      case VcvtPartFamily::EvenOdd:
+        return emitOpError("part must be EVEN or ODD for 8/16 and 16/32 vcvt forms");
+      case VcvtPartFamily::Packed4:
+        return emitOpError("part must be P0, P1, P2, or P3 for 8/32 vcvt forms");
+      }
+    }
   }
   if (static_cast<bool>(getPartAttr()) != contract->requiresPart) {
     return contract->requiresPart ? emitOpError("requires part attr for this vcvt type pair")

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -354,6 +354,20 @@ static std::optional<uint64_t> parsePartImmediate(StringRef part) {
   return std::nullopt;
 }
 
+static std::optional<uint64_t> parseVcvtPartImmediate(StringRef part) {
+  if (part == "EVEN" || part == "PART_EVEN" || part == "P0" ||
+      part == "PART_P0")
+    return 0;
+  if (part == "ODD" || part == "PART_ODD" || part == "P1" ||
+      part == "PART_P1")
+    return 1;
+  if (part == "P2" || part == "PART_P2")
+    return 2;
+  if (part == "P3" || part == "PART_P3")
+    return 3;
+  return std::nullopt;
+}
+
 static std::optional<uint64_t> parsePredicateStoreDistImmediate(StringRef dist) {
   if (dist == "NORM")
     return 0;
@@ -4187,7 +4201,8 @@ public:
     }
 
     if ((*contract).requiresPart) {
-      auto part = op.getPartAttr() ? parsePartImmediate(*op.getPart()) : std::nullopt;
+      auto part =
+          op.getPartAttr() ? parseVcvtPartImmediate(*op.getPart()) : std::nullopt;
       if (!part)
         return rewriter.notifyMatchFailure(op, "vcvt requires valid part attr");
       Value partValue = getI32Constant(rewriter, op.getLoc(), *part);

--- a/lib/TileOps/tload_template.py
+++ b/lib/TileOps/tload_template.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 """`pto.tload` 的 TileLang DSL 模板"""
 
 import tilelang_dsl as pto

--- a/lib/TileOps/tstore_template.py
+++ b/lib/TileOps/tstore_template.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 """`pto.tstore` 的 TileLang DSL 模板"""
 
 import tilelang_dsl as pto

--- a/test/basic/membar_barrier_types_vpto_llvm.pto
+++ b/test/basic/membar_barrier_types_vpto_llvm.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @membar_all_documented_kinds() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.vecscope {
+      pto.mem_bar "VV_ALL"
+      pto.mem_bar "VST_VLD"
+      pto.mem_bar "VLD_VST"
+      pto.mem_bar "VST_VST"
+      pto.mem_bar "VS_ALL"
+      pto.mem_bar "VST_LD"
+      pto.mem_bar "VLD_ST"
+      pto.mem_bar "VST_ST"
+      pto.mem_bar "SV_ALL"
+      pto.mem_bar "ST_VLD"
+      pto.mem_bar "LD_VST"
+      pto.mem_bar "ST_VST"
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @membar_all_documented_kinds(
+// CHECK: call void @llvm.hivm.mem.bar.vv.all()
+// CHECK: call void @llvm.hivm.mem.bar.vst.vld()
+// CHECK: call void @llvm.hivm.mem.bar.vld.vst()
+// CHECK: call void @llvm.hivm.mem.bar.vst.vst()
+// CHECK: call void @llvm.hivm.mem.bar.vs.all()
+// CHECK: call void @llvm.hivm.mem.bar.vst.ld()
+// CHECK: call void @llvm.hivm.mem.bar.vld.st()
+// CHECK: call void @llvm.hivm.mem.bar.vst.st()
+// CHECK: call void @llvm.hivm.mem.bar.sv.all()
+// CHECK: call void @llvm.hivm.mem.bar.st.vld()
+// CHECK: call void @llvm.hivm.mem.bar.ld.vst()
+// CHECK: call void @llvm.hivm.mem.bar.st.vst()

--- a/test/basic/vcvt_part_modes_verify_invalid.pto
+++ b/test/basic/vcvt_part_modes_verify_invalid.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'pto.vcvt' op part must be P0, P1, P2, or P3 for 8/32 vcvt forms
+// CHECK: error: 'pto.vcvt' op part must be EVEN or ODD for 8/16 and 16/32 vcvt forms
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vcvt_u32_to_u8_rejects_even(%seed: ui32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.vecscope {
+      %src = pto.vbr %seed : ui32 -> !pto.vreg<64xui32>
+      %bad = pto.vcvt %src {sat = "SAT", part = "EVEN"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+    }
+    return
+  }
+
+  func.func @vcvt_u16_to_u8_rejects_p0(%seed: ui16) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.vecscope {
+      %src = pto.vbr %seed : ui16 -> !pto.vreg<128xui16>
+      %bad = pto.vcvt %src {sat = "SAT", part = "P0"} : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+    }
+    return
+  }
+}

--- a/test/basic/vcvt_part_modes_vpto_llvm.pto
+++ b/test/basic/vcvt_part_modes_vpto_llvm.pto
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vcvt_u32_to_u8_packed_parts(%seed: ui32, %dst: !pto.ptr<ui8, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %src = pto.vbr %seed : ui32 -> !pto.vreg<64xui32>
+      %p0 = pto.vcvt %src {sat = "SAT", part = "P0"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+      %p1 = pto.vcvt %src {sat = "SAT", part = "P1"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+      %p2 = pto.vcvt %src {sat = "SAT", part = "P2"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+      %p3 = pto.vcvt %src {sat = "SAT", part = "P3"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+      %m01 = pto.vor %p0, %p1, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+      %m23 = pto.vor %p2, %p3, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+      %out = pto.vor %m01, %m23, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+      pto.vsts %out, %dst[%c0], %mask : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @vcvt_u32_to_u8_packed_parts(
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 0)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 1)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 2)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 3)

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/compare.py
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/compare.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_bin(golden_path: str, output_path: str) -> bool:
+    if not os.path.exists(golden_path) or not os.path.exists(output_path):
+        return False
+    golden = np.fromfile(golden_path, dtype=np.uint8)
+    output = np.fromfile(output_path, dtype=np.uint8)
+    return golden.shape == output.shape and np.array_equal(golden, output)
+
+
+def main() -> None:
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = compare_bin("golden_v2.bin", "v2.bin")
+    if not ok:
+        if strict:
+            print("[ERROR] compare failed")
+            sys.exit(2)
+        print("[WARN] compare failed (non-gating)")
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/golden.py
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/golden.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# case: micro-op/conversion/vcvt-u32-to-u8-part-p0123
+# family: conversion
+# target_ops: pto.vcvt
+# scenarios: u32-to-u8, sat, part-p0123
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+ELEMS = 1024
+SEED = 23
+CHUNK = 256
+SUBCHUNK = 64
+U8_MAX = np.iinfo(np.uint8).max
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    data = rng.integers(0, 2000, size=ELEMS, dtype=np.uint32)
+    edge = np.array(
+        [
+            0,
+            1,
+            2,
+            3,
+            4,
+            7,
+            15,
+            31,
+            63,
+            127,
+            128,
+            129,
+            254,
+            255,
+            256,
+            257,
+            511,
+            512,
+            1023,
+            65535,
+            0xFFFFFFFF,
+        ],
+        dtype=np.uint32,
+    )
+    data[: edge.size] = edge
+
+    clipped = np.clip(data, 0, U8_MAX).astype(np.uint8)
+    golden = np.empty(ELEMS, dtype=np.uint8)
+    for offset in range(0, ELEMS, CHUNK):
+        p0 = clipped[offset : offset + SUBCHUNK]
+        p1 = clipped[offset + SUBCHUNK : offset + 2 * SUBCHUNK]
+        p2 = clipped[offset + 2 * SUBCHUNK : offset + 3 * SUBCHUNK]
+        p3 = clipped[offset + 3 * SUBCHUNK : offset + 4 * SUBCHUNK]
+        merged = np.empty(CHUNK, dtype=np.uint8)
+        merged[0::4] = p0
+        merged[1::4] = p1
+        merged[2::4] = p2
+        merged[3::4] = p3
+        golden[offset : offset + CHUNK] = merged
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data.tofile(output_dir / "v1.bin")
+    np.zeros(ELEMS, dtype=np.uint8).tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/kernel.pto
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------------
+// case: micro-op/conversion/vcvt-u32-to-u8-part-p0123
+// family: conversion
+// target_ops: pto.vcvt
+// scenarios: u32-to-u8, sat, part-p0123
+// -----------------------------------------------------------------------------
+module attributes {pto.target_arch = "a5"} {
+  func.func @vcvt_u32_to_u8_part_p0123_kernel(%arg0: !pto.ptr<ui32, gm>,
+                                              %arg1: !pto.ptr<ui8, gm>) {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c192 = arith.constant 192 : index
+    %c256 = arith.constant 256 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui8, ub>
+
+    %false = arith.constant false
+    pto.set_loop_size_outtoub %c1_i64, %c1_i64 : i64, i64
+    pto.copy_gm_to_ubuf %arg0, %ub_in, %c0_i64, %c32_i64, %c128_i64, %c0_i64, %c0_i64, %false, %c0_i64, %c128_i64, %c128_i64 : !pto.ptr<ui32, gm>, !pto.ptr<ui32, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %full_mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      scf.for %offset = %c0 to %c1024 step %c256 {
+        %offset_p1 = arith.addi %offset, %c64 : index
+        %offset_p2 = arith.addi %offset, %c128 : index
+        %offset_p3 = arith.addi %offset, %c192 : index
+        %src_p0 = pto.vlds %ub_in[%offset] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+        %src_p1 = pto.vlds %ub_in[%offset_p1] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+        %src_p2 = pto.vlds %ub_in[%offset_p2] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+        %src_p3 = pto.vlds %ub_in[%offset_p3] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+        %part_p0 = pto.vcvt %src_p0 {sat = "SAT", part = "P0"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+        %part_p1 = pto.vcvt %src_p1 {sat = "SAT", part = "P1"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+        %part_p2 = pto.vcvt %src_p2 {sat = "SAT", part = "P2"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+        %part_p3 = pto.vcvt %src_p3 {sat = "SAT", part = "P3"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+        %merged01 = pto.vor %part_p0, %part_p1, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+        %merged23 = pto.vor %part_p2, %part_p3, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+        %merged = pto.vor %merged01, %merged23, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
+        pto.vsts %merged, %ub_out[%offset], %full_mask : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.set_loop_size_ubtoout %c1_i64, %c1_i64 : i64, i64
+    pto.copy_ubuf_to_gm %ub_out, %arg1, %c0_i64, %c4_i64, %c256_i64, %c0_i64, %c256_i64, %c256_i64 : !pto.ptr<ui8, ub>, !pto.ptr<ui8, gm>, i64, i64, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/launch.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/launch.cpp
@@ -2,7 +2,7 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/launch.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/launch.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// ---------------------------------------------------------------------------
+// PTOAS compatibility layer
+// ---------------------------------------------------------------------------
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+
+#if defined(__CCE_AICORE__) && defined(PTOAS_ENABLE_CCE_PRINT)
+#include <ccelib/print/print.h>
+#endif
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+    uint16_t mrgSortList0;
+    uint16_t mrgSortList1;
+    uint16_t mrgSortList2;
+    uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void vcvt_u32_to_u8_part_p0123_kernel(
+    __gm__ uint32_t *v1, __gm__ uint8_t *v2);
+
+void LaunchVcvt_u32_to_u8_part_p0123_kernel(uint32_t *v1, uint8_t *v2,
+                                            void *stream) {
+  vcvt_u32_to_u8_part_p0123_kernel<<<1, nullptr, stream>>>(
+      (__gm__ uint32_t *)v1, (__gm__ uint8_t *)v2);
+}

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/main.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/main.cpp
@@ -2,7 +2,7 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/main.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/main.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// -----------------------------------------------------------------------------
+// case: micro-op/conversion/vcvt-u32-to-u8-part-p0123
+// family: conversion
+// target_ops: pto.vcvt
+// scenarios: u32-to-u8, sat, part-p0123
+// -----------------------------------------------------------------------------
+/**
+Copyright (c) 2025 Huawei Technologies Co., Ltd.
+*/
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+
+using namespace PtoTestCommon;
+
+#ifndef TMRGSORT_HPP
+struct MrgSortExecutedNumList {
+    uint16_t mrgSortList0;
+    uint16_t mrgSortList1;
+    uint16_t mrgSortList2;
+    uint16_t mrgSortList3;
+};
+#endif
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      const char *_recent = aclGetRecentErrMsg();                                \
+      if (_recent != nullptr && _recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", _recent);             \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVcvt_u32_to_u8_part_p0123_kernel(uint32_t *v1, uint8_t *v2,
+                                            void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(uint32_t);
+  size_t elemCount_v2 = 1024;
+  size_t fileSize_v2 = elemCount_v2 * sizeof(uint8_t);
+  uint32_t *v1Host = nullptr;
+  uint32_t *v1Device = nullptr;
+  uint8_t *v2Host = nullptr;
+  uint8_t *v2Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSize_v2));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ReadFile("./v2.bin", fileSize_v2, v2Host, fileSize_v2);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v2Device, fileSize_v2, v2Host, fileSize_v2,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVcvt_u32_to_u8_part_p0123_kernel(v1Device, v2Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v2Host, fileSize_v2, v2Device, fileSize_v2,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", v2Host, fileSize_v2);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFree(v2Device);
+  aclrtFreeHost(v1Host);
+  aclrtFreeHost(v2Host);
+  if (stream != nullptr)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/stub.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/stub.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include <cstdint>
+
+#ifndef __global__
+#define __global__
+#endif
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+extern "C" __global__ [aicore] void vcvt_u32_to_u8_part_p0123_kernel(
+    __gm__ uint32_t *v1, __gm__ uint8_t *v2) {
+  (void)v1;
+  (void)v2;
+}

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/stub.cpp
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/stub.cpp
@@ -2,7 +2,7 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -7,9 +7,9 @@ Operations for pipeline synchronization and buffer management.
 The following enum types provide type-safe parameter specification for synchronization operations:
 
 - **`BarrierType`**: Memory barrier types for `pto.mem_bar`
-  - `VV_ALL`: All prior vector ops complete before subsequent
-  - `VST_VLD`: All prior vector stores visible before subsequent loads  
-  - `VLD_VST`: All prior vector loads complete before subsequent stores
+  - `VV_ALL`, `VST_VLD`, `VLD_VST`, `VST_VST`: vector→vector barriers
+  - `VS_ALL`, `VST_LD`, `VLD_ST`, `VST_ST`: vector→scalar barriers
+  - `SV_ALL`, `ST_VLD`, `LD_VST`, `ST_VST`: scalar→vector barriers
 
 - **`Pipe`**: Hardware pipeline identifiers
   - `MTE2`: Memory Transfer Engine 2 pipeline
@@ -127,7 +127,7 @@ pto.rls_buf(Pipe.MTE2, 0, 0)
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `barrier_type` | `BarrierType` | Barrier type: `BarrierType.VV_ALL` (all prior vector ops complete before subsequent), `BarrierType.VST_VLD` (all prior vector stores visible before subsequent loads), `BarrierType.VLD_VST` (all prior vector loads complete before subsequent stores) |
+| `barrier_type` | `BarrierType` | Barrier type controlling prior/subsequent instruction ordering. Supported values are `BarrierType.VV_ALL`, `BarrierType.VST_VLD`, `BarrierType.VLD_VST`, `BarrierType.VST_VST`, `BarrierType.VS_ALL`, `BarrierType.VST_LD`, `BarrierType.VLD_ST`, `BarrierType.VST_ST`, `BarrierType.SV_ALL`, `BarrierType.ST_VLD`, `BarrierType.LD_VST`, and `BarrierType.ST_VST`. |
 
 **Returns**: None (side-effect operation)
 

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1354,7 +1354,7 @@ family.
 **Attribute Enums**:
 - `pto.VcvtRoundMode`: `R`, `A`, `F`, `C`, `Z`, `O`
 - `pto.VcvtSatMode`: `SAT`, `NOSAT`
-- `pto.VcvtPartMode`: `EVEN`, `ODD`
+- `pto.VcvtPartMode`: `EVEN`, `ODD`, `P0`, `P1`, `P2`, `P3`
 
 **Parameters**:
 | Parameter | Type | Description |
@@ -1364,7 +1364,7 @@ family.
 | `mask` | `MaskType` | Predicate mask selecting active source lanes. Its granularity must match the source vector family, not the destination family |
 | `rnd` | `pto.VcvtRoundMode` \| `None` | Optional rounding-mode attribute lowered to VPTO `rnd` |
 | `sat` | `pto.VcvtSatMode` \| `None` | Optional saturation attribute lowered to VPTO `sat` |
-| `part` | `pto.VcvtPartMode` \| `None` | Optional even/odd packing selector lowered to VPTO `part` |
+| `part` | `pto.VcvtPartMode` \| `None` | Optional width-changing lane-placement selector lowered to VPTO `part` |
 
 **Returns**:
 | Return Value | Type | Description |
@@ -1384,6 +1384,18 @@ family.
   `i8`/`si8`/`ui8` use `mask_b8`.
 - The enum form is preferred. For compatibility, canonical strings such as
   `"R"`, `"SAT"`, and `"EVEN"` are also accepted.
+- VPTO `part` supports two families: `Part` (`EVEN`/`ODD`) for ordinary
+  width-changing conversions (e.g. `32 -> 16`, `16 -> 32`), and `Part_T`
+  (`P0`–`P3`) for 4-way packed placement (e.g. `32 -> 8`, fp8/fp4 flows).
+
+  | Mode | VPTO spelling | Family | Description | TileLang DSL v1 status |
+  |------|---------------|--------|-------------|------------------------|
+  | `EVEN` | `PART_EVEN` | `Part` | Output to even-indexed lanes | Exposed as `pto.VcvtPartMode.EVEN` |
+  | `ODD` | `PART_ODD` | `Part` | Output to odd-indexed lanes | Exposed as `pto.VcvtPartMode.ODD` |
+  | `P0` | `PART_P0` | `Part_T` | Output to sub-part 0 in 4-way packed placement | Exposed as `pto.VcvtPartMode.P0` |
+  | `P1` | `PART_P1` | `Part_T` | Output to sub-part 1 in 4-way packed placement | Exposed as `pto.VcvtPartMode.P1` |
+  | `P2` | `PART_P2` | `Part_T` | Output to sub-part 2 in 4-way packed placement | Exposed as `pto.VcvtPartMode.P2` |
+  | `P3` | `PART_P3` | `Part_T` | Output to sub-part 3 in 4-way packed placement | Exposed as `pto.VcvtPartMode.P3` |
 - Only backend-supported source/destination type pairs are legal. For the full
   A5 `vcvt` type matrix, width-changing packing rules, and attribute-sensitive
   forms, refer to

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 """Frontend AST nodes for TileLang DSL descriptor materialization."""
 
 from __future__ import annotations

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -6007,8 +6007,14 @@ class _SemanticAnalyzer:
             if expr.type.kind == "barrier_type" and isinstance(expr.binding.value, BarrierType):
                 return expr.binding.value.value
         if isinstance(expr, SemanticLiteralExpr) and isinstance(expr.type, SemanticMetaType) and expr.type.kind == "string":
-            return expr.value
-        raise TypeError(f"{context} must be a BarrierType symbol or string literal in TileLang DSL v1")
+            if expr.value in {barrier_type.value for barrier_type in BarrierType}:
+                return expr.value
+        raise TypeError(
+            f"{context} must be a BarrierType symbol or canonical barrier string "
+            "(`VV_ALL`, `VST_VLD`, `VLD_VST`, `VST_VST`, `VS_ALL`, `VST_LD`, "
+            "`VLD_ST`, `VST_ST`, `SV_ALL`, `ST_VLD`, `LD_VST`, or `ST_VST`) "
+            "in TileLang DSL v1"
+        )
 
     def _normalize_event_id_expr(self, expr: SemanticExpr, context: str) -> SemanticExpr:
         if isinstance(expr, SemanticSymbolExpr) and expr.type.kind == "event" and isinstance(expr.value, Event):

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -5453,8 +5453,10 @@ class _SemanticAnalyzer:
         if part_mode not in {mode.value for mode in VcvtPartMode}:
             raise TypeError(
                 "pto.vcvt part must be a VcvtPartMode enum such as "
-                "`pto.VcvtPartMode.EVEN` or `pto.VcvtPartMode.ODD`, or one of the "
-                'canonical strings `"EVEN"` / `"ODD"` in TileLang DSL v1'
+                "`pto.VcvtPartMode.EVEN`, `pto.VcvtPartMode.ODD`, or "
+                "`pto.VcvtPartMode.P0`..`pto.VcvtPartMode.P3`, or one of the "
+                'canonical strings `"EVEN"`, `"ODD"`, `"P0"`, `"P1"`, `"P2"`, or `"P3"` '
+                "in TileLang DSL v1"
             )
         return SemanticLiteralExpr(value=part_mode, type=SemanticMetaType(kind="string"))
 

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 """Support-matrix definitions and diagnostics for TileLang DSL v1."""
 
 from __future__ import annotations

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -178,6 +178,15 @@ class BarrierType(str, Enum):
     VV_ALL = "VV_ALL"
     VST_VLD = "VST_VLD"
     VLD_VST = "VLD_VST"
+    VST_VST = "VST_VST"
+    VS_ALL = "VS_ALL"
+    VST_LD = "VST_LD"
+    VLD_ST = "VLD_ST"
+    VST_ST = "VST_ST"
+    SV_ALL = "SV_ALL"
+    ST_VLD = "ST_VLD"
+    LD_VST = "LD_VST"
+    ST_VST = "ST_VST"
 
 
 class MaskPattern(str, Enum):

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -448,6 +448,10 @@ class VcvtSatMode(str, Enum):
 class VcvtPartMode(str, Enum):
     EVEN = "EVEN"
     ODD = "ODD"
+    P0 = "P0"
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
 
 
 class PostUpdateMode(str, Enum):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -160,7 +160,12 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.CmpMode.GE.value, "ge")
         self.assertEqual(pto.VcvtRoundMode.R.value, "R")
         self.assertEqual(pto.VcvtSatMode.SAT.value, "SAT")
+        self.assertEqual(pto.VcvtPartMode.EVEN.value, "EVEN")
         self.assertEqual(pto.VcvtPartMode.ODD.value, "ODD")
+        self.assertEqual(pto.VcvtPartMode.P0.value, "P0")
+        self.assertEqual(pto.VcvtPartMode.P1.value, "P1")
+        self.assertEqual(pto.VcvtPartMode.P2.value, "P2")
+        self.assertEqual(pto.VcvtPartMode.P3.value, "P3")
         self.assertEqual(pto.PostUpdateMode.POST_UPDATE.value, "POST_UPDATE")
         self.assertEqual(pto.PostUpdateMode.NO_POST_UPDATE.value, "NO_POST_UPDATE")
         self.assertEqual(pto.Event.ID31.value, "EVENT_ID31")
@@ -2982,6 +2987,68 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             text,
             r"= pto\.vcvt %[^,\s]+(?: \{[^}]+\})? : !pto\.vreg<[^>]+> -> !pto\.vreg<[^>]+>",
         )
+
+    def test_vcvt_supports_part_t_modes_with_enum(self) -> None:
+        @pto.vkernel(
+            op="vcvt_part_t_enum_unique",
+            dtypes=[(pto.i8, pto.f16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+            dst_mask = pto.make_mask(pto.i8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vcvt(
+                vec,
+                pto.i8,
+                src_mask,
+                rnd=pto.VcvtRoundMode.R,
+                sat=pto.VcvtSatMode.SAT,
+                part=pto.VcvtPartMode.P0,
+            )
+            pto.vsts(out, dst, 0, dst_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 256), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vcvt", text)
+        self.assertIn('rnd = "R"', text)
+        self.assertIn('sat = "SAT"', text)
+        self.assertIn('part = "P0"', text)
+
+    def test_vcvt_supports_part_t_modes_with_canonical_string(self) -> None:
+        @pto.vkernel(
+            op="vcvt_part_t_string_unique",
+            dtypes=[(pto.i8, pto.f16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            src_mask = pto.make_mask(pto.f16, pto.PAT.ALL)
+            dst_mask = pto.make_mask(pto.i8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vcvt(
+                vec,
+                pto.i8,
+                src_mask,
+                rnd="R",
+                sat="SAT",
+                part="P3",
+            )
+            pto.vsts(out, dst, 0, dst_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 256), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vcvt", text)
+        self.assertIn('part = "P3"', text)
 
     def test_vcvt_i32_to_i64_reuses_b32_mask_and_emits_i64_vreg(self) -> None:
         @pto.vkernel(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import tempfile
 import unittest
 from unittest import mock

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -128,6 +128,15 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertTrue(hasattr(pto, "si64"))
         self.assertTrue(hasattr(pto, "ui64"))
         self.assertEqual(pto.BarrierType.VST_VLD.value, "VST_VLD")
+        self.assertEqual(pto.BarrierType.VST_VST.value, "VST_VST")
+        self.assertEqual(pto.BarrierType.VS_ALL.value, "VS_ALL")
+        self.assertEqual(pto.BarrierType.VST_LD.value, "VST_LD")
+        self.assertEqual(pto.BarrierType.VLD_ST.value, "VLD_ST")
+        self.assertEqual(pto.BarrierType.VST_ST.value, "VST_ST")
+        self.assertEqual(pto.BarrierType.SV_ALL.value, "SV_ALL")
+        self.assertEqual(pto.BarrierType.ST_VLD.value, "ST_VLD")
+        self.assertEqual(pto.BarrierType.LD_VST.value, "LD_VST")
+        self.assertEqual(pto.BarrierType.ST_VST.value, "ST_VST")
         self.assertEqual(pto.PadMode.PadNull.value, "PadNull")
         self.assertEqual(pto.PadMode.PadFirstElem.value, "PadFirstElem")
         self.assertEqual(pto.PadMode.PadValue.value, "PadValue")
@@ -5367,6 +5376,78 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.set_intra_core %arg5 : i32", text)
         self.assertIn("pto.wait_flag_dev %arg3, %c8_i64 : i64, i64", text)
         self.assertIn("pto.wait_intra_core %arg4, %c31_i64 : i64, i64", text)
+
+    def test_mem_bar_accepts_extended_barrier_type_enum(self) -> None:
+        BarrierType = pto.BarrierType
+
+        @pto.vkernel(
+            op="mem_bar_extended_enum_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            pto.mem_bar(BarrierType.ST_VST)
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            pto.vsts(vec, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        self.assertIsInstance(semantic_kernel.body[0], SemanticMemBarStmt)
+
+        text = specialized.mlir_text()
+        self.assertIn('pto.mem_bar "ST_VST"', text)
+
+    def test_mem_bar_accepts_extended_barrier_type_enum_vst_st(self) -> None:
+        BarrierType = pto.BarrierType
+
+        @pto.vkernel(
+            op="mem_bar_extended_enum_vst_st_unique",
+            dtypes=[(pto.f32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            pto.mem_bar(BarrierType.VST_ST)
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            pto.vsts(vec, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn('pto.mem_bar "VST_ST"', text)
+
+    def test_mem_bar_rejects_unknown_barrier_string(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+
+            @pto.vkernel(
+                op="mem_bar_invalid_string_unique",
+                dtypes=[(pto.f32, pto.f32)],
+                advanced=True,
+            )
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                pto.mem_bar("NOT_A_BARRIER")
+                mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                pto.vsts(vec, dst, 0, mask)
+                return None
+
+            specialized = kernel.specialize(
+                dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            )
+            specialized.mlir_text()
+
+        self.assertIn("canonical barrier string", str(ctx.exception))
 
     def test_runtime_block_queries_and_scalar_pointer_helpers_lower_to_v0_3_surface(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary

Align the TileLang DSL and VPTO backend coverage with the A5 `tcvt` `u32 -> u8` packed conversion path used by `cast32to8`.

This PR updates the public DSL surface and tests so packed `vcvt` part placement and the related memory barrier kinds can be expressed in TileLang DSL, and adds backend regression coverage for the documented `pto.mem_bar` barrier types.
 
Fixes #180

## Changes

- extend `pto.VcvtPartMode` to include `P0`, `P1`, `P2`, and `P3`
- accept the new `vcvt part` modes in TileLang DSL semantic analysis and diagnostics
- extend `pto.BarrierType` with the documented vector/vector, vector/scalar, and scalar/vector barrier kinds
- tighten `pto.mem_bar(...)` string validation to accept only canonical barrier tokens
- update TileLang DSL user guide docs for `vcvt` part modes and `mem_bar` barrier types
- add TileLang DSL unit tests for the new `VcvtPartMode` / `BarrierType` surface
- add VPTO backend LLVM regression coverage for the documented `mem_bar` barrier kinds

## Validation

- `PYTHONPATH=$PWD/tilelang-dsl/tests:$PWD/tilelang-dsl/python:$PWD python3 -m unittest test_tilelang_dsl_v1.TileLangDSLPackageTests.test_package_exports_surface test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vcvt_supports_part_t_modes_with_enum test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vcvt_supports_part_t_modes_with_canonical_string test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_mem_bar_accepts_extended_barrier_type_enum test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_mem_bar_accepts_extended_barrier_type_enum_vst_st test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_mem_bar_rejects_unknown_barrier_string`
- `python3 -m py_compile tilelang-dsl/python/tilelang_dsl/types.py tilelang-dsl/python/tilelang_dsl/semantic.py tilelang-dsl/tests/test_tilelang_dsl_v1.py`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm test/basic/membar_barrier_types_vpto_llvm.pto -o - | /home/zhangzhendong/.local/bin/FileCheck test/basic/membar_barrier_types_vpto_llvm.pto`

## Context

`issue #180` comes from the A5 TCVT `u32 -> u8` path, where the C++ implementation uses packed `vcvt` placement (`PART_P0` and friends) and a `VST_VST` memory barrier. Before this change, those enum values were missing or not covered end-to-end on the DSL side, which made it hard to express logic aligned with `cast32to8`.