### PR TITLE
fix(dsl): normalize pto.vci order mode lowering

### DIFF
--- a/docs/isa/09-conversion-ops.md
+++ b/docs/isa/09-conversion-ops.md
@@ -29,14 +29,14 @@ Cycle-accurate simulator **popped→retire** latency (cycles). Only representati
 
 ## `pto.vci`
 
-- **syntax:** `%result = pto.vci %index {order = "ORDER"} : integer -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vci %index {order = "ASC|DESC"} : integer -> !pto.vreg<NxT>`
 - **semantics:** Generate a lane-index vector from a scalar seed/index value.
 - **inputs:**
   `%index` is the scalar seed or base index.
 - **outputs:**
   `%result` is the generated index vector.
 - **constraints and limitations:**
-  This is an index-generation family, not a numeric conversion. `ORDER` and the
+  This is an index-generation family, not a numeric conversion. `order` and the
   result element type together determine how indices are generated. `%result`
   uses an integer element type, and the scalar `%index` type matches that
   result element type.

--- a/docs/isa/13-dsa-sfu-ops.md
+++ b/docs/isa/13-dsa-sfu-ops.md
@@ -149,7 +149,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vci`
 
-- **syntax:** `%result = pto.vci %index {order = "ORDER"} : integer -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vci %index {order = "ASC|DESC"} : integer -> !pto.vreg<NxT>`
 - **semantics:** Generate lane index vector.
 
 ```c
@@ -208,7 +208,7 @@ for (int i = 0; i < N; i++)
 
 - `pto.vmull %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.vreg<NxT>`
 - `pto.vmula %acc, %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
-- `pto.vci %index {order = "ORDER"} : integer -> !pto.vreg<NxT>`
+- `pto.vci %index {order = "ASC|DESC"} : integer -> !pto.vreg<NxT>`
 - `pto.vbitsort %dest, %src, %indices, %repeat_times : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, index`
 - `pto.vmrgsort4 %dest, %src0, %src1, %src2, %src3, %count, %config : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, i64, i64`
 

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1499,7 +1499,7 @@ None. The op writes UB memory directly.
 - `dest` and `src0` through `src3` must be UB-backed pointers
 - Inputs must already be sorted according to the order encoded by `config`
 
-**Order Mode Enum**: The `OrderMode` enum provides type-safe order selection for `pto.vci` operations. Currently only `ASC` (ascending order) is supported, with more order options planned for future releases.
+**Order Mode Enum**: The `OrderMode` enum provides type-safe order selection for `pto.vci` operations. `ASC` and `DESC` are supported.
 
 #### `pto.vci(index: ScalarType, order: OrderMode = OrderMode.ASC) -> VRegType`
 
@@ -1509,7 +1509,7 @@ None. The op writes UB memory directly.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `index` | `ScalarType` | Scalar seed or base index value |
-| `order` | `OrderMode` | Order mode enum (default: `OrderMode.ASC` for ascending order) |
+| `order` | `OrderMode` | Order mode enum (default: `OrderMode.ASC`; supported values: `ASC`, `DESC`) |
 
 **Returns**:
 | Return Value | Type | Description |
@@ -1519,12 +1519,15 @@ None. The op writes UB memory directly.
 **Constraints**:
 - This is an index-generation family, not a numeric conversion
 - The `order` parameter and result element type together determine how indices are generated
-- Currently only ascending order (`OrderMode.ASC`) is supported
+- Supported order modes are ascending (`OrderMode.ASC`) and descending (`OrderMode.DESC`)
 
 **Example**:
 ```python
 # Generate ascending indices starting from 0
 indices = pto.vci(pto.i32(0), OrderMode.ASC)
