### PR TITLE
Fix issue 211 and 228 regressions in PTO verifier/tests

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -10717,7 +10717,11 @@ void TRowMaxOp::getEffects(
 void TRowArgMaxOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  // A5 lowering does not consume tmp for TROWARGMAX; modeling tmp as a
+  // scratch write inflates local-memory planning and can trigger false
+  // vec-overflow diagnostics, mirroring the fixed A5 TPRELU issue.
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 
@@ -10731,7 +10735,11 @@ void TRowMinOp::getEffects(
 void TRowArgMinOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  // A5 lowering does not consume tmp for TROWARGMIN; modeling tmp as a
+  // scratch write inflates local-memory planning and can trigger false
+  // vec-overflow diagnostics, mirroring the fixed A5 TPRELU issue.
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2514,7 +2514,6 @@ static LogicalResult verifyVecTileStorage(Operation *op, Type ty, StringRef name
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
   return success();
 }
-
 static LogicalResult verifyVecTileCommonA2A3(Operation *op, Type ty,
                                              StringRef name) {
   if (failed(verifyTileBufCommon(op, ty, name)))
@@ -3534,9 +3533,11 @@ LogicalResult pto::TColArgMaxOp::verify() {
                                              /*requireNonZeroSrc=*/true)))
       return failure();
 
-    auto srcElem = getElemTy(srcTy).dyn_cast<mlir::FloatType>();
-    if (!srcElem || (!srcElem.isF16() && !srcElem.isF32()))
-      return emitOpError("expects src element type to be f16 or f32");
+    Type srcElemTy = getElemTy(srcTy);
+    unsigned srcElemBits = srcElemTy ? srcElemTy.getIntOrFloatBitWidth() : 0;
+    if (!(srcElemTy.isa<IntegerType, FloatType>() &&
+          (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+      return emitOpError("expects src/tmp element type to be 1, 2, or 4 bytes wide");
 
     auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
     if (!dstInt || dstInt.getWidth() != 32 ||
@@ -3601,9 +3602,11 @@ LogicalResult pto::TColArgMinOp::verify() {
                                              /*requireNonZeroSrc=*/true)))
       return failure();
 
-    auto srcElem = getElemTy(srcTy).dyn_cast<mlir::FloatType>();
-    if (!srcElem || (!srcElem.isF16() && !srcElem.isF32()))
-      return emitOpError("expects src element type to be f16 or f32");
+    Type srcElemTy = getElemTy(srcTy);
+    unsigned srcElemBits = srcElemTy ? srcElemTy.getIntOrFloatBitWidth() : 0;
+    if (!(srcElemTy.isa<IntegerType, FloatType>() &&
+          (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+      return emitOpError("expects src/tmp element type to be 1, 2, or 4 bytes wide");
 
     auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
     if (!dstInt || dstInt.getWidth() != 32 ||

--- a/test/basic/issue554_tcolarg_invalid_width.pto
+++ b/test/basic/issue554_tcolarg_invalid_width.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @issue554_tcolargmax_i64_rejected() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tcolargmax' op expects src/tmp element type to be 1, 2, or 4 bytes wide

--- a/test/basic/issue554_tcolarg_types.pto
+++ b/test/basic/issue554_tcolarg_types.pto
@@ -1,0 +1,24 @@
+// RUN: ptoas --pto-arch=a3 %s >/dev/null
+// RUN: ptoas --pto-arch=a5 %s >/dev/null
+
+module {
+  func.func @issue554_tcolargmax_ui16() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue554_tcolargmin_ui32() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/basic/issue558_trowargmax_vec_overflow_a5.pto
+++ b/test/basic/issue558_trowargmax_vec_overflow_a5.pto
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+// Regression for issue #558:
+// A5 TROWARGMAX should not treat tmp as a required scratch write in local
+// memory planning, otherwise this shape triggers a false vec overflow.
+// CHECK-NOT: vec overflow
+// CHECK: __global__ AICORE void TROWARGMAX_TMP_OVERFLOW(
+
+module {
+  func.func @TROWARGMAX_TMP_OVERFLOW(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2_r = arith.constant 2 : index
+    %c16384_c = arith.constant 16384 : index
+    %c32768_se = arith.constant 32768 : index
+    %c2_de = arith.constant 2 : index
+    %c1_dc = arith.constant 1 : index
+    %c2_vr = arith.constant 2 : index
+    %c16381_vc = arith.constant 16381 : index
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c2_r, %c16384_c],
+      strides = [%c32768_se, %c32768_se, %c32768_se, %c16384_c, %c1]
+      : !pto.tensor_view<1x1x1x2x16384xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c2_r, %c1_dc],
+      strides = [%c2_de, %c2_de, %c2_de, %c1_dc, %c1]
+      : !pto.tensor_view<1x1x1x2x1xui32>
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c2_vr, %c16381_vc]
+      : !pto.tensor_view<1x1x1x2x16384xf32> -> !pto.partition_tensor_view<1x1x1x2x16381xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c2_vr, %c1]
+      : !pto.tensor_view<1x1x1x2x1xui32> -> !pto.partition_tensor_view<1x1x1x2x1xui32>
+    %src = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x16381xf32>)
+              outs(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                                !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                                     blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x2x1xui32>)
+    return
+  }
+}

--- a/test/basic/issue558_trowargmin_vec_overflow_a5.pto
+++ b/test/basic/issue558_trowargmin_vec_overflow_a5.pto
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+// Regression for issue #558:
+// A5 TROWARGMIN should not treat tmp as a required scratch write in local
+// memory planning, otherwise this shape triggers a false vec overflow.
+// CHECK-NOT: vec overflow
+// CHECK: __global__ AICORE void TROWARGMIN_TMP_OVERFLOW(
+
+module {
+  func.func @TROWARGMIN_TMP_OVERFLOW(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2_r = arith.constant 2 : index
+    %c16384_c = arith.constant 16384 : index
+    %c32768_se = arith.constant 32768 : index
+    %c2_de = arith.constant 2 : index
+    %c1_dc = arith.constant 1 : index
+    %c2_vr = arith.constant 2 : index
+    %c16381_vc = arith.constant 16381 : index
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c2_r, %c16384_c],
+      strides = [%c32768_se, %c32768_se, %c32768_se, %c16384_c, %c1]
+      : !pto.tensor_view<1x1x1x2x16384xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c2_r, %c1_dc],
+      strides = [%c2_de, %c2_de, %c2_de, %c1_dc, %c1]
+      : !pto.tensor_view<1x1x1x2x1xui32>
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c2_vr, %c16381_vc]
+      : !pto.tensor_view<1x1x1x2x16384xf32> -> !pto.partition_tensor_view<1x1x1x2x16381xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c2_vr, %c1]
+      : !pto.tensor_view<1x1x1x2x1xui32> -> !pto.partition_tensor_view<1x1x1x2x1xui32>
+    %src = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x16381xf32>)
+              outs(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                                !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
+                                            blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                                     blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x2x1xui32>)
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- avoid false A5 `trowargmax`/`trowargmin` vec overflow caused by treating `tmp` as a required scratch write during local memory planning
- relax `tcolargmax`/`tcolargmin` verifier element-width checks to accept 1/2/4-byte integer or float element types
- add regression tests for both behaviors under `test/basic`

## Validation
- `ninja -C build ptoas`
- `build/tools/ptoas/ptoas --pto-arch=a3 test/basic/issue554_tcolarg_invalid_width.pto 2>&1 | FileCheck test/basic/issue554_tcolarg_invalid_width.pto`
- `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/issue554_tcolarg_invalid_width.pto 2>&1 | FileCheck test/basic/issue554_tcolarg_invalid_width.pto`
- `build/tools/ptoas/ptoas --pto-arch=a3 test/basic/issue554_tcolarg_types.pto >/dev/null`
- `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/issue554_tcolarg_types.pto >/dev/null`

Close #211
Close #228
