### PR TITLE
fix(expand-tileop): propagate cmp_mode into TileLang specialization

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -255,6 +255,18 @@ static void appendOpContextAttrs(
     if (roundMode)
       attrs.emplace_back("round_mode", *roundMode);
   }
+  if (auto tcmp = dyn_cast<pto::TCmpOp>(op)) {
+    if (auto cmpModeAttr = tcmp.getCmpModeAttr()) {
+      attrs.emplace_back("cmp_mode",
+                         stringifyCmpMode(cmpModeAttr.getValue()).str());
+    }
+  }
+  if (auto tcmps = dyn_cast<pto::TCmpSOp>(op)) {
+    if (auto cmpModeAttr = tcmps.getCmpModeAttr()) {
+      attrs.emplace_back("cmp_mode",
+                         stringifyCmpMode(cmpModeAttr.getValue()).str());
+    }
+  }
 }
 
 static bool getStaticIntFromValue(Value value, int64_t &out) {


### PR DESCRIPTION
## Summary
- thread `cmp_mode` from `pto.tcmp` and `pto.tcmps` into `ExpandTileOp` context attrs
- make TileLang specialization/cache keys distinguish compare modes instead of reusing the default `eq` template instance
- add a focused regression test that exercises `lt`/`gt` for both `tcmp` and `tcmps`

## Validation
- `ninja -C build ptoas`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --emit-vpto --tilelang-path=$(dirname test/basic/expand_tile_op_tilelang_cmp_mode.pto)/tilelang_cmp_mode_templates test/basic/expand_tile_op_tilelang_cmp_mode.pto -o - 2>/dev/null | FileCheck test/basic/expand_tile_op_tilelang_cmp_mode.pto`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand test/basic/expand_tile_op_tilelang_tcvt.pto -o - 2>/dev/null | FileCheck test/basic/expand_tile_op_tilelang_tcvt.pto`

Fixes #179
