### PR TITLE
fix(dsl): unify signless integer lowering and typed bridges

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -2528,7 +2528,9 @@ public:
       return rewriter.notifyMatchFailure(op, "failed to convert vbr result type");
 
     Value scalar = adaptor.getValue();
-    if (!scalar || scalar.getType() != op.getValue().getType())
+    Type expectedScalarType =
+        this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!scalar || !expectedScalarType || scalar.getType() != expectedScalarType)
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vbr operand type");
 

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -3278,15 +3278,10 @@ class _AuthoringRenderer:
         into: list[str],
     ) -> _RenderedValue:
         value = self._lower_expr(expr, env, indent=indent, into=into)
-        if isinstance(value.type, SemanticScalarType) and value.type.dtype.name == "i32":
-            return value
-        if isinstance(value.type, SemanticIndexType):
-            cast_name = self._new_temp()
-            into.append(
-                self._indent(indent)
-                + f"{cast_name} = arith.index_cast {value.name} : index to i32"
-            )
-            return _RenderedValue(name=cast_name, type=_I32_TYPE)
+        if isinstance(value.type, SemanticIndexType) or (
+            isinstance(value.type, SemanticScalarType) and is_integer_dtype(value.type.dtype)
+        ):
+            return self._coerce_rendered_value(value, _I32_TYPE, indent=indent, into=into)
         raise NotImplementedError("expected an i32 or index operand during TileLang DSL v1 lowering")
 
     def _lower_to_index(
@@ -3298,11 +3293,21 @@ class _AuthoringRenderer:
         into: list[str],
     ) -> _RenderedValue:
         value = self._lower_expr(expr, env, indent=indent, into=into)
