### PR TITLE
feat(tilelang-dsl): add vscatter surface lowering

### DIFF
--- a/tilelang-dsl/docs/user_guide/09-vector-memory-operations.md
+++ b/tilelang-dsl/docs/user_guide/09-vector-memory-operations.md
@@ -768,7 +768,7 @@ pto.vsta(align, tile[k:])
 
 **Constraints**:
 - Only `b8`, `b16`, and `b32` element sizes are supported
-- Index vector must use a supported integer element type and layout
+- Current TileLang DSL / VPTO path requires `i32` index vectors
 - Each computed address must be element-aligned
 - If indices alias, only one write is guaranteed (winning lane is implementation-defined)
 - Only the first `active_lanes` offsets participate in the scatter

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -65,6 +65,7 @@ from .semantic import (
     SemanticType,
     SemanticTupleExpr,
     SemanticTupleType,
+    SemanticVScatterStmt,
     SemanticVRegType,
     SemanticVectorPairStoreStmt,
     SemanticVectorStoreStmt,
@@ -313,6 +314,12 @@ class _AuthoringRenderer:
                 self._collect_used_tile_buffers_from_expr(index, used)
             self._collect_used_tile_buffers_from_expr(stmt.mask, used)
             return
+        if isinstance(stmt, SemanticVScatterStmt):
+            self._collect_used_tile_buffers_from_expr(stmt.value, used)
+            self._record_tile_buffer_use(stmt.destination, used)
+            self._collect_used_tile_buffers_from_expr(stmt.offsets, used)
+            self._collect_used_tile_buffers_from_expr(stmt.active_lanes, used)
+            return
         if isinstance(stmt, SemanticPredicateStoreStmt):
             self._collect_used_tile_buffers_from_expr(stmt.value, used)
             self._record_tile_buffer_use(stmt.destination, used)
@@ -432,6 +439,8 @@ class _AuthoringRenderer:
             return self._render_dma_store(stmt, env, indent=indent)
         if isinstance(stmt, SemanticVectorStoreStmt):
             return self._render_vector_store(stmt, env, indent=indent)
+        if isinstance(stmt, SemanticVScatterStmt):
+            return self._render_vscatter(stmt, env, indent=indent)
         if isinstance(stmt, SemanticVectorPairStoreStmt):
             return self._render_vector_pair_store(stmt, env, indent=indent)
         if isinstance(stmt, SemanticPredicateStoreStmt):
@@ -1085,6 +1094,27 @@ class _AuthoringRenderer:
             + f"{low.name}, {high.name}, {destination.name}[{rendered_indices}], {dist}, {mask.name} : "
             + f"{self._render_type(low.type)}, {self._render_type(high.type)}, "
             + f"{self._render_type(destination.type)}, {self._render_type(mask.type)}"
+        )
+        return lines
+
+    def _render_vscatter(
+        self,
+        stmt: SemanticVScatterStmt,
+        env: dict[str, _RenderedValue],
+        *,
+        indent: int,
+    ) -> list[str]:
+        lines: list[str] = []
+        value = self._lower_expr(stmt.value, env, indent=indent, into=lines)
+        destination = self._lower_expr(stmt.destination, env, indent=indent, into=lines)
+        offsets = self._lower_expr(stmt.offsets, env, indent=indent, into=lines)
+        active_lanes = self._lower_to_index(stmt.active_lanes, env, indent=indent, into=lines)
+        lines.append(
+            self._indent(indent)
+            + "pto.vscatter "
+            + f"{value.name}, {destination.name}, {offsets.name}, {active_lanes.name} : "
+            + f"{self._render_type(value.type)}, {self._render_type(destination.type)}, "
+            + f"{self._render_type(offsets.type)}, {self._render_type(active_lanes.type)}"
         )
         return lines
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -597,6 +597,14 @@ class SemanticVectorPairStoreStmt(SemanticStmt):
 
 
 @dataclass(frozen=True)
+class SemanticVScatterStmt(SemanticStmt):
+    value: SemanticExpr
+    destination: SemanticExpr
+    offsets: SemanticExpr
+    active_lanes: SemanticExpr
+
+
+@dataclass(frozen=True)
 class SemanticPredicateStoreStmt(SemanticStmt):
     op_name: str
     value: SemanticExpr
@@ -1166,6 +1174,7 @@ class _SemanticAnalyzer:
                 "vsta",
                 "vstas",
                 "vstar",
+                "vscatter",
                 "vsts",
                 "vstsx2",
                 "vstus",
@@ -1266,6 +1275,7 @@ class _SemanticAnalyzer:
                     "vsta",
                     "vstas",
                     "vstar",
+                    "vscatter",
                     "vsts",
                     "vstsx2",
                     "vstus",
@@ -1364,6 +1374,8 @@ class _SemanticAnalyzer:
             if isinstance(stmt, SemanticDmaStoreStmt):
                 return True
             if isinstance(stmt, SemanticVectorStoreStmt):
+                return True
+            if isinstance(stmt, SemanticVScatterStmt):
                 return True
             if isinstance(stmt, SemanticPredicateStoreStmt):
                 return True
