### PR TITLE
fix(dsl): align vexpdif surface with VPTO

### DIFF
--- a/docs/isa/13-dsa-sfu-ops.md
+++ b/docs/isa/13-dsa-sfu-ops.md
@@ -57,9 +57,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-### `pto.vexpdiff`
+### `pto.vexpdif`
 
-- **syntax:** `%result = pto.vexpdiff %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
+- **syntax:** `%result = pto.vexpdif %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
 - **A5 types:** input `f16` or `f32`, output `f32`
 - **semantics:** Fused exp(x - max) for numerically stable softmax.
 
@@ -219,7 +219,7 @@ for (int i = 0; i < N; i++)
 ```mlir
 // Softmax with fused expdiff
 %max_broadcast = pto.vlds %ub_max[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-%exp_stable = pto.vexpdiff %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp_stable = pto.vexpdif %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // Leaky ReLU activation
 %activated = pto.vlrelu %linear_out, %alpha_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -893,7 +893,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
 | 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
 | 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
@@ -982,7 +982,7 @@ pto.vsts %max_vec, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !
 %max_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 2. exp(x - max) using fused op
-%exp = pto.vexpdiff %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp = pto.vexpdif %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // 3. Sum
 %sum = pto.vcadd %exp, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -1456,7 +1456,7 @@ class PTO_UnmaskedBinaryVecOp<string mnemonic> : PTO_Op<mnemonic, [Pure]> {
 }
 
 def PTO_VpreluOp : PTO_UnmaskedBinaryVecOp<"vprelu">;
-def PTO_VexpdiffOp : PTO_Op<"vexpdiff", [Pure]> {
+def PTO_VexpdifOp : PTO_Op<"vexpdif", [Pure]> {
   let arguments = (ins
     PTO_VectorType:$input,
     PTO_VectorType:$max,

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -2941,7 +2941,7 @@ static LogicalResult verifyFloatBinaryVecNoMaskOp(BinaryVecNoMaskOp op) {
 }
 
 LogicalResult VpreluOp::verify() { return verifyFloatBinaryVecNoMaskOp(*this); }
-LogicalResult VexpdiffOp::verify() {
+LogicalResult VexpdifOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyVRegTypeLike(*this, getMax().getType(), "max type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1669,9 +1669,9 @@ static FailureOr<StringRef> buildVtrcCallee(MLIRContext *context, Type resultTyp
   return StringAttr::get(context, "llvm.hivm.vtrc." + vec + ".x").getValue();
 }
 
-static FailureOr<StringRef> buildVexpdiffCallee(MLIRContext *context,
-                                                Type inputType,
-                                                Type resultType) {
+static FailureOr<StringRef> buildVexpdifCallee(MLIRContext *context,
+                                               Type inputType,
+                                               Type resultType) {
   std::string srcVec =
       getElementTypeFragment(getElementTypeFromVectorLike(inputType));
   auto srcLanes = getElementCountFromVectorLike(inputType);
@@ -4090,38 +4090,38 @@ private:
   LoweringState &state;
 };
 
-class LowerVexpdiffOpPattern final
-    : public OpConversionPattern<pto::VexpdiffOp> {
+class LowerVexpdifOpPattern final
+    : public OpConversionPattern<pto::VexpdifOp> {
 public:
-  explicit LowerVexpdiffOpPattern(TypeConverter &typeConverter,
-                                  MLIRContext *context, LoweringState &state)
-      : OpConversionPattern<pto::VexpdiffOp>(typeConverter, context),
+  explicit LowerVexpdifOpPattern(TypeConverter &typeConverter,
+                                 MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::VexpdifOp>(typeConverter, context),
         state(state) {}
 
   LogicalResult
-  matchAndRewrite(pto::VexpdiffOp op, pto::VexpdiffOp::Adaptor adaptor,
+  matchAndRewrite(pto::VexpdifOp op, pto::VexpdifOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto laneCount = getElementCountFromVectorLike(op.getInput().getType());
     Type elemType = getElementTypeFromVectorLike(op.getInput().getType());
     auto part = parsePartImmediate(op.getPart());
     if (!laneCount || !elemType || !part)
-      return rewriter.notifyMatchFailure(op, "unsupported vexpdiff signature");
+      return rewriter.notifyMatchFailure(op, "unsupported vexpdif signature");
 
     FailureOr<Value> mask = materializeDynamicPltMask(
         rewriter, state, op.getLoc(), getI32Constant(rewriter, op.getLoc(), *laneCount),
         elemType);
     if (failed(mask))
-      return rewriter.notifyMatchFailure(op, "failed to materialize vexpdiff mask");
+      return rewriter.notifyMatchFailure(op, "failed to materialize vexpdif mask");
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
-      return rewriter.notifyMatchFailure(op, "failed to convert vexpdiff result type");
+      return rewriter.notifyMatchFailure(op, "failed to convert vexpdif result type");
 
     FailureOr<StringRef> calleeName =
-        buildVexpdiffCallee(op.getContext(), op.getInput().getType(),
-                            op.getResult().getType());
+        buildVexpdifCallee(op.getContext(), op.getInput().getType(),
+                           op.getResult().getType());
     if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported vexpdiff callee");
+      return rewriter.notifyMatchFailure(op, "unsupported vexpdif callee");
 
     Value partValue = getI32Constant(rewriter, op.getLoc(), *part);
     auto funcType = rewriter.getFunctionType(
@@ -5051,7 +5051,7 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerVgather2OpPattern, LowerVgather2BcOpPattern,
                LowerVgatherbOpPattern, LowerVscatterOpPattern,
                LowerVpreluOpPattern, LowerVaxpyOpPattern,
-               LowerVciOpPattern, LowerVexpdiffOpPattern,
+               LowerVciOpPattern, LowerVexpdifOpPattern,
                LowerVbitsortOpPattern, LowerVtrcOpPattern, LowerVcvtOpPattern,
                LowerVbitcastOpPattern,
                LowerPredicateLoadOpPattern<pto::PldiOp>,
@@ -5110,7 +5110,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::PintlvB8Op, pto::PintlvB16Op, pto::PintlvB32Op,
                       pto::VsunpackOp, pto::VzunpackOp, pto::VpackOp,
                       pto::VintlvOp, pto::VdintlvOp, pto::VpreluOp,
-                      pto::VaxpyOp, pto::VciOp, pto::VexpdiffOp,
+                      pto::VaxpyOp, pto::VciOp, pto::VexpdifOp,
                       pto::VbitsortOp, pto::VtrcOp, pto::VcvtOp,
                       pto::VbitcastOp,
                       pto::VcmpOp, pto::VcmpsOp,

--- a/test/vpto/cases/kernels/online-softmax-update/compare.py
+++ b/test/vpto/cases/kernels/online-softmax-update/compare.py
@@ -9,7 +9,7 @@
 
 # case: kernels/online-softmax-update
 # family: kernels
-# target_ops: pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+# target_ops: pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 # scenarios: online-softmax-update, 16x128-f32, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 
 import os

--- a/test/vpto/cases/kernels/online-softmax-update/golden.py
+++ b/test/vpto/cases/kernels/online-softmax-update/golden.py
@@ -9,7 +9,7 @@
 
 # case: kernels/online-softmax-update
 # family: kernels
-# target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+# target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 # scenarios: online-softmax-update, dynamic-rows-and-seq, max-seq-128, block-rows-8, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 
 import argparse

--- a/test/vpto/cases/kernels/online-softmax-update/kernel.pto
+++ b/test/vpto/cases/kernels/online-softmax-update/kernel.pto
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 // case: kernels/online-softmax-update
 // family: kernels
-// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 // scenarios: online-softmax-update, dynamic-rows-and-seq, max-seq-128, block-rows-8, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 // -----------------------------------------------------------------------------
 module attributes {pto.target_arch = "a5"} {
@@ -104,9 +104,9 @@ module attributes {pto.target_arch = "a5"} {
               %chunk_max = pto.vcmax %vec, %chunk_mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
               %chunk_max_bc = pto.vdup %chunk_max, %active {position = "LOWEST"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
               %merged_max = pto.vmax %running_max, %chunk_max_bc, %active : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-              %scaled_running = pto.vexpdiff %running_max, %merged_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+              %scaled_running = pto.vexpdif %running_max, %merged_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
               %running_sum_scaled = pto.vmul %scaled_running, %running_sum, %active : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-              %chunk_exp = pto.vexpdiff %vec, %merged_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+              %chunk_exp = pto.vexpdif %vec, %merged_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
               %chunk_sum = pto.vcadd %chunk_exp, %chunk_mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
               %chunk_sum_bc = pto.vdup %chunk_sum, %active {position = "LOWEST"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
               %merged_sum = pto.vadd %running_sum_scaled, %chunk_sum_bc, %active : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
@@ -117,7 +117,7 @@ module attributes {pto.target_arch = "a5"} {
             scf.yield %next_max, %next_sum : !pto.vreg<64xf32>, !pto.vreg<64xf32>
           }
 
-          %raw_expmax = pto.vexpdiff %oldmax_bc, %final_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+          %raw_expmax = pto.vexpdif %oldmax_bc, %final_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
           %scaled_oldsum = pto.vmul %raw_expmax, %oldsum_bc, %active : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
           %expmax = pto.vdiv %scaled_oldsum, %final_sum, %active : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
           pto.vsts %final_max, %ub_newmax[%row], %one_mask {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
@@ -138,7 +138,7 @@ module attributes {pto.target_arch = "a5"} {
               %chunk_mask, %chunk_rest = pto.plt_b32 %remaining_cols : i32 -> !pto.mask<b32>, i32
               %chunk_base = arith.addi %row_qk, %chunk : index
               %vec = pto.vlds %ub_qk[%chunk_base] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-              %exp = pto.vexpdiff %vec, %final_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+              %exp = pto.vexpdif %vec, %final_max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
               %out = pto.vdiv %exp, %final_sum, %chunk_mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
               pto.vsts %out, %ub_out[%chunk_base], %chunk_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
             }

--- a/test/vpto/cases/kernels/online-softmax-update/launch.cpp
+++ b/test/vpto/cases/kernels/online-softmax-update/launch.cpp
@@ -9,7 +9,7 @@
 // -----------------------------------------------------------------------------
 // case: kernels/online-softmax-update
 // family: kernels
-// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 // scenarios: online-softmax-update, dynamic-rows-and-seq, max-seq-128, block-rows-8, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 // -----------------------------------------------------------------------------
 #ifndef __VEC_SCOPE__

--- a/test/vpto/cases/kernels/online-softmax-update/main.cpp
+++ b/test/vpto/cases/kernels/online-softmax-update/main.cpp
@@ -9,7 +9,7 @@
 // -----------------------------------------------------------------------------
 // case: kernels/online-softmax-update
 // family: kernels
-// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+// target_ops: pto.get_block_idx, pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 // scenarios: online-softmax-update, dynamic-rows-and-seq, max-seq-128, block-rows-8, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 // -----------------------------------------------------------------------------
 #include "test_common.h"

--- a/test/vpto/cases/kernels/online-softmax-update/stub.cpp
+++ b/test/vpto/cases/kernels/online-softmax-update/stub.cpp
@@ -9,7 +9,7 @@
 // -----------------------------------------------------------------------------
 // case: kernels/online-softmax-update
 // family: kernels
-// target_ops: pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdiff, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
+// target_ops: pto.copy_gm_to_ubuf, pto.copy_ubuf_to_gm, pto.vlds, pto.vcmax, pto.vdup, pto.vmax, pto.vexpdif, pto.vcadd, pto.vadd, pto.vmul, pto.vdiv, pto.vsts
 // scenarios: online-softmax-update, dynamic-rows-and-seq, max-seq-128, block-rows-8, oldmax-oldsum-qk-to-newmax-newsum-expmax-out
 // -----------------------------------------------------------------------------
 #include <pto/common/type.hpp>

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/compare.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/compare.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-boundary
+# case: micro-op/dsa-sfu/vexpdif-boundary
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 # NOTE: bulk-generated coverage skeleton.
 

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/golden.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/golden.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-boundary
+# case: micro-op/dsa-sfu/vexpdif-boundary
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/kernel.pto
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/kernel.pto
@@ -1,13 +1,13 @@
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-boundary
+// case: micro-op/dsa-sfu/vexpdif-boundary
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
 // -----------------------------------------------------------------------------
 module attributes {pto.target_arch = "a5"} {
-  func.func @vexpdiff_boundary_kernel_2d(%arg0: !pto.ptr<f32, gm>,
+  func.func @vexpdif_boundary_kernel_2d(%arg0: !pto.ptr<f32, gm>,
                                          %arg1: !pto.ptr<f32, gm>,
                                          %arg2: !pto.ptr<f32, gm>) {
     %c0 = arith.constant 0 : index
@@ -40,7 +40,7 @@ module attributes {pto.target_arch = "a5"} {
       scf.for %offset = %c0 to %c1024 step %c64 {
         %vec = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %max = pto.vlds %ub_max[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %sum = pto.vexpdiff %vec, %max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+        %sum = pto.vexpdif %vec, %max, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
         pto.vsts %sum, %ub_out[%offset], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/launch.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/launch.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-boundary
+// case: micro-op/dsa-sfu/vexpdif-boundary
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
@@ -43,12 +43,12 @@ struct MrgSortExecutedNumList {
 #include "acl/acl.h"
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_boundary_kernel_2d(__gm__ float *v1,
+extern "C" __global__ [aicore] void vexpdif_boundary_kernel_2d(__gm__ float *v1,
                                                               __gm__ float *v2,
                                                               __gm__ float *v3);
 
 void LaunchVexpdiff_boundary_kernel_2d(float *v1, float *v2, float *v3, void *stream) {
-  vexpdiff_boundary_kernel_2d<<<1, nullptr, stream>>>((__gm__ float *)v1,
+  vexpdif_boundary_kernel_2d<<<1, nullptr, stream>>>((__gm__ float *)v1,
                                                       (__gm__ float *)v2,
                                                       (__gm__ float *)v3);
 }

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/main.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/main.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-boundary
+// case: micro-op/dsa-sfu/vexpdif-boundary
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/stub.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-boundary/stub.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-boundary
+// case: micro-op/dsa-sfu/vexpdif-boundary
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff, exceptional-values, floating-overflow-underflow
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
@@ -23,7 +23,7 @@
 #define __gm__
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_boundary_kernel_2d(__gm__ float *v1,
+extern "C" __global__ [aicore] void vexpdif_boundary_kernel_2d(__gm__ float *v1,
                                                               __gm__ float *v2,
                                                               __gm__ float *v3) {
   (void)v1;

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/compare.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/compare.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-f16-part
+# case: micro-op/dsa-sfu/vexpdif-f16-part
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f16, fused-expdiff, part-even-odd
 
 import os

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/golden.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/golden.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-f16-part
+# case: micro-op/dsa-sfu/vexpdif-f16-part
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f16, fused-expdiff, part-even-odd
 
 import argparse

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/kernel.pto
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/kernel.pto
@@ -1,12 +1,12 @@
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f16-part
+// case: micro-op/dsa-sfu/vexpdif-f16-part
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f16, fused-expdiff, part-even-odd
 // NOTE: validates that ODD/EVEN selects odd/even lanes from f16 inputs.
 // -----------------------------------------------------------------------------
 module attributes {pto.target_arch = "a5"} {
-  func.func @vexpdiff_f16_part_kernel_2d(%arg0: !pto.ptr<f16, gm>,
+  func.func @vexpdif_f16_part_kernel_2d(%arg0: !pto.ptr<f16, gm>,
                                          %arg1: !pto.ptr<f16, gm>,
                                          %arg2: !pto.ptr<f32, gm>) {
     %c0 = arith.constant 0 : index
@@ -43,8 +43,8 @@ module attributes {pto.target_arch = "a5"} {
         %max = pto.vlds %ub_max[%offset] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
         %even_mask, %remaining_after_even = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
         %odd_mask, %next_remaining = pto.plt_b32 %remaining_after_even : i32 -> !pto.mask<b32>, i32
-        %even = pto.vexpdiff %input, %max, "EVEN" : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<64xf32>
-        %odd = pto.vexpdiff %input, %max, "ODD" : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %even = pto.vexpdif %input, %max, "EVEN" : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %odd = pto.vexpdif %input, %max, "ODD" : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<64xf32>
         %odd_offset = arith.addi %offset, %c64 : index
         pto.vsts %even, %ub_out[%offset], %even_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
         pto.vsts %odd, %ub_out[%odd_offset], %odd_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/launch.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/launch.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f16-part
+// case: micro-op/dsa-sfu/vexpdif-f16-part
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f16, fused-expdiff, part-even-odd
 // -----------------------------------------------------------------------------
 #ifndef __VEC_SCOPE__
@@ -41,13 +41,13 @@ struct MrgSortExecutedNumList {
 #include "acl/acl.h"
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_f16_part_kernel_2d(__gm__ half *v1,
+extern "C" __global__ [aicore] void vexpdif_f16_part_kernel_2d(__gm__ half *v1,
                                                               __gm__ half *v2,
                                                               __gm__ float *v3);
 
 void LaunchVexpdiff_f16_part_kernel_2d(uint16_t *v1, uint16_t *v2, float *v3,
                                        void *stream) {
-  vexpdiff_f16_part_kernel_2d<<<1, nullptr, stream>>>((__gm__ half *)v1,
+  vexpdif_f16_part_kernel_2d<<<1, nullptr, stream>>>((__gm__ half *)v1,
                                                       (__gm__ half *)v2,
                                                       (__gm__ float *)v3);
 }

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/main.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/main.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f16-part
+// case: micro-op/dsa-sfu/vexpdif-f16-part
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f16, fused-expdiff, part-even-odd
 // -----------------------------------------------------------------------------
 /**

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/stub.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f16-part/stub.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f16-part
+// case: micro-op/dsa-sfu/vexpdif-f16-part
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f16, fused-expdiff, part-even-odd
 // -----------------------------------------------------------------------------
 
@@ -21,7 +21,7 @@
 #define __gm__
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_f16_part_kernel_2d(__gm__ half *v1,
+extern "C" __global__ [aicore] void vexpdif_f16_part_kernel_2d(__gm__ half *v1,
                                                               __gm__ half *v2,
                                                               __gm__ float *v3) {
   (void)v1;

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/compare.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/compare.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-f32
+# case: micro-op/dsa-sfu/vexpdif-f32
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f32, fused-expdiff
 # NOTE: bulk-generated coverage skeleton.
 

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/golden.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/golden.py
@@ -7,9 +7,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# case: micro-op/dsa-sfu/vexpdiff-f32
+# case: micro-op/dsa-sfu/vexpdif-f32
 # family: dsa-sfu
-# target_ops: pto.vexpdiff
+# target_ops: pto.vexpdif
 # scenarios: core-f32, fused-expdiff
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/kernel.pto
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/kernel.pto
@@ -1,13 +1,13 @@
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f32
+// case: micro-op/dsa-sfu/vexpdif-f32
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
 // -----------------------------------------------------------------------------
 module attributes {pto.target_arch = "a5"} {
-  func.func @vexpdiff_kernel_2d(%arg0: !pto.ptr<f32, gm>,
+  func.func @vexpdif_kernel_2d(%arg0: !pto.ptr<f32, gm>,
                                 %arg1: !pto.ptr<f32, gm>) {
     %c0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
@@ -34,7 +34,7 @@ module attributes {pto.target_arch = "a5"} {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c64 iter_args(%remaining = %c1024_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
         %vec = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %sum = pto.vexpdiff %vec, %vec, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+        %sum = pto.vexpdif %vec, %vec, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
         pto.vsts %sum, %ub_out[%offset], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
         scf.yield %next_remaining : i32
       }

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/launch.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/launch.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f32
+// case: micro-op/dsa-sfu/vexpdif-f32
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
@@ -43,10 +43,10 @@ struct MrgSortExecutedNumList {
 #include "acl/acl.h"
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_kernel_2d(__gm__ float *v1,
+extern "C" __global__ [aicore] void vexpdif_kernel_2d(__gm__ float *v1,
                                                      __gm__ float *v2);
 
 void LaunchVexpdiff_kernel_2d(float *v1, float *v2, void *stream) {
-  vexpdiff_kernel_2d<<<1, nullptr, stream>>>((__gm__ float *)v1,
+  vexpdif_kernel_2d<<<1, nullptr, stream>>>((__gm__ float *)v1,
                                              (__gm__ float *)v2);
 }

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/main.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/main.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f32
+// case: micro-op/dsa-sfu/vexpdif-f32
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.

--- a/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/stub.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vexpdiff-f32/stub.cpp
@@ -7,9 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/dsa-sfu/vexpdiff-f32
+// case: micro-op/dsa-sfu/vexpdif-f32
 // family: dsa-sfu
-// target_ops: pto.vexpdiff
+// target_ops: pto.vexpdif
 // scenarios: core-f32, fused-expdiff
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
@@ -23,7 +23,7 @@
 #define __gm__
 #endif
 
-extern "C" __global__ [aicore] void vexpdiff_kernel_2d(__gm__ float *v1,
+extern "C" __global__ [aicore] void vexpdif_kernel_2d(__gm__ float *v1,
                                                      __gm__ float *v2) {
   (void)v1;
   (void)v2;

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -343,23 +343,27 @@ neg_vec = pto.vneg(vec_f32, mask32)
 **Constraints**:
 - Operates on integer vector types only
 
-#### `pto.vexpdiff(vec: VRegType, mask: MaskType) -> VRegType`
+#### `pto.vexpdif(vec: VRegType, max_vec: VRegType, part: pto.VcvtPartMode) -> VRegType`
 
-**Description**: Exponential difference of vector elements.
+**Description**: Fused exponential difference `exp(vec - max_vec)` for numerically stable softmax lowering.
 
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `vec` | `VRegType` | Input vector |
-| `mask` | `MaskType` | Predicate mask |
+| `max_vec` | `VRegType` | Per-lane max vector subtracted before exponentiation |
+| `part` | `pto.VcvtPartMode` | Output part selector enum. Use `pto.VcvtPartMode.EVEN` or `pto.VcvtPartMode.ODD`. |
 
 **Returns**:
 | Return Value | Type | Description |
 |--------------|------|-------------|
-| `result` | `VRegType` | Exponential difference values |
+| `result` | `VRegType` | Exponential difference values; result element type is `f32` |
 
 **Constraints**:
-- For floating-point vector types only
+- Supports `f16` and `f32` input vectors only
+- `vec` and `max_vec` must use the same vector type
+- `part` should use `pto.VcvtPartMode.EVEN` or `pto.VcvtPartMode.ODD`
+- Canonical strings `"EVEN"` / `"ODD"` are still accepted for compatibility
 
 ### Binary Vector Operations
 

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
@@ -894,7 +894,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 10 | [Reduction Ops](#isa-10-reduction-ops) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
 | 11 | [Compare & Select](#isa-11-compare-select) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
 | 12 | [Data Rearrangement](#isa-12-data-rearrangement) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](#isa-13-dsa-sfu-ops) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 13 | [DSA/SFU Ops](#isa-13-dsa-sfu-ops) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
 | 14 | [Arith (Shared MLIR Dialect)](#isa-14-shared-arith) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](#isa-15-shared-scf) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
@@ -4888,9 +4888,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-##### `pto.vexpdiff`
+##### `pto.vexpdif`
 
-- **syntax:** `%result = pto.vexpdiff %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
+- **syntax:** `%result = pto.vexpdif %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
 - **A5 types:** input `f16` or `f32`, output `f32`
 - **semantics:** Fused exp(x - max) for numerically stable softmax.
 
@@ -5049,7 +5049,7 @@ for (int i = 0; i < N; i++)
 ```mlir
 // Softmax with fused expdiff
 %max_broadcast = pto.vlds %ub_max[%c0] {dist = "BRC"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-%exp_stable = pto.vexpdiff %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp_stable = pto.vexpdif %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // Leaky ReLU activation
 %activated = pto.vlrelu %linear_out, %alpha_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
@@ -5285,7 +5285,7 @@ pto.vsts %max_vec, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !
 %max_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 2. exp(x - max) using fused op
-%exp = pto.vexpdiff %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp = pto.vexpdif %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // 3. Sum
 %sum = pto.vcadd %exp, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.2.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.2.md
@@ -4490,9 +4490,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-##### `pto.vexpdiff`
+##### `pto.vexpdif`
 
-- **syntax:** `%result = pto.vexpdiff %input, %max : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vexpdif %input, %max : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** Fused exp(x - max) for numerically stable softmax.
 
@@ -4736,7 +4736,7 @@ for (int i = 0; i < N; i++)
 ```mlir
 // Softmax with fused expdiff
 %max_broadcast = pto.vlds %ub_max[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-%exp_stable = pto.vexpdiff %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp_stable = pto.vexpdif %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // Leaky ReLU activation
 %activated = pto.vlrelu %linear_out, %alpha_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
@@ -4975,7 +4975,7 @@ pto.vsts %max_vec, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !
 %max_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 2. exp(x - max) using fused op
-%exp = pto.vexpdiff %logits, %max_bc : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp = pto.vexpdif %logits, %max_bc : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // 3. Sum
 %sum = pto.vcadd %exp, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
@@ -894,7 +894,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 10 | [Reduction Ops](#isa-10-reduction-ops) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
 | 11 | [Compare & Select](#isa-11-compare-select) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
 | 12 | [Data Rearrangement](#isa-12-data-rearrangement) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](#isa-13-dsa-sfu-ops) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdiff`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 13 | [DSA/SFU Ops](#isa-13-dsa-sfu-ops) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
 | 14 | [Arith (Shared MLIR Dialect)](#isa-14-shared-arith) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](#isa-15-shared-scf) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 
@@ -4855,9 +4855,9 @@ for (int i = 0; i < N; i++)
 
 ---
 
-##### `pto.vexpdiff`
+##### `pto.vexpdif`
 
-- **syntax:** `%result = pto.vexpdiff %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
+- **syntax:** `%result = pto.vexpdif %input, %max, "EVEN|ODD" : !pto.vreg<NxT>, !pto.vreg<NxT> -> !pto.vreg<Mxf32>`
 - **A5 types:** input `f16` or `f32`, output `f32`
 - **semantics:** Fused exp(x - max) for numerically stable softmax.
 
@@ -5016,7 +5016,7 @@ for (int i = 0; i < N; i++)
 ```mlir
 // Softmax with fused expdiff
 %max_broadcast = pto.vlds %ub_max[%c0] {dist = "BRC"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-%exp_stable = pto.vexpdiff %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp_stable = pto.vexpdif %logits, %max_broadcast : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // Leaky ReLU activation
 %activated = pto.vlrelu %linear_out, %alpha_scalar, %mask : !pto.vreg<64xf32>, f32, !pto.mask<G> -> !pto.vreg<64xf32>
@@ -5252,7 +5252,7 @@ pto.vsts %max_vec, %ub_tmp[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !
 %max_bc = pto.vlds %ub_tmp[%c0] {dist = "BRC"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
 // 2. exp(x - max) using fused op
-%exp = pto.vexpdiff %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
+%exp = pto.vexpdif %logits, %max_bc, "ODD" : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>
 
 // 3. Sum
 %sum = pto.vcadd %exp, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -3038,7 +3038,6 @@ class _AuthoringRenderer:
             "vzunpack",
             "vusqz",
             "vsqz",
-            "vexpdiff",
             "vcgadd",
             "vcgmax",
             "vcgmin",
@@ -3051,6 +3050,17 @@ class _AuthoringRenderer:
                 self._indent(indent)
                 + f"{result_name} = pto.{expr.name} {value.name}, {mask.name} : "
                 + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
+            )
+            return _RenderedValue(name=result_name, type=expr.type)
+
+        if expr.name == "vexpdif":
+            lhs = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            rhs = self._lower_expr(expr.args[1], env, indent=indent, into=into)
+            part = self._render_string_literal(expr.args[2])
+            into.append(
+                self._indent(indent)
+                + f"{result_name} = pto.vexpdif {lhs.name}, {rhs.name}, {part} : "
+                + f"{self._render_type(lhs.type)}, {self._render_type(rhs.type)} -> {self._render_type(expr.type)}"
             )
             return _RenderedValue(name=result_name, type=expr.type)
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -228,7 +228,6 @@ _UNARY_VECTOR_OPS = {
     "vzunpack",
     "vusqz",
     "vsqz",
-    "vexpdiff",
     "vtrc",
     "vcgadd",
     "vcgmax",
@@ -275,6 +274,7 @@ _VECTOR_IMMEDIATE_OPS = {"vshift", "vslide"}
 _TERNARY_VECTOR_OPS = {"vaxpy", "vmula"}
 _MULTI_RESULT_VECTOR_OPS = {"vmull", "vldsx2", "vldus", "pstu"}
 _BROADCAST_VECTOR_OPS = {"vbr", "vdup", "vci"}
+_VEXPDIF_OP_ALIASES = {"vexpdif", "vexpdiff"}
 _LOW_LEVEL_DMA_UNARY_CONFIG_OPS = {"set_mov_pad_val"}
 _LOW_LEVEL_DMA_CONFIG_OPS = {
     "set_loop2_stride_outtoub",
@@ -1188,6 +1188,7 @@ class _SemanticAnalyzer:
             | _MULTI_RESULT_VECTOR_OPS
             | _BROADCAST_VECTOR_OPS
             | _ADVANCED_VECTOR_ACTIVITY_OPS
+            | _VEXPDIF_OP_ALIASES
         )
 
     def _block_can_live_in_inferred_vecscope(
@@ -1289,6 +1290,7 @@ class _SemanticAnalyzer:
                 | _MULTI_RESULT_VECTOR_OPS
                 | _BROADCAST_VECTOR_OPS
                 | _ADVANCED_VECTOR_ACTIVITY_OPS
+                | _VEXPDIF_OP_ALIASES
             )
         )
 
@@ -1412,6 +1414,7 @@ class _SemanticAnalyzer:
                 | _MULTI_RESULT_VECTOR_OPS
                 | _BROADCAST_VECTOR_OPS
                 | _ADVANCED_VECTOR_ACTIVITY_OPS
+                | _VEXPDIF_OP_ALIASES
             ):
                 return True
             return any(self._expr_contains_vector_activity(arg) for arg in expr.args)
@@ -4033,6 +4036,8 @@ class _SemanticAnalyzer:
             return self._analyze_broadcast_vector_op(name, args)
         if name in _MULTI_RESULT_VECTOR_OPS:
             return self._analyze_multi_result_vector_op(name, args)
+        if name in _VEXPDIF_OP_ALIASES:
+            return self._analyze_vexpdif_op(args)
         if name in _UNARY_VECTOR_OPS:
             return self._analyze_unary_vector_op(name, args)
         if name in _BINARY_VECTOR_OPS:
@@ -4742,6 +4747,26 @@ class _SemanticAnalyzer:
             result_type = self._vcadd_result_vreg_type(vreg)
         return SemanticCallExpr(namespace="pto", name=name, args=args, type=result_type)
 
+    def _analyze_vexpdif_op(
+        self,
+        args: tuple[SemanticExpr, ...],
+    ) -> SemanticExpr:
+        if len(args) != 3:
+            raise TypeError("pto.vexpdif expects exactly 3 positional arguments in TileLang DSL v1")
+        input_expr, max_expr, part_expr = args
+        input_type = self._require_vreg_expr(input_expr, "pto.vexpdif input")
+        max_type = self._require_vreg_expr(max_expr, "pto.vexpdif max")
+        if input_type != max_type:
+            raise TypeError("pto.vexpdif requires input/max vector types to match")
+        self._validate_vexpdif_dtype(input_type.element_dtype)
+        part = self._normalize_vexpdif_part(part_expr, "pto.vexpdif part")
+        return SemanticCallExpr(
+            namespace="pto",
+            name="vexpdif",
+            args=(input_expr, max_expr, part),
+            type=self._vexpdif_result_vreg_type(input_type),
+        )
+
     def _analyze_binary_vector_op(
         self,
         name: str,
@@ -5366,6 +5391,11 @@ class _SemanticAnalyzer:
             return self._vreg_type_for_dtype(widened_dtype)
         return vreg_type
 
+    def _vexpdif_result_vreg_type(self, vreg_type: SemanticVRegType) -> SemanticVRegType:
+        if vreg_type.element_dtype.name == "f32":
+            return vreg_type
+        return SemanticVRegType(element_dtype=f32, lanes=vreg_type.lanes // 2)
+
     def _normalize_position_mode(
         self,
         expr: SemanticExpr | None,
@@ -5581,6 +5611,31 @@ class _SemanticAnalyzer:
         ):
             return expr.binding.value
         raise TypeError(f"{context} must be a string literal in TileLang DSL")
+
+    def _normalize_vexpdif_part(self, expr: SemanticExpr, context: str) -> SemanticExpr:
+        if (
+            isinstance(expr, SemanticSymbolExpr)
+            and isinstance(expr.type, SemanticMetaType)
+            and expr.type.kind == "vcvt_part_mode"
+            and isinstance(expr.value, VcvtPartMode)
+        ):
+            part = expr.value.value
+        elif (
+            isinstance(expr, SemanticBindingRef)
+            and isinstance(expr.type, SemanticMetaType)
+            and expr.type.kind == "vcvt_part_mode"
+            and isinstance(expr.binding.value, VcvtPartMode)
+        ):
+            part = expr.binding.value.value
+        else:
+            part = self._require_string_expr(expr, context)
+        if part not in {VcvtPartMode.EVEN.value, VcvtPartMode.ODD.value}:
+            raise TypeError(
+                "pto.vexpdif part must be `pto.VcvtPartMode.EVEN` or "
+                "`pto.VcvtPartMode.ODD`, or one of the canonical strings "
+                '`"EVEN"` / `"ODD"` in TileLang DSL v1'
+            )
+        return SemanticLiteralExpr(value=part, type=SemanticMetaType(kind="string"))
 
     def _normalize_cmp_mode(self, expr: SemanticExpr, context: str) -> SemanticExpr:
         if (
@@ -5953,7 +6008,7 @@ class _SemanticAnalyzer:
         return SemanticVRegType(element_dtype=dtype, lanes=256 // width)
 
     def _validate_unary_dtype(self, name: str, dtype: ScalarType) -> None:
-        if name in {"vexp", "vln", "vsqrt", "vrec", "vrsqrt", "vexpdiff"} and dtype.name not in {"f16", "f32"}:
+        if name in {"vexp", "vln", "vsqrt", "vrec", "vrsqrt"} and dtype.name not in {"f16", "f32"}:
             raise TypeError(f"pto.{name} only supports f16/f32 in TileLang DSL v1")
         if name == "vrelu" and dtype.name not in {"f16", "f32"}:
             raise TypeError("pto.vrelu only supports f16/f32 in TileLang DSL v1")
@@ -6002,6 +6057,10 @@ class _SemanticAnalyzer:
             (is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32}) or dtype.name in {"f16", "bf16", "f32"}
         ):
             raise TypeError(f"pto.{name} does not support this dtype in TileLang DSL v1")
+
+    def _validate_vexpdif_dtype(self, dtype: ScalarType) -> None:
+        if dtype.name not in {"f16", "f32"}:
+            raise TypeError("pto.vexpdif only supports f16/f32 in TileLang DSL v1")
 
     def _validate_vector_scalar_dtype(self, name: str, dtype: ScalarType) -> None:
         if name == "vdivs" and dtype.name not in {"f16", "f32"}:

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -104,6 +104,7 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
         "vzunpack",
         "vusqz",
         "vsqz",
+        "vexpdif",
         "vexpdiff",
         "vtrc",
         "vbr",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2965,7 +2965,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             out = pto.vsqrt(out, all_mask)
             out = pto.vrec(out, all_mask)
             out = pto.vrsqrt(out, all_mask)
-            out = pto.vexpdiff(out, all_mask)
+            out = pto.vexpdif(out, vec1, pto.VcvtPartMode.ODD)
             out = pto.vcadd(out, all_mask)
             out = pto.vcmax(out, all_mask)
             out = pto.vcmin(out, all_mask)
@@ -2987,7 +2987,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.vsqrt", text)
         self.assertIn("pto.vrec", text)
         self.assertIn("pto.vrsqrt", text)
-        self.assertIn("pto.vexpdiff", text)
+        self.assertIn("pto.vexpdif", text)
         self.assertIn("pto.vcadd", text)
         self.assertIn("pto.vcmax", text)
         self.assertIn("pto.vcmin", text)
@@ -2996,6 +2996,32 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.vprelu", text)
         self.assertIn("pto.vlrelu", text)
         self.assertIn("pto.vcvt", text)
+
+    def test_vexpdif_f16_surface_lowers_to_f32_half_lanes(self) -> None:
+        @pto.vkernel(
+            op="vexpdif_f16_surface_unique",
+            dtypes=[(pto.f32, pto.f16, pto.f16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile, max_src: pto.Tile):
+            vec = pto.vlds(src, 0)
+            max_vec = pto.vlds(max_src, 0)
+            out = pto.vexpdif(vec, max_vec, pto.VcvtPartMode.ODD)
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            max_src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(
+            text,
+            r'pto\.vexpdif %\w+_\d+, %\w+_\d+, "ODD" : !pto\.vreg<128xf16>, !pto\.vreg<128xf16> -> !pto\.vreg<64xf32>',
+        )
 
     def test_vcvt_supports_keyword_attrs_with_enums(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- rename the VPTO/DSL exp-difference op surface to `vexpdif` and keep `vexpdiff` as a DSL compatibility alias
- fix TileLang DSL semantic/lowering handling so the op uses the correct binary-plus-part surface and accepts the existing `pto.VcvtPartMode` enum
- update regression tests, docs, and VPTO micro-op/kernel cases to use the new op spelling

## Validation
- `python3 .github/scripts/check_license_headers.py --repo mouliangyu/PTOAS --event-name push --base-sha 567a9910 --head-sha HEAD`
- `PYTHONPATH=tilelang-dsl/python:tilelang-dsl/tests python3 -m unittest test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_extended_float_vector_ops_surface_lowers test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vexpdif_f16_surface_lowers_to_f32_half_lanes`

Fixes #203