### PR TITLE
fix(dsl): forward trandom rounds in tile expansion

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -247,6 +247,10 @@ static std::optional<std::string> getTCvtRoundModeString(pto::TCvtOp op) {
   return std::nullopt;
 }
 
+static std::string getTRandomRoundsString(pto::TRandomOp op) {
+  return std::to_string(op.getRounds());
+}
+
 static void appendOpContextAttrs(
     Operation *op,
     SmallVectorImpl<std::pair<std::string, std::string>> &attrs) {
@@ -255,6 +259,8 @@ static void appendOpContextAttrs(
     if (roundMode)
       attrs.emplace_back("round_mode", *roundMode);
   }
+  if (auto trandom = dyn_cast<pto::TRandomOp>(op))
+    attrs.emplace_back("rounds", getTRandomRoundsString(trandom));
   if (auto tcmp = dyn_cast<pto::TCmpOp>(op)) {
     if (auto cmpModeAttr = tcmp.getCmpModeAttr()) {
       attrs.emplace_back("cmp_mode",


### PR DESCRIPTION
## Summary
- forward `pto.trandom` `rounds` into ExpandTileOp context attrs
- make trandom TileLang specialization keys distinguish rounds `7` vs `10`
- add an ExpandTileOp regression test with a self-contained minimal TileLang template

## Validation
- `FileCheck test/basic/expand_tile_op_tilelang_trandom.pto < build/issue245_test.log`
- `../llvm-project/build-shared/bin/llvm-lit -sv test/basic/expand_tile_op_tilelang_trandom.pto test/basic/expand_tile_op_tilelang_tcvt.pto`

Closes #245