@@ -1640,7 +1652,7 @@ class _SemanticAnalyzer:
         return (
             isinstance(expr, FrontendCallExpr)
             and expr.namespace == "pto"
-            and expr.name in {"psts", "pst", "psti", "vsst", "vsta", "vstas", "vstar", "vsts", "vstsx2"}
+            and expr.name in {"psts", "pst", "psti", "vsst", "vsta", "vstas", "vstar", "vscatter", "vsts", "vstsx2"}
         )
 
     def _is_scalar_store_call(self, expr: FrontendExprNode) -> bool:
@@ -1885,6 +1897,35 @@ class _SemanticAnalyzer:
                     destination=destination,
                     indices=indices,
                     offset=offset,
+                ),
+                dict(env),
+            )
+
+        if expr.name == "vscatter":
+            args = tuple(
+                self._analyze_expr(arg, env, allow_outer_lookup=allow_outer_lookup)
+                for arg in expr.args
+            )
+            if len(args) != 4:
+                raise TypeError("pto.vscatter expects exactly 4 positional arguments in TileLang DSL v1")
+            value, destination, offsets, active_lanes = args
+            value_type = self._require_vreg_expr(value, "pto.vscatter value")
+            self._require_vector_pointer_expr(destination, "pto.vscatter destination")
+            offsets_type = self._require_vreg_expr(offsets, "pto.vscatter offsets")
+            if not is_integer_dtype(offsets_type.element_dtype):
+                raise TypeError("pto.vscatter offsets must use an integer vector type in TileLang DSL v1")
+            if integer_bitwidth(offsets_type.element_dtype) != 32:
+                raise TypeError("pto.vscatter currently requires i32 offset vectors in TileLang DSL v1")
+            if value_type.lanes != offsets_type.lanes:
+                raise TypeError("pto.vscatter value and offsets must use the same lane count in TileLang DSL v1")
+            self._require_i32_like_expr(active_lanes, "pto.vscatter active_lanes")
+            self._require_matching_vector_pointer(value_type, destination.type, "pto.vscatter")
+            return (
+                SemanticVScatterStmt(
+                    value=value,
+                    destination=destination,
+                    offsets=offsets,
+                    active_lanes=active_lanes,
                 ),
                 dict(env),
             )
@@ -6448,6 +6489,7 @@ __all__ = [
     "SemanticTupleType",
     "SemanticType",
     "SemanticVRegType",
+    "SemanticVScatterStmt",
     "SemanticVectorPairStoreStmt",
     "SemanticVectorStoreStmt",
     "SemanticWaitFlagDevStmt",

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -157,6 +157,7 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
 
 ADVANCED_VECSCOPE_PTO_CALLS = frozenset(
     {
+        "vscatter",
         "vcmp",
         "vcmps",
         "vsel",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -74,6 +74,7 @@ from tilelang_dsl.semantic import (
     SemanticTileConfigType,
     SemanticTileType,
     SemanticVecscopeStmt,
+    SemanticVScatterStmt,
     SemanticVectorPairStoreStmt,
     SemanticVectorStoreStmt,
     SemanticVRegType,
@@ -444,6 +445,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertEqual(get_feature_tier("pto.vsort32"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vldsx2"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vstsx2"), BASIC_TIER)
+        self.assertEqual(get_feature_tier("pto.vscatter"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.vbitsort"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.vmrgsort4"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("PadMode"), BASIC_TIER)
@@ -5531,6 +5533,36 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         text = specialized.mlir_text()
         self.assertIn('"DINTLV"', text)
         self.assertIn('"INTLV"', text)
+
+    def test_vscatter_lowers_from_advanced_pointer_surface(self) -> None:
+        @pto.vkernel(
+            op="vscatter_pointer_surface",
+            dtypes=[(pto.i32, pto.f32)],
+            advanced=True,
+        )
+        def kernel(
+            offsets_src: pto.ptr(pto.i32, pto.MemorySpace.UB),
+            dst: pto.ptr(pto.f32, pto.MemorySpace.UB),
+        ):
+            vec = pto.vbr(1.0)
+            offsets = pto.vlds(offsets_src, 0)
+            pto.vscatter(vec, dst, offsets, 64)
+            return None
+
+        specialized = kernel.specialize()
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        vecscope = next(stmt for stmt in semantic_kernel.body if isinstance(stmt, SemanticVecscopeStmt))
+        scatter_stmt = next(stmt for stmt in vecscope.body if isinstance(stmt, SemanticVScatterStmt))
+
+        self.assertIsInstance(scatter_stmt, SemanticVScatterStmt)
+        self.assertEqual(scatter_stmt.destination.type.memory_space, "ub")
+        self.assertEqual(scatter_stmt.value.type.element_dtype, pto.f32)
+        self.assertEqual(scatter_stmt.offsets.type.element_dtype, pto.i32)
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vscatter", text)
+        self.assertIn("!pto.vreg<64xf32>", text)
+        self.assertIn("!pto.vreg<64xi32>", text)
 
     def test_align_load_and_stateful_store_ops_lower_to_current_vpto_surface(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- add TileLang DSL semantic analysis and lowering support for `pto.vscatter`
- classify `pto.vscatter` as an advanced vecscope surface and cover it with a DSL test
- align the user guide constraint note with the current implementation path (`i32` offsets)

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLSupportMatrixTests.test_stable_starter_surface_groups_map_to_stable_tier tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vscatter_lowers_from_advanced_pointer_surface`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vldsx2_and_vstsx2_tile_sugar_lower_with_normalized_dist_tokens tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_align_load_and_stateful_store_ops_lower_to_current_vpto_surface`

## Issue
- Fixes #192
