### PR TITLE
fix(vpto): align vrelu i32 support

### DIFF
--- a/docs/isa/06-unary-vector-ops.md
+++ b/docs/isa/06-unary-vector-ops.md
@@ -126,7 +126,7 @@ for (int i = 0; i < N; i++)
 ### `pto.vrelu`
 
 - **syntax:** `%result = pto.vrelu %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
-- **A5 types:** f16, f32
+- **A5 types:** si32, i32, f16, f32
 
 ```c
 for (int i = 0; i < N; i++)
@@ -135,8 +135,9 @@ for (int i = 0; i < N; i++)
 
 - **inputs:** `%input` is the source vector and `%mask` selects active lanes.
 - **outputs:** `%result` holds `max(input[i], 0)` per active lane.
-- **constraints and limitations:** Only floating-point element types are legal
-  on the current A5 surface described here.
+- **constraints and limitations:** Signed or signless 32-bit integer and
+  floating-point element types are legal on the current A5 surface described
+  here.
 
 ---
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -2340,7 +2340,20 @@ LogicalResult VexpOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VlnOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VsqrtOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VnegOp::verify() { return verifyUnaryVecOp(*this); }
-LogicalResult VreluOp::verify() { return verifyUnaryVecOp(*this); }
+LogicalResult VreluOp::verify() {
+  if (failed(verifyUnaryVecOp(*this)))
+    return failure();
+  auto inputType = cast<VRegType>(getInput().getType());
+  Type elemType = inputType.getElementType();
+  if (auto intType = dyn_cast<IntegerType>(elemType)) {
+    if (intType.getWidth() != 32 || intType.isUnsigned())
+      return emitOpError("requires si32/i32/f16/f32 vector element type");
+    return success();
+  }
+  if (!elemType.isF16() && !elemType.isF32())
+    return emitOpError("requires si32/i32/f16/f32 vector element type");
+  return success();
+}
 LogicalResult VnotOp::verify() { return verifyUnaryVecOp(*this); }
 
 template <typename BinaryOp>

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -600,6 +600,27 @@ private:
         .Default([](Operation *) { return success(); });
   }
 
