### PR TITLE
fix(dsl): fix TileLang punpack mask widening

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -87,6 +87,12 @@ static LogicalResult verifyMaskTypeWithGranularityLike(Operation *op, Type type,
   return success();
 }
 
+static bool isMaskGranularityAdjacentWidening(StringRef inputGranularity,
+                                              StringRef resultGranularity) {
+  return (inputGranularity == "b8" && resultGranularity == "b16") ||
+         (inputGranularity == "b16" && resultGranularity == "b32");
+}
+
 static LogicalResult verifyEnclosingLoopLike(Operation *op,
                                              StringRef opNameForDiag) {
   if (!op->getParentOfType<LoopLikeOpInterface>()) {
@@ -2130,6 +2136,15 @@ LogicalResult PunpackOp::verify() {
     return failure();
   if (getPart() != "LOWER")
     return emitOpError("currently supports only LOWER part");
+  auto inputMaskType = cast<MaskType>(getInput().getType());
+  auto resultMaskType = cast<MaskType>(getResult().getType());
+  StringRef inputGranularity = inputMaskType.getGranularity();
+  StringRef resultGranularity = resultMaskType.getGranularity();
+  if (inputGranularity != resultGranularity &&
+      !isMaskGranularityAdjacentWidening(inputGranularity, resultGranularity)) {
+    return emitOpError(
+        "requires result mask granularity to match the input or widen by one step");
+  }
   return success();
 }
 

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -389,6 +389,27 @@ private:
                              << rhsRole << " " << rhsType;
   }
 
+  static bool isAdjacentMaskGranularityWidening(VPTOMaskGranularity input,
+                                                VPTOMaskGranularity result) {
+    return (input == VPTOMaskGranularity::B8 &&
+            result == VPTOMaskGranularity::B16) ||
+           (input == VPTOMaskGranularity::B16 &&
+            result == VPTOMaskGranularity::B32);
+  }
+
+  static LogicalResult validatePunpackMaskGranularity(PunpackOp op) {
+    auto input = VPTOLegalityHelper::getMaskGranularity(op.getInput().getType());
+    auto result = VPTOLegalityHelper::getMaskGranularity(op.getResult().getType());
+    if (!input || !result || *input == *result ||
+        isAdjacentMaskGranularityWidening(*input, *result))
+      return success();
+
+    return op.emitOpError()
+           << "input mask type " << op.getInput().getType()
+           << " does not match result mask type " << op.getResult().getType()
+           << " for pto.punpack";
+  }
+
   template <typename OpTy>
   static LogicalResult validateInputMaskVectorConsumer(OpTy op) {
     return validateMaskMatchesVectorFamily(op, op.getMask().getType(),
@@ -643,8 +664,11 @@ private:
           return validateCompareFamilyContract(concreteOp,
                                                concreteOp.getSrc().getType());
         })
-        .Case<PpackOp, PunpackOp>([](auto concreteOp) {
+        .Case<PpackOp>([](PpackOp concreteOp) {
           return validateMaskOnlyUnaryContract(concreteOp);
+        })
+        .Case<PunpackOp>([](PunpackOp concreteOp) {
+          return validatePunpackMaskGranularity(concreteOp);
         })
         .Case<PnotOp>(
             [](PnotOp concreteOp) { return validateMaskOnlyPnotContract(concreteOp); })

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4851,7 +4851,18 @@ class _SemanticAnalyzer:
             raise TypeError(f"pto.{name} expects exactly 2 positional arguments in TileLang DSL")
         mask = self._require_mask_expr(args[0], f"pto.{name} mask")
         part = self._normalize_predicate_part(args[1], f"pto.{name} part")
-        return SemanticCallExpr(namespace="pto", name=name, args=(args[0], part), type=mask)
+        result_granularity = mask.granularity
+        if name == "punpack":
+            if mask.granularity == "b8":
+                result_granularity = "b16"
+            elif mask.granularity == "b16":
+                result_granularity = "b32"
+        return SemanticCallExpr(
+            namespace="pto",
+            name=name,
+            args=(args[0], part),
+            type=SemanticMaskType(granularity=result_granularity),
+        )
 
     def _analyze_mask_logic_op(
         self,

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -6183,6 +6183,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
                     result = pto.vselr(converted, v_idx_ui8)
                     pto.mem_bar(pto.BarrierType.VST_VST)
                     pto.vsts(result, dst[row, col:], store_mask, dist="NORM_B8")
+
             return None
 
         specialized = kernel.specialize(
@@ -6200,6 +6201,42 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn('pto.mem_bar "VST_VST"', text)
         self.assertIn("pto.vselr", text)
         self.assertIn("pto.vsts", text)
+
+    def test_punpack_widens_b16_mask_for_norm_b32_store_in_advanced_mode(self) -> None:
+        @pto.vkernel(op="punpack_widen_b16_to_b32_unique", dtypes=[(pto.si8, pto.i32)], advanced=True)
+        def kernel(src: pto.Tile, dst: pto.Tile):
+            valid_rows, valid_cols = dst.valid_shape
+            lanes_i32 = pto.get_lanes(pto.i32)
+            for row in range(0, valid_rows, 1):
+                b8_mask = pto.make_mask(pto.i8, pto.PAT.ALL)
+                mask_b16, _ = pto.make_mask(pto.i16, valid_cols)
+                mask_b32 = pto.punpack(mask_b16, pto.PredicatePart.LOWER)
+                vec_si8 = pto.vlds(src[row, 0:], dist="UNPK_B8")
+                vec_ui8 = pto.vbitcast(vec_si8, pto.ui8)
+                v_zero_i8 = pto.vdup(pto.i8(0), b8_mask)
+                v_zero = pto.vbitcast(v_zero_i8, pto.ui8)
+                wide_lo, _ = pto.vintlv(vec_ui8, v_zero)
+                narrowed = pto.vbitcast(wide_lo, pto.si8)
+                converted = pto.vcvt(narrowed, pto.i32, b8_mask, part=pto.VcvtPartMode.P0)
+                pto.vsts(converted, dst[row, 0:], mask_b32, dist="NORM_B32")
+                pto.vsts(converted, dst[row, lanes_i32:], mask_b32, dist="NORM_B32")
+            return None
+
+        specialized = kernel.specialize(
+            src=pto.TileSpecialization(shape=(16, 64), memory_space=pto.MemorySpace.UB),
+            dst=pto.TileSpecialization(shape=(16, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertIn(' = pto.punpack ', text)
+        self.assertRegex(
+            text,
+            r"pto\.punpack %mask_b16_\d+, \"LOWER\" : !pto\.mask<b16> -> !pto\.mask<b32>",
+        )
+        self.assertRegex(
+            text,
+            r"pto\.vsts %converted_\d+, %tmp_\d+\[%c0\], %mask_b32_\d+ \{dist = \"NORM_B32\"\} : !pto\.vreg<64xi32>, memref<\?x\?xi32, strided<\[\?, \?\], offset: \?>, #pto\.address_space<vec>>, !pto\.mask<b32>",
+        )
 
     def test_elementwise_kernel_positive_regression_covers_vecscope_tail_mask_and_dynamic_loop_bound(self) -> None:
         @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.f32, pto.i32)], advanced=True)


### PR DESCRIPTION
## Summary
- fix TileLang DSL `pto.punpack` mask result typing so `b16` inputs widen to `b32`
- allow the widened `pto.punpack` mask contract in VPTO verifier and shared legality validation
- add a TileLang DSL regression test covering `punpack` feeding a `NORM_B32` store

## Validation
- `python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_punpack_widens_b16_mask_for_norm_b32_store_in_advanced_mode`

Closes #225