+
+# Generate descending indices starting from the seed value
+indices_desc = pto.vci(pto.i32(63), OrderMode.DESC)
 
 # Keyword form for the optional order argument is also supported
 indices_kw = pto.vci(pto.i32(0), order=OrderMode.ASC)

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -5469,8 +5469,10 @@ class _SemanticAnalyzer:
         ):
             return SemanticLiteralExpr(value=expr.binding.value.value, type=SemanticMetaType(kind="string"))
         order = self._require_string_expr(expr, context)
-        if order != OrderMode.ASC.value:
-            raise TypeError("pto.vci currently only supports order `OrderMode.ASC` in TileLang DSL v1")
+        if order not in {OrderMode.ASC.value, OrderMode.DESC.value}:
+            raise TypeError(
+                "pto.vci currently only supports order `OrderMode.ASC` or `OrderMode.DESC` in TileLang DSL v1"
+            )
         return SemanticLiteralExpr(value=order, type=SemanticMetaType(kind="string"))
 
     def _normalize_vcvt_round_mode(self, expr: SemanticExpr | None) -> SemanticExpr | None:

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -437,7 +437,8 @@ class PositionMode(str, Enum):
 
 
 class OrderMode(str, Enum):
-    ASC = "ORDER_ASC"
+    ASC = "ASC"
+    DESC = "DESC"
 
 
 class VcvtRoundMode(str, Enum):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -161,7 +161,8 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertEqual(pto.InterleaveDist.INTLV.value, "INTLV")
         self.assertEqual(pto.PositionMode.LOWEST.value, "LOWEST")
         self.assertEqual(pto.PositionMode.HIGHEST.value, "HIGHEST")
-        self.assertEqual(pto.OrderMode.ASC.value, "ORDER_ASC")
+        self.assertEqual(pto.OrderMode.ASC.value, "ASC")
+        self.assertEqual(pto.OrderMode.DESC.value, "DESC")
         self.assertEqual(pto.PredicateDist.NORM.value, "NORM")
         self.assertEqual(pto.PredicateDist.US.value, "US")
         self.assertEqual(pto.PredicateDist.DS.value, "DS")
@@ -4471,11 +4472,36 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertNotIn('position = "POS_LOWEST"', text)
         self.assertRegex(
             text,
-            r'pto\.vci\s+%[^\s]+\s+\{order = "ORDER_ASC"\}\s+:',
+            r'pto\.vci\s+%[^\s]+\s+\{order = "ASC"\}\s+:',
         )
         self.assertNotRegex(
             text,
-            r'pto\.vci\s+%[^\s]+,\s*"ORDER_ASC"\s+:',
+            r'pto\.vci\s+%[^\s]+,\s*"ASC"\s+:',
+        )
+
+    def test_vci_desc_lowers_to_desc_order_attr(self) -> None:
+        @pto.vkernel(
+            op="vci_desc_order_unique",
+            dtypes=[(pto.i32, pto.i32, pto.i32)],
+            advanced=True,
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile, seed: pto.i32):
+            mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+            indices = pto.vci(seed, pto.OrderMode.DESC)
+            vec = pto.vlds(src, 0)
+            out = pto.vadd(vec, indices, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(
+            text,
+            r'pto\.vci\s+%[^\s]+\s+\{order = "DESC"\}\s+:',
         )
 
     def test_vdup_scalar_input_rejects_position_argument(self) -> None:


### PR DESCRIPTION
## Summary
- normalize TileLang DSL `pto.vci` order mode lowering to emit `ASC` / `DESC`
- keep VPTO LLVM emission compatible with both legacy `ORDER_*` spellings and normalized IR spellings
- document supported `pto.vci` order values and align the user guide wording

## Repro
- issue: #216
- repro cmd: `ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --vpto-emit-hivm-llvm test/dsl/issue_216.pto`

## Validation
- confirmed `issue_216.pto` now lowers successfully through `--vpto-emit-hivm-llvm`
- confirmed expanded TileLang DSL now emits `order = "ASC"`
- confirmed hand-authored `order = "DESC"` lowers to the expected HIVM `vci` call form

Closes #216