+  static LogicalResult validateUnaryElementTypeContracts(Operation *op) {
+    return llvm::TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<VreluOp>([](VreluOp concreteOp) {
+          auto vecType = dyn_cast<VRegType>(concreteOp.getInput().getType());
+          if (!vecType)
+            return success();
+
+          Type elemType = vecType.getElementType();
+          if (auto intType = dyn_cast<IntegerType>(elemType)) {
+            if (intType.getWidth() == 32 && !intType.isUnsigned())
+              return success();
+          } else if (elemType.isF16() || elemType.isF32()) {
+            return success();
+          }
+
+          concreteOp.emitOpError("requires si32/i32/f16/f32 vector element type");
+          return failure();
+        })
+        .Default([](Operation *) { return success(); });
+  }
+
   static LogicalResult validateMaskGranularityContracts(Operation *op) {
     return llvm::TypeSwitch<Operation *, LogicalResult>(op)
         .Case<VabsOp, VexpOp, VlnOp, VsqrtOp, VreluOp, VnotOp,
@@ -717,6 +738,7 @@ private:
 
       if (VPTOLegalityHelper::getEnclosingVectorScopeCarrier(op)) {
         if (failed(validateFamilySuffixMaskContracts(op)) ||
+            failed(validateUnaryElementTypeContracts(op)) ||
             failed(validateMaskGranularityContracts(op)))
           return WalkResult::interrupt();
         emitHardwareSupportWarnings(op);

--- a/test/basic/issue220_vrelu_i32_vpto_llvm.pto
+++ b/test/basic/issue220_vrelu_i32_vpto_llvm.pto
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression test for issue #220: direct VPTO `pto.vrelu` should accept both
+// signless and signed i32 vectors and lower them to the same HIVM callee.
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vrelu_signless_i32_store(%value: !pto.vreg<64xi32>, %dst: !pto.ptr<i32, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %out = pto.vrelu %value, %mask : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+      pto.vsts %out, %dst[%c0], %mask : !pto.vreg<64xi32>, !pto.ptr<i32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+
+  func.func @vrelu_signed_i32_store(%value: !pto.vreg<64xsi32>, %dst: !pto.ptr<si32, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %out = pto.vrelu %value, %mask : !pto.vreg<64xsi32>, !pto.mask<b32> -> !pto.vreg<64xsi32>
+      pto.vsts %out, %dst[%c0], %mask : !pto.vreg<64xsi32>, !pto.ptr<si32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-COUNT-1: declare <64 x i32> @llvm.hivm.vrelu.v64s32.x(<64 x i32>, <256 x i1>)
+// CHECK-LABEL: define void @vrelu_signless_i32_store(
+// CHECK: %[[RELU0:[^ ]+]] = call <64 x i32> @llvm.hivm.vrelu.v64s32.x(<64 x i32> %0, <256 x i1> %[[MASK0:[^ ]+]])
+// CHECK: call void @llvm.hivm.vstsx1.v64s32(<64 x i32> %[[RELU0]], ptr addrspace(6) %1, i32 0, i32 2, i32 0, <256 x i1> %[[MASK0]])
+// CHECK-LABEL: define void @vrelu_signed_i32_store(
+// CHECK: %[[RELU1:[^ ]+]] = call <64 x i32> @llvm.hivm.vrelu.v64s32.x(<64 x i32> %0, <256 x i1> %[[MASK1:[^ ]+]])
+// CHECK: call void @llvm.hivm.vstsx1.v64s32(<64 x i32> %[[RELU1]], ptr addrspace(6) %1, i32 0, i32 2, i32 0, <256 x i1> %[[MASK1]])

--- a/test/basic/vrelu_verify_invalid.pto
+++ b/test/basic/vrelu_verify_invalid.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ! ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// Negative tests for pto.vrelu verifier.
+//
+// CHECK: error: 'pto.vrelu' op requires si32/i32/f16/f32 vector element type
+
+func.func @vrelu_bf16_invalid(%src: !pto.ptr<bf16, ub>, %dst: !pto.ptr<bf16, ub>)
+    attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %c0 = arith.constant 0 : index
+  pto.vecscope {
+    %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %vec = pto.vlds %src[%c0] : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+    %out = pto.vrelu %vec, %mask : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+    pto.vsts %out, %dst[%c0], %mask : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+  }
+  return
+}

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -89,6 +89,8 @@ abs_vec = pto.vabs(vec_f32, mask32)
 
 **Description**: ReLU activation (max(0, x)) of vector elements.
 
+**Supported dtypes**: `si32`, `i32`, `f16`, `f32`
+
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
@@ -3326,7 +3326,7 @@ for (int i = 0; i < N; i++)
 ##### `pto.vrelu`
 
 - **syntax:** `%result = pto.vrelu %input, %mask : !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
-- **A5 types:** f16, f32
+- **A5 types:** si32, i32, f16, f32
 
 ```c
 for (int i = 0; i < N; i++)
@@ -3335,8 +3335,9 @@ for (int i = 0; i < N; i++)
 
 - **inputs:** `%input` is the source vector and `%mask` selects active lanes.
 - **outputs:** `%result` holds `max(input[i], 0)` per active lane.
-- **constraints and limitations:** Only floating-point element types are legal
-  on the current A5 surface described here.
+- **constraints and limitations:** Signed or signless 32-bit integer and
+  floating-point element types are legal on the current A5 surface described
+  here.
 
 ---
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -6033,8 +6033,11 @@ class _SemanticAnalyzer:
     def _validate_unary_dtype(self, name: str, dtype: ScalarType) -> None:
         if name in {"vexp", "vln", "vsqrt", "vrec", "vrsqrt"} and dtype.name not in {"f16", "f32"}:
             raise TypeError(f"pto.{name} only supports f16/f32 in TileLang DSL v1")
-        if name == "vrelu" and dtype.name not in {"f16", "f32"}:
-            raise TypeError("pto.vrelu only supports f16/f32 in TileLang DSL v1")
+        if name == "vrelu" and not (
+            dtype.name in {"f16", "f32"}
+            or (is_integer_dtype(dtype) and integer_bitwidth(dtype) == 32)
+        ):
+            raise TypeError("pto.vrelu only supports i32/f16/f32 in TileLang DSL v1")
         if name in {"vnot", "vbcnt", "vcls", "vsunpack", "vzunpack", "vusqz", "vsqz"} and not (
             is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32}
         ):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2917,6 +2917,39 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertRegex(text, r"%activated_\d+ = pto\.vrelu %summed_\d+, %mask_\d+ : !pto\.vreg<64xf32>, !pto\.mask<b32> -> !pto\.vreg<64xf32>")
         self.assertRegex(text, r"pto\.vsts %activated_\d+, %dst_\d+\[%lane_\d+\], %mask_\d+ : !pto\.vreg<64xf32>, !pto\.ptr<f32, ub>, !pto\.mask<b32>")
 
+    def test_vrelu_accepts_i32_inside_strict_vecscope(self) -> None:
+        @pto.vkernel(op="eltwise", dtypes=[(pto.i32, pto.i32)], advanced=True)
+        def kernel(tile: pto.Tile, bias: pto.i32):
+            with pto.strict_vecscope(tile, tile, bias, 0, 256, 64) as (
+                src,
+                dst,
+                offset,
+                lb,
+                ub,
+                step,
+            ):
+                for lane in range(lb, ub, step):
+                    mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                    vec = pto.vlds(src, lane)
+                    shifted = pto.vadds(vec, offset, mask)
+                    activated = pto.vrelu(shifted, mask)
+                    pto.vsts(activated, dst, lane, mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(16, 16),
+                memory_space=pto.MemorySpace.UB,
+            ),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r'%mask_\d+ = pto\.pset_b32 "PAT_ALL" : !pto\.mask<b32>')
+        self.assertRegex(text, r"%vec_\d+ = pto\.vlds %src_\d+\[%lane_\d+\] : !pto\.ptr<i32, ub> -> !pto\.vreg<64xi32>")
+        self.assertRegex(text, r"%shifted_\d+ = pto\.vadds %vec_\d+, %offset_\d+, %mask_\d+ : !pto\.vreg<64xi32>, i32, !pto\.mask<b32> -> !pto\.vreg<64xi32>")
+        self.assertRegex(text, r"%activated_\d+ = pto\.vrelu %shifted_\d+, %mask_\d+ : !pto\.vreg<64xi32>, !pto\.mask<b32> -> !pto\.vreg<64xi32>")
+        self.assertRegex(text, r"pto\.vsts %activated_\d+, %dst_\d+\[%lane_\d+\], %mask_\d+ : !pto\.vreg<64xi32>, !pto\.ptr<i32, ub>, !pto\.mask<b32>")
+
     def test_tail_make_mask_lowers_to_typed_plt_and_updates_remaining(self) -> None:
         @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.i32)], advanced=True)
         def kernel(tile: pto.Tile, remaining: pto.i32):


### PR DESCRIPTION
## Summary
- align `pto.vrelu` docs to reflect support for both `si32` and `i32` alongside `f16/f32`
- tighten VPTO `pto.vrelu` legality checks so signed/signless 32-bit integer vectors are accepted but unsupported element types are rejected
- add signed/signless i32 VPTO LLVM regression coverage and keep the negative verifier test

## Validation
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto test/basic/vrelu_verify_invalid.pto 2>&1 | FileCheck /home/zhangzhendong/ptoas-workspace/PTOAS/test/basic/vrelu_verify_invalid.pto`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm /home/zhangzhendong/ptoas-workspace/PTOAS/test/basic/issue220_vrelu_i32_vpto_llvm.pto -o - | FileCheck /home/zhangzhendong/ptoas-workspace/PTOAS/test/basic/issue220_vrelu_i32_vpto_llvm.pto`
- `python3 .github/scripts/check_license_headers.py --repo mouliangyu/PTOAS --event-name push --base-sha f2bf1ec22c8cdc2b8c95e50e5b13b797f667678c --head-sha HEAD`

Closes #220