+        return self._coerce_rendered_to_index(value, indent=indent, into=into)
+
+    def _coerce_rendered_to_index(
+        self,
+        value: _RenderedValue,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
         if isinstance(value.type, SemanticIndexType):
             return value
         if isinstance(value.type, SemanticScalarType) and is_integer_dtype(value.type.dtype):
             bits = integer_bitwidth(value.type.dtype)
             if bits in {32, 64}:
+                value = self._bridge_rendered_to_signless_integer(value, indent=indent, into=into)
                 cast_name = self._new_temp()
                 into.append(
                     self._indent(indent)
@@ -3318,15 +3323,10 @@ class _AuthoringRenderer:
         indent: int,
         into: list[str],
     ) -> _RenderedValue:
-        if isinstance(value.type, SemanticScalarType) and value.type.dtype.name == "i64":
-            return value
-        if isinstance(value.type, SemanticIndexType):
-            cast_name = self._new_temp()
-            into.append(
-                self._indent(indent)
-                + f"{cast_name} = arith.index_castui {value.name} : index to i64"
-            )
-            return _RenderedValue(name=cast_name, type=_I64_TYPE)
+        if isinstance(value.type, SemanticIndexType) or (
+            isinstance(value.type, SemanticScalarType) and is_integer_dtype(value.type.dtype)
+        ):
+            return self._coerce_rendered_value(value, _I64_TYPE, indent=indent, into=into)
         raise NotImplementedError("expected an i64 or index operand during TileLang DSL v1 lowering")
 
     def _lower_remaining_to_i32(
@@ -3338,16 +3338,49 @@ class _AuthoringRenderer:
         into: list[str],
     ) -> _RenderedValue:
         value = self._lower_expr(expr, env, indent=indent, into=into)
-        if isinstance(value.type, SemanticScalarType) and value.type.dtype.name == "i32":
-            return value
-        if isinstance(value.type, SemanticIndexType):
-            cast_name = self._new_temp()
-            into.append(
-                self._indent(indent)
-                + f"{cast_name} = arith.index_cast {value.name} : index to i32"
-            )
-            return _RenderedValue(name=cast_name, type=_I32_TYPE)
+        if isinstance(value.type, SemanticIndexType) or (
+            isinstance(value.type, SemanticScalarType) and is_integer_dtype(value.type.dtype)
+        ):
+            return self._coerce_rendered_value(value, _I32_TYPE, indent=indent, into=into)
         raise NotImplementedError("tail make_mask lowering expects an i32 or index remaining operand")
+
+    def _bridge_rendered_to_signless_integer(
+        self,
+        value: _RenderedValue,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        if not isinstance(value.type, SemanticScalarType) or not is_integer_dtype(value.type.dtype):
+            return value
+        raw_type = self._signless_integer_scalar_type(value.type)
+        if raw_type is None:
+            return value
+        cast_name = self._new_temp()
+        into.append(
+            self._indent(indent)
+            + f"{cast_name} = builtin.unrealized_conversion_cast {value.name} : "
+            f"{self._render_type(value.type)} to {self._render_type(raw_type)}"
+        )
+        return _RenderedValue(name=cast_name, type=raw_type)
+
+    def _bridge_rendered_integer_to_target(
+        self,
+        value: _RenderedValue,
+        target_type: SemanticScalarType,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        if value.type == target_type:
+            return value
+        cast_name = self._new_temp()
+        into.append(
+            self._indent(indent)
+            + f"{cast_name} = builtin.unrealized_conversion_cast {value.name} : "
+            f"{self._render_type(value.type)} to {self._render_type(target_type)}"
+        )
+        return _RenderedValue(name=cast_name, type=target_type)
 
     def _materialize_copy_buffer_ptr(
         self,
@@ -3393,27 +3426,49 @@ class _AuthoringRenderer:
             sign = integer_signedness(dtype)
             return "signless" if sign is None else sign
 
+        def _signless_int_type_for_bits(bits: int) -> SemanticScalarType:
+            if bits not in {8, 16, 32, 64}:
+                raise NotImplementedError(
+                    f"unsupported integer bitwidth {bits!r} for signless coercion in TileLang DSL v1 lowering"
+                )
+            return SemanticScalarType(dtype=ScalarType(f"i{bits}"))
+
         if type(value.type) is type(target_type) and value.type == target_type:
             return value
         if isinstance(value.type, SemanticIndexType) and isinstance(target_type, SemanticScalarType):
             target_int_bits = _scalar_int_bits(target_type.dtype)
             target_sign = _scalar_int_sign(target_type.dtype)
-            if target_int_bits == 32:
+            signless_target_type = self._signless_integer_scalar_type(target_type)
+            if signless_target_type is None and target_int_bits in {8, 16, 32, 64}:
+                signless_target_type = target_type
+            if target_int_bits in {8, 16, 32, 64} and signless_target_type is not None:
+                carrier_type = (
+                    _signless_int_type_for_bits(32)
+                    if target_int_bits in {8, 16}
+                    else _signless_int_type_for_bits(target_int_bits)
+                )
                 op = "arith.index_castui" if target_sign == "unsigned" else "arith.index_cast"
                 cast_name = self._new_temp()
                 into.append(
                     self._indent(indent)
-                    + f"{cast_name} = {op} {value.name} : index to {target_type.dtype.name}"
+                    + f"{cast_name} = {op} {value.name} : index to {carrier_type.dtype.name}"
                 )
-                return _RenderedValue(name=cast_name, type=target_type)
-            if target_int_bits == 64:
-                op = "arith.index_castui" if target_sign in {"signless", "unsigned"} else "arith.index_cast"
-                cast_name = self._new_temp()
-                into.append(
-                    self._indent(indent)
-                    + f"{cast_name} = {op} {value.name} : index to {target_type.dtype.name}"
-                )
-                return _RenderedValue(name=cast_name, type=target_type)
+                lowered_value = _RenderedValue(name=cast_name, type=carrier_type)
+                if target_int_bits in {8, 16}:
+                    lowered_value = self._coerce_rendered_value(
+                        lowered_value,
+                        signless_target_type,
+                        indent=indent,
+                        into=into,
+                    )
+                if signless_target_type != target_type:
+                    return self._coerce_rendered_value(
+                        lowered_value,
+                        target_type,
+                        indent=indent,
+                        into=into,
+                    )
+                return lowered_value
             if target_type.dtype.name in {"f16", "bf16", "f32"}:
                 index_to_int_name = self._new_temp()
                 index_to_int_op = "arith.index_castui"
@@ -3432,35 +3487,73 @@ class _AuthoringRenderer:
             dst = target_type.dtype.name
             if src == dst:
                 return value
-            cast_name = self._new_temp()
             src_bits = _scalar_int_bits(value.type.dtype)
             dst_bits = _scalar_int_bits(target_type.dtype)
             if src_bits is not None and dst_bits is not None:
-                if src_bits == dst_bits:
-                    op = "arith.bitcast"
-                elif src_bits < dst_bits:
+                src_sign = _scalar_int_sign(value.type.dtype)
+                signless_value = self._bridge_rendered_to_signless_integer(value, indent=indent, into=into)
+                signless_target_type = self._signless_integer_scalar_type(target_type) or target_type
+                if signless_value.type == signless_target_type:
+                    if signless_target_type != target_type:
+                        return self._bridge_rendered_integer_to_target(
+                            signless_value,
+                            target_type,
+                            indent=indent,
+                            into=into,
+                        )
+                    return signless_value
+                cast_name = self._new_temp()
+                if src_bits < dst_bits:
                     op = "arith.extui" if _scalar_int_sign(value.type.dtype) == "unsigned" else "arith.extsi"
-                else:
+                elif src_bits > dst_bits:
                     op = "arith.trunci"
+                else:
+                    raise NotImplementedError(
+                        f"unsupported same-width integer coercion from {value.type!r} to {target_type!r} "
+                        "in TileLang DSL v1 lowering"
+                    )
                 into.append(
                     self._indent(indent)
-                    + f"{cast_name} = {op} {value.name} : {src} to {dst}"
+                    + f"{cast_name} = {op} {signless_value.name} : "
+                    f"{self._render_type(signless_value.type)} to {self._render_type(signless_target_type)}"
                 )
-                return _RenderedValue(name=cast_name, type=target_type)
+                lowered_value = _RenderedValue(name=cast_name, type=signless_target_type)
+                if signless_target_type != target_type:
+                    return self._bridge_rendered_integer_to_target(
+                        lowered_value,
+                        target_type,
+                        indent=indent,
+                        into=into,
+                    )
+                return lowered_value
             if src_bits is not None and dst in {"f16", "bf16", "f32"}:
+                signless_value = self._bridge_rendered_to_signless_integer(value, indent=indent, into=into)
+                cast_name = self._new_temp()
                 op = "arith.uitofp" if _scalar_int_sign(value.type.dtype) == "unsigned" else "arith.sitofp"
                 into.append(
                     self._indent(indent)
-                    + f"{cast_name} = {op} {value.name} : {src} to {dst}"
+                    + f"{cast_name} = {op} {signless_value.name} : "
+                    f"{self._render_type(signless_value.type)} to {dst}"
                 )
                 return _RenderedValue(name=cast_name, type=target_type)
             if src in {"f16", "bf16", "f32"} and dst_bits is not None:
+                signless_target_type = self._signless_integer_scalar_type(target_type) or target_type
+                cast_name = self._new_temp()
                 op = "arith.fptoui" if _scalar_int_sign(target_type.dtype) == "unsigned" else "arith.fptosi"
                 into.append(
                     self._indent(indent)
-                    + f"{cast_name} = {op} {value.name} : {src} to {dst}"
+                    + f"{cast_name} = {op} {value.name} : {src} to {self._render_type(signless_target_type)}"
                 )
-                return _RenderedValue(name=cast_name, type=target_type)
+                lowered_value = _RenderedValue(name=cast_name, type=signless_target_type)
+                if signless_target_type != target_type:
+                    return self._bridge_rendered_integer_to_target(
+                        lowered_value,
+                        target_type,
+                        indent=indent,
+                        into=into,
+                    )
+                return lowered_value
+            cast_name = self._new_temp()
             if src in {"f16", "bf16", "f32"} and dst in {"f16", "bf16", "f32"}:
                 op = "arith.extf" if src in {"f16", "bf16"} and dst == "f32" else "arith.truncf"
                 into.append(
@@ -3707,6 +3800,18 @@ class _AuthoringRenderer:
         cache_key = (self._render_type(ty), value)
         if cache_key in self._constant_cache:
             return self._constant_cache[cache_key]
+
+        raw_type = self._signless_integer_scalar_type(ty)
+        if raw_type is not None:
+            raw_name = self._materialize_constant(value, raw_type)
+            name = self._constant_name(value, ty)
+            self._constant_cache[cache_key] = name
+            self._constant_lines.append(
+                self._indent(4)
+                + f"{name} = builtin.unrealized_conversion_cast {raw_name} : "
+                f"{self._render_type(raw_type)} to {self._render_type(ty)}"
+            )
+            return name
 
         name = self._constant_name(value, ty)
         self._constant_cache[cache_key] = name

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2450,6 +2450,79 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("arith.constant 4294967295 : i32", text)
         self.assertNotIn("arith.constant 4294967295 : ui32", text)
 
+    def test_cached_unsigned_integer_constructor_constant_preserves_typed_bridge(self) -> None:
+        @pto.vkernel(
+            op="cached_ui16_constructor_constant_bridge_unique",
+            dtypes=[(pto.ui16, pto.ui16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            biased = pto.vadds(vec, pto.ui16(1), all_mask)
+            out = pto.vadds(biased, pto.ui16(1), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertEqual(text.count("arith.constant 1 : i16"), 1)
+        self.assertEqual(text.count(": i16 to ui16"), 1)
+        self.assertNotIn("arith.constant 1 : ui16", text)
+
+    def test_narrow_typed_integer_zero_constructors_lower_with_signless_bridge(self) -> None:
+        @pto.vkernel(op="si16_zero_constructor_bridge_unique", dtypes=[(pto.si16, pto.si16)], advanced=True)
+        def si16_kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.si16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vadds(vec, pto.si16(0), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        @pto.vkernel(op="ui16_zero_constructor_bridge_unique", dtypes=[(pto.ui16, pto.ui16)], advanced=True)
+        def ui16_kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vadds(vec, pto.ui16(0), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        @pto.vkernel(op="si8_zero_constructor_bridge_unique", dtypes=[(pto.si8, pto.si8)], advanced=True)
+        def si8_kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.si8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vadds(vec, pto.si8(0), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        @pto.vkernel(op="ui8_zero_constructor_bridge_unique", dtypes=[(pto.ui8, pto.ui8)], advanced=True)
+        def ui8_kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.ui8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vadds(vec, pto.ui8(0), all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        tile_specs = dict(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+        for dtype_name, raw_type, kernel in (
+            ("si16", "i16", si16_kernel),
+            ("ui16", "i16", ui16_kernel),
+            ("si8", "i8", si8_kernel),
+            ("ui8", "i8", ui8_kernel),
+        ):
+            with self.subTest(dtype=dtype_name):
+                text = kernel.specialize(**tile_specs).mlir_text()
+                self.assertEqual(text.count(f"arith.constant 0 : {raw_type}"), 1)
+                self.assertEqual(text.count(f": {raw_type} to {dtype_name}"), 1)
+                self.assertNotIn(f"arith.constant 0 : {dtype_name}", text)
+
     def test_unsigned_pad_value_eval_broadcast_bitcasts_signless_literal(self) -> None:
         @pto.vkernel(op="tile_pad_value_ui16_vbr_unique", dtypes=[(pto.ui16,)], advanced=True)
         def kernel(tile: pto.Tile):
@@ -2475,6 +2548,325 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("builtin.unrealized_conversion_cast", text)
         self.assertIn(": i16 to ui16", text)
         self.assertIn("pto.vbr", text)
+
+    def test_index_to_unsigned_scalar_constructor_bridges_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_ui32_constructor_unique", dtypes=[(pto.ui32,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.ui32(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.ui32, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_castui", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i32 to ui32", text)
+        self.assertNotIn(": index to ui32", text)
+
+    def test_index_to_ui16_scalar_constructor_bridges_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_ui16_constructor_unique", dtypes=[(pto.ui16,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.ui16(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.ui16, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_castui", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertNotIn(": index to ui16", text)
+
+    def test_index_to_ui8_scalar_constructor_bridges_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_ui8_constructor_unique", dtypes=[(pto.ui8,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.ui8(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.ui8, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_castui", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i8", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i8 to ui8", text)
+        self.assertNotIn(": index to ui8", text)
+
+    def test_index_to_si8_scalar_constructor_bridges_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_si8_constructor_unique", dtypes=[(pto.si8,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.si8(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.si8, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_cast", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i8", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i8 to si8", text)
+        self.assertNotIn(": index to si8", text)
+
+    def test_index_to_i16_scalar_constructor_lowers_via_index_cast_then_trunci(self) -> None:
+        @pto.vkernel(op="index_to_i16_constructor_unique", dtypes=[(pto.i16,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.i16(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.i16, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_cast", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertNotIn("builtin.unrealized_conversion_cast", text)
+        self.assertNotIn(": index to i16", text)
+
+    def test_index_to_si16_scalar_constructor_bridges_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_si16_constructor_unique", dtypes=[(pto.si16,)], advanced=True)
+        def kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.si16(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.si16, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(8, 1),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+                config=pto.TileConfig.from_mapping(
+                    {
+                        "b_layout": pto.BLayout.COL_MAJOR,
+                        "s_layout": pto.SLayout.NONE_BOX,
+                    }
+                ),
+            )
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.index_cast", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
+        self.assertIn(": i16 to si16", text)
+        self.assertNotIn(": index to si16", text)
+
+    def test_index_to_32bit_integer_scalar_constructors_bridge_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_i32_constructor_unique", dtypes=[(pto.i32,)], advanced=True)
+        def i32_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.i32(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.i32, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        @pto.vkernel(op="index_to_si32_constructor_unique", dtypes=[(pto.si32,)], advanced=True)
+        def si32_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.si32(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.si32, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        @pto.vkernel(op="index_to_ui32_constructor_bridge_unique", dtypes=[(pto.ui32,)], advanced=True)
+        def ui32_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.ui32(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.ui32, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        tile_spec = pto.TileSpecialization(
+            shape=(8, 1),
+            valid_shape=(8, 1),
+            memory_space=pto.MemorySpace.UB,
+            config=pto.TileConfig.from_mapping(
+                {
+                    "b_layout": pto.BLayout.COL_MAJOR,
+                    "s_layout": pto.SLayout.NONE_BOX,
+                }
+            ),
+        )
+
+        for dtype_name, op_name, kernel in (
+            ("i32", "arith.index_cast", i32_kernel),
+            ("si32", "arith.index_cast", si32_kernel),
+            ("ui32", "arith.index_castui", ui32_kernel),
+        ):
+            with self.subTest(dtype=dtype_name):
+                text = kernel.specialize(tile=tile_spec).mlir_text()
+                self.assertIn(op_name, text)
+                self.assertIn(": index to i32", text)
+                if dtype_name == "i32":
+                    self.assertNotIn("builtin.unrealized_conversion_cast", text)
+                else:
+                    self.assertIn("builtin.unrealized_conversion_cast", text)
+                    self.assertIn(f": i32 to {dtype_name}", text)
+                    self.assertNotIn(f": index to {dtype_name}", text)
+
+    def test_index_to_64bit_integer_scalar_constructors_bridge_via_signless_integer(self) -> None:
+        @pto.vkernel(op="index_to_i64_constructor_unique", dtypes=[(pto.i64,)], advanced=True)
+        def i64_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.i64(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.i64, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        @pto.vkernel(op="index_to_si64_constructor_unique", dtypes=[(pto.si64,)], advanced=True)
+        def si64_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.si64(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.si64, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        @pto.vkernel(op="index_to_ui64_constructor_unique", dtypes=[(pto.ui64,)], advanced=True)
+        def ui64_kernel(tile: pto.Tile):
+            cols = tile.valid_shape[1]
+            for col in range(0, cols, 1):
+                offset = pto.ui64(col)
+                vec = pto.vbr(offset)
+                mask, _ = pto.make_mask(pto.ui64, 1)
+                pto.vsts(vec, tile[col, 0:], mask)
+            return None
+
+        tile_spec = pto.TileSpecialization(
+            shape=(8, 1),
+            valid_shape=(8, 1),
+            memory_space=pto.MemorySpace.UB,
+            config=pto.TileConfig.from_mapping(
+                {
+                    "b_layout": pto.BLayout.COL_MAJOR,
+                    "s_layout": pto.SLayout.NONE_BOX,
+                }
+            ),
+        )
+
+        for dtype_name, op_name, kernel in (
+            ("i64", "arith.index_cast", i64_kernel),
+            ("si64", "arith.index_cast", si64_kernel),
+            ("ui64", "arith.index_castui", ui64_kernel),
+        ):
+            with self.subTest(dtype=dtype_name):
+                text = kernel.specialize(tile=tile_spec).mlir_text()
+                self.assertIn(op_name, text)
+                self.assertIn(": index to i64", text)
+                if dtype_name == "i64":
+                    self.assertNotIn("builtin.unrealized_conversion_cast", text)
+                else:
+                    self.assertIn("builtin.unrealized_conversion_cast", text)
+                    self.assertIn(f": i64 to {dtype_name}", text)
+                    self.assertNotIn(f": index to {dtype_name}", text)
 
 
     def test_make_mask_vlds_vsts_and_vector_families_lower_inside_strict_vecscope(self) -> None:
@@ -3887,6 +4279,65 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.vors", text)
         self.assertIn("pto.vxors", text)
 
+    def test_vci_typed_integer_inputs_lower_without_typed_arith(self) -> None:
+        @pto.vkernel(
+            op="vci_typed_integer_inputs_unique",
+            dtypes=[(pto.ui16, pto.si16, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst_u: pto.Tile, dst_s: pto.Tile, seed: pto.i32):
+            unsigned_mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            signed_mask = pto.make_mask(pto.si16, pto.PAT.ALL)
+
+            unsigned_idx = pto.vci(pto.ui16(0))
+            signed_idx = pto.vci(pto.si16(seed), pto.OrderMode.ASC)
+
+            pto.vsts(unsigned_idx, dst_u, 0, unsigned_mask)
+            pto.vsts(signed_idx, dst_s, 0, signed_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst_u=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst_s=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vci", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertIn(": i16 to si16", text)
+        self.assertNotIn("arith.constant 0 : ui16", text)
+        self.assertNotRegex(text, r"arith\.(extsi|extui|trunci|bitcast) %\w+ : .* to (ui16|si16)")
+
+    def test_vector_scalar_bitwise_typed_scalar_inputs_lower_without_typed_arith(self) -> None:
+        @pto.vkernel(
+            op="vector_scalar_bitwise_typed_scalar_inputs_unique",
+            dtypes=[(pto.ui16, pto.ui16, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile, seed: pto.i32):
+            mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            scalar = pto.ui16(seed)
+            out = pto.vands(vec, scalar, mask)
+            out = pto.vors(out, scalar, mask)
+            out = pto.vxors(out, scalar, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vands", text)
+        self.assertIn("pto.vors", text)
+        self.assertIn("pto.vxors", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertNotRegex(text, r"arith\.trunci %\w+ : i32 to ui16")
+
     def test_broadcast_and_index_vector_ops_surface_lowers(self) -> None:
         @pto.vkernel(
             op="broadcast_and_index_vector_ops_unique",
@@ -3959,6 +4410,45 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         self.assertIn("pto.vdup scalar input does not accept `position`", str(ctx.exception))
 
+    def test_vbr_and_vdup_accept_narrow_typed_scalar_constructors_with_explicit_bridges(self) -> None:
+        @pto.vkernel(
+            op="narrow_typed_vbr_vdup_scalar_constructors_unique",
+            dtypes=[(pto.si16, pto.ui16)],
+            advanced=True,
+        )
+        def kernel(dst_s: pto.Tile, dst_u: pto.Tile):
+            signed_mask = pto.make_mask(pto.si16, pto.PAT.ALL)
+            unsigned_mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+
+            signed = pto.vadd(
+                pto.vbr(pto.si16(0)),
+                pto.vdup(pto.si16(0), signed_mask),
+                signed_mask,
+            )
+            unsigned = pto.vadd(
+                pto.vbr(pto.ui16(0)),
+                pto.vdup(pto.ui16(0), unsigned_mask),
+                unsigned_mask,
+            )
+
+            pto.vsts(signed, dst_s, 0, signed_mask)
+            pto.vsts(unsigned, dst_u, 0, unsigned_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst_s=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst_u=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vbr", text)
+        self.assertIn("pto.vdup", text)
+        self.assertIn("arith.constant 0 : i16", text)
+        self.assertIn(": i16 to si16", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertNotIn("arith.constant 0 : si16", text)
+        self.assertNotIn("arith.constant 0 : ui16", text)
+
     def test_signed_and_unsigned_integer_dtypes_lower_distinctly(self) -> None:
         @pto.vkernel(
             op="signed_unsigned_integer_types_unique",
@@ -3988,6 +4478,90 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("dtype=ui16", text)
         self.assertIn("!pto.vreg<128xsi16>", text)
         self.assertIn("!pto.vreg<128xui16>", text)
+
+    def test_vcmps_literal_scalar_uses_signless_integer_bridge(self) -> None:
+        @pto.vkernel(
+            op="vcmps_literal_scalar_bridge_unique",
+            dtypes=[(pto.si16, pto.si16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            all_mask = pto.make_mask(pto.si16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            cmp_mask = pto.vcmps(vec, pto.si16(-1), all_mask, pto.CmpMode.GT)
+            selected = pto.vsel(vec, vec, cmp_mask)
+            pto.vsts(selected, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vcmps", text)
+        self.assertIn("arith.constant -1 : i16", text)
+        self.assertIn(": i16 to si16", text)
+        self.assertNotIn("arith.constant -1 : si16", text)
+
+    def test_vadds_index_constructor_scalar_uses_signless_integer_bridge(self) -> None:
+        @pto.vkernel(
+            op="vadds_index_constructor_bridge_unique",
+            dtypes=[(pto.ui16, pto.ui16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            cols = dst.valid_shape[1]
+            vec = pto.vlds(src, 0)
+            mask, _ = pto.make_mask(pto.ui16, 1)
+            for col in range(0, cols, 1):
+                scalar = pto.ui16(col)
+                out = pto.vadds(vec, scalar, mask)
+                pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(
+                shape=(8, 128),
+                valid_shape=(8, 1),
+                memory_space=pto.MemorySpace.UB,
+            ),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vadds", text)
+        self.assertIn("arith.index_castui", text)
+        self.assertIn(": index to i32", text)
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertNotIn(": index to ui16", text)
+
+    def test_vshrs_cast_result_scalar_uses_signless_integer_bridge(self) -> None:
+        @pto.vkernel(
+            op="vshrs_cast_result_scalar_bridge_unique",
+            dtypes=[(pto.i32, pto.i32, pto.ui16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile, shift_seed: pto.ui16):
+            all_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            shift = pto.i16(shift_seed)
+            out = pto.vshrs(vec, shift, all_mask)
+            pto.vsts(out, dst, 0, all_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vshrs", text)
+        self.assertIn(": ui16 to i16", text)
+        self.assertNotRegex(text, r"arith\.bitcast %\w+ : ui16 to i16")
+        self.assertNotRegex(text, r"arith\.trunci %\w+ : ui16 to i16")
 
     def test_vbr_accepts_float_literal_constant(self) -> None:
         @pto.vkernel(
@@ -4068,6 +4642,95 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("arith.fptosi", text)
         self.assertIn("arith.extf", text)
         self.assertIn("arith.truncf", text)
+
+    def test_typed_integer_scalar_coercion_uses_signless_integer_carriers(self) -> None:
+        @pto.vkernel(
+            op="typed_integer_scalar_coercion_unique",
+            dtypes=[(pto.si16, pto.si16, pto.ui16, pto.ui16, pto.i32, pto.i32, pto.i32)],
+            advanced=True,
+        )
+        def kernel(
+            dst_s: pto.Tile,
+            src_s: pto.Tile,
+            dst_u: pto.Tile,
+            src_u: pto.Tile,
+            dst_i: pto.Tile,
+            src_i: pto.Tile,
+            seed: pto.i32,
+        ):
+            signed_mask = pto.make_mask(pto.si16, pto.PAT.ALL)
+            unsigned_mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            scalar_mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+
+            signed_scalar = pto.si16(seed)
+            unsigned_scalar = pto.ui16(seed)
+
+            signed_vec = pto.vlds(src_s, 0)
+            unsigned_vec = pto.vlds(src_u, 0)
+            scalar_vec = pto.vlds(src_i, 0)
+
+            signed_out = pto.vadds(signed_vec, signed_scalar, signed_mask)
+            unsigned_out = pto.vadds(unsigned_vec, unsigned_scalar, unsigned_mask)
+            scalar_out = pto.vadds(scalar_vec, pto.i32(signed_scalar), scalar_mask)
+            scalar_out = pto.vadds(scalar_out, pto.i32(unsigned_scalar), scalar_mask)
+
+            pto.vsts(signed_out, dst_s, 0, signed_mask)
+            pto.vsts(unsigned_out, dst_u, 0, unsigned_mask)
+            pto.vsts(scalar_out, dst_i, 0, scalar_mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst_s=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src_s=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst_u=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src_u=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst_i=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src_i=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn("arith.trunci", text)
+        self.assertIn(": i32 to i16", text)
+        self.assertIn(": i16 to si16", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertIn(": si16 to i16", text)
+        self.assertIn(": ui16 to i16", text)
+        self.assertIn("arith.extsi", text)
+        self.assertIn("arith.extui", text)
+        self.assertNotRegex(text, r"arith\.trunci %\w+ : i32 to (si16|ui16)")
+        self.assertNotRegex(text, r"arith\.extsi %\w+ : si16 to i32")
+        self.assertNotRegex(text, r"arith\.extui %\w+ : ui16 to i32")
+
+    def test_typed_integer_float_scalar_coercion_uses_signless_integer_carriers(self) -> None:
+        @pto.vkernel(
+            op="typed_integer_float_scalar_coercion_unique",
+            dtypes=[(pto.ui16, pto.ui16)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.ui16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            scalar = pto.ui16(1)
+            flt = pto.f32(scalar)
+            back = pto.ui16(flt)
+            out = pto.vadds(vec, back, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn(": ui16 to i16", text)
+        self.assertIn("arith.uitofp", text)
+        self.assertIn(": i16 to f32", text)
+        self.assertIn("arith.fptoui", text)
+        self.assertIn(": f32 to i16", text)
+        self.assertIn(": i16 to ui16", text)
+        self.assertNotRegex(text, r"arith\.uitofp %\w+ : ui16 to f32")
+        self.assertNotRegex(text, r"arith\.fptoui %\w+ : f32 to ui16")
 
     def test_scalar_constructor_accepts_signed_float_literals(self) -> None:
         @pto.vkernel(op="scalar_constructor_signed_float_literals_unique", dtypes=[(pto.f32,)])
@@ -4945,7 +5608,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         )
 
         text = specialized.mlir_text()
-        self.assertIn("arith.bitcast", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
         self.assertRegex(text, r"pto\.set_mov_pad_val %[^ ]+ : i16")
 
     def test_copy_ubuf_to_gm_keyword_surface_lowers_in_advanced_mode(self) -> None:
@@ -5806,17 +6469,19 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
     def test_predicate_load_store_alias_and_immediate_forms_lower_to_supported_ops(self) -> None:
         @pto.vkernel(
             op="predicate_load_store_alias_and_immediate_forms",
-            dtypes=[(pto.ui32, pto.ui32)],
+            dtypes=[(pto.ui32, pto.ui32, pto.ui32, pto.si32)],
             advanced=True,
         )
         def kernel(
             mask_src: pto.ptr(pto.ui32, pto.MemorySpace.UB),
             mask_dst: pto.ptr(pto.ui32, pto.MemorySpace.UB),
+            off_u: pto.ui32,
+            off_s: pto.si32,
         ):
             mask0 = pto.pld(mask_src, 0, pto.PredicateDist.NORM)
-            mask1 = pto.pldi(mask_src, pto.i32(8), pto.PredicateDist.US)
+            mask1 = pto.pldi(mask_src, pto.i32(off_u), pto.PredicateDist.US)
             pto.pst(mask0, mask_dst, 0)
-            pto.psti(mask1, mask_dst, pto.i32(8), pto.PredicateDist.PK)
+            pto.psti(mask1, mask_dst, pto.i32(off_s), pto.PredicateDist.PK)
             return None
 
         text = kernel.specialize().mlir_text()
@@ -5824,7 +6489,10 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("pto.pldi", text)
         self.assertIn("pto.psts", text)
         self.assertIn("pto.psti", text)
+        self.assertIn("builtin.unrealized_conversion_cast", text)
         self.assertIn("arith.index_cast", text)
+        self.assertNotRegex(text, r"arith\.extsi %\w+ : si32 to i32")
+        self.assertNotRegex(text, r"arith\.extui %\w+ : ui32 to i32")
 
     def test_predicate_reorder_families_lower_to_supported_ops(self) -> None:
         @pto.vkernel(


### PR DESCRIPTION
## Summary
- unify TileLang DSL integer lowering around signless `arith` carriers plus explicit `builtin.unrealized_conversion_cast` bridges
- fix `index -> integer scalar` constructors and scalar-to-scalar integer coercion for signed/unsigned narrow dtypes
- add regression coverage for constant lowering, constructor caching, vector-scalar surfaces, and issue #200/#204 cast paths
- adjust VPTO LLVM emission type compatibility for `vbr`/related legalization on the LLVM path

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_unsigned_integer_constants_lower_with_signless_arith_types tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_narrow_typed_integer_zero_constructors_lower_with_signless_bridge tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_index_to_ui8_scalar_constructor_bridges_via_signless_integer tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_index_to_ui16_scalar_constructor_bridges_via_signless_integer tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_index_to_unsigned_scalar_constructor_bridges_via_signless_integer tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_index_to_si16_scalar_constructor_bridges_via_signless_integer tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vbr_and_vdup_accept_narrow_typed_scalar_constructors_with_explicit_bridges tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vcmps_literal_scalar_uses_signless_integer_bridge tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vadds_index_constructor_scalar_uses_signless_integer_bridge tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vshrs_cast_result_scalar_uses_signless_integer_bridge`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_typed_integer_scalar_coercion_uses_signless_integer_carriers tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_typed_integer_float_scalar_coercion_uses_signless_integer_carriers tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_predicate_load_store_alias_and_immediate_forms_lower_to_supported_ops tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_scalar_constructor_call_surfaces_lower`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_broadcast_and_index_vector_ops_surface_lowers tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_advanced_mode_lowers_compare_predicate_carry_and_rearrangement_families tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_extended_integer_vector_ops_surface_lowers tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_vmull_and_vector_scalar_bitwise_surface_lowers tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_signed_and_unsigned_integer_dtypes_lower_distinctly`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand test/dsl/issue_204_repro.pto -o -`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --vpto-emit-hivm-llvm test/dsl/issue_204_repro.pto -o -`
- `openspec validate unify-tilelang-dsl-signless-integer-lowering --type change --strict --json --no-interactive`

## Notes
- the OpenSpec change is included under `openspec/changes/unify-tilelang-dsl-signless-integer-lowering/`
- issue #204 end-to-end repro was re-validated after removing duplicate repro template registrations from the active template set in the local workspace

Closes #200
Closes #204
