### PR TITLE
fix(dsl): allow mixed index and integer scalar binary ops

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2552,6 +2552,9 @@ class _AuthoringRenderer:
                     desired_name=desired_name,
                     into=into,
                 )
+            if isinstance(expr.type, SemanticScalarType):
+                lhs = self._coerce_rendered_value(lhs, expr.type, indent=indent, into=into)
+                rhs = self._coerce_rendered_value(rhs, expr.type, indent=indent, into=into)
             result_name = desired_name or self._new_temp()
             into.append(
                 self._indent(indent)
@@ -3194,7 +3197,23 @@ class _AuthoringRenderer:
                 "le": "sle",
             }
             predicate = index_predicates[op]
-        elif isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
+            cmp_name = "arith.cmpi"
+        elif (
+            isinstance(lhs.type, SemanticIndexType)
+            and isinstance(rhs.type, SemanticScalarType)
+            and is_integer_dtype(rhs.type.dtype)
+            and integer_bitwidth(rhs.type.dtype) in {32, 64}
+        ):
+            lhs = self._coerce_rendered_value(lhs, rhs.type, indent=indent, into=into)
+        elif (
+            isinstance(rhs.type, SemanticIndexType)
+            and isinstance(lhs.type, SemanticScalarType)
+            and is_integer_dtype(lhs.type.dtype)
+            and integer_bitwidth(lhs.type.dtype) in {32, 64}
+        ):
+            rhs = self._coerce_rendered_value(rhs, lhs.type, indent=indent, into=into)
+
+        if isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
             if lhs.type.dtype.name in {"f16", "bf16", "f32"}:
                 float_predicates = {
                     "eq": "oeq",
@@ -3207,13 +3226,14 @@ class _AuthoringRenderer:
                 predicate = float_predicates[op]
                 cmp_name = "arith.cmpf"
             else:
+                int_sign = integer_signedness(lhs.type.dtype)
                 int_predicates = {
                     "eq": "eq",
                     "ne": "ne",
-                    "gt": "sgt",
-                    "lt": "slt",
-                    "ge": "sge",
-                    "le": "sle",
+                    "gt": "ugt" if int_sign == "unsigned" else "sgt",
+                    "lt": "ult" if int_sign == "unsigned" else "slt",
+                    "ge": "uge" if int_sign == "unsigned" else "sge",
+                    "le": "ule" if int_sign == "unsigned" else "sle",
                 }
                 predicate = int_predicates[op]
                 cmp_name = "arith.cmpi"
@@ -3223,16 +3243,17 @@ class _AuthoringRenderer:
                 f"{self._render_type(lhs.type)}"
             )
             return _RenderedValue(name=result_name, type=_I1_TYPE)
-        else:
-            raise NotImplementedError(
-                f"comparison lowering requires matching scalar types or index operands, got {lhs.type!r} and {rhs.type!r}"
-            )
 
-        into.append(
-            self._indent(indent)
-            + f"{result_name} = arith.cmpi {predicate}, {lhs.name}, {rhs.name} : {self._render_type(lhs.type)}"
+        if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
+            into.append(
+                self._indent(indent)
+                + f"{result_name} = {cmp_name} {predicate}, {lhs.name}, {rhs.name} : {self._render_type(lhs.type)}"
+            )
+            return _RenderedValue(name=result_name, type=_I1_TYPE)
+
+        raise NotImplementedError(
+            f"comparison lowering requires matching scalar types or index operands, got {lhs.type!r} and {rhs.type!r}"
         )
-        return _RenderedValue(name=result_name, type=_I1_TYPE)
 
     def _lower_bool_expr(
         self,

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3957,6 +3957,7 @@ class _SemanticAnalyzer:
         rhs: SemanticExpr,
         op: str,
     ) -> SemanticType:
+        mixed_index_scalar_type = self._mixed_index_integer_scalar_type(lhs.type, rhs.type)
         if op in {"add", "sub", "mul", "mod", "floordiv", "bitand", "bitor", "bitxor", "lshift", "rshift"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 if op in {"add", "sub", "mul", "mod", "floordiv"}:
@@ -3969,36 +3970,61 @@ class _SemanticAnalyzer:
                     return SemanticScalarType(dtype=dtype)
                 if op in {"bitand", "bitor", "bitxor", "lshift", "rshift"} and is_integer_dtype(dtype):
                     return SemanticScalarType(dtype=dtype)
+            if mixed_index_scalar_type is not None and op in {"add", "sub", "mul", "mod", "floordiv"}:
+                return mixed_index_scalar_type
             raise TypeError(
                 "binary expressions currently require matching index operands, "
-                "or matching scalar operands (add/sub/mul for integer/float; "
-                "mod/floordiv/bitwise/shift for integer)"
+                "matching scalar operands (add/sub/mul for integer/float; "
+                "mod/floordiv/bitwise/shift for integer), or index operands "
+                "mixed with 32/64-bit integer scalars for add/sub/mul/mod/floordiv"
             )
         if op in {"eq", "ne"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
                 return SemanticScalarType(dtype=i1)
+            if mixed_index_scalar_type is not None:
+                return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticPadValueType) and isinstance(rhs.type, SemanticPadValueType):
                 return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticMetaType) and lhs.type == rhs.type:
                 return SemanticScalarType(dtype=i1)
             raise TypeError(
-                "comparison expressions currently require matching scalar/meta types or index-typed operands"
+                "comparison expressions currently require matching scalar/meta types, "
+                "index-typed operands, or index operands mixed with 32/64-bit integer scalars"
             )
         if op in {"gt", "lt", "ge", "le"}:
             if isinstance(lhs.type, SemanticIndexType) and isinstance(rhs.type, SemanticIndexType):
                 return SemanticScalarType(dtype=i1)
             if isinstance(lhs.type, SemanticScalarType) and lhs.type == rhs.type:
                 return SemanticScalarType(dtype=i1)
+            if mixed_index_scalar_type is not None:
+                return SemanticScalarType(dtype=i1)
             raise TypeError(
-                "ordered comparison expressions currently require matching scalar types or index-typed operands"
+                "ordered comparison expressions currently require matching scalar types, "
+                "index-typed operands, or index operands mixed with 32/64-bit integer scalars"
             )
         if op in {"and", "or"}:
             self._require_condition_type(lhs.type)
             self._require_condition_type(rhs.type)
             return SemanticScalarType(dtype=i1)
         raise TypeError(f"unsupported binary operator '{op}' in TileLang DSL v1")
+
+    def _mixed_index_integer_scalar_type(
+        self,
+        lhs_type: SemanticType,
+        rhs_type: SemanticType,
+    ) -> SemanticScalarType | None:
+        scalar_type: SemanticScalarType | None = None
+        if isinstance(lhs_type, SemanticIndexType) and isinstance(rhs_type, SemanticScalarType):
+            scalar_type = rhs_type
+        elif isinstance(rhs_type, SemanticIndexType) and isinstance(lhs_type, SemanticScalarType):
+            scalar_type = lhs_type
+        if scalar_type is None or not is_integer_dtype(scalar_type.dtype):
+            return None
+        if integer_bitwidth(scalar_type.dtype) not in {32, 64}:
+            return None
+        return scalar_type
 
     def _analyze_call_expr(
         self,

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3195,6 +3195,68 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertRegex(text, r"= arith\.mulf %tmp_\d+, %c0_5_f32 : f32")
         self.assertRegex(text, r"= arith\.addf %tmp_\d+, %tmp_\d+ : f32")
 
+    def test_index_and_i32_scalar_binary_ops_bridge_index_literals(self) -> None:
+        @pto.vkernel(
+            op="index_i32_scalar_binary_bridge_unique",
+            dtypes=[(pto.f32, pto.AnyType, pto.f32)],
+            advanced=True,
+        )
+        def kernel(src: pto.Tile, gate: pto.AnyType, dst: pto.Tile):
+            rows = src.shape[0]
+            cols = src.shape[1]
+            with pto.strict_vecscope(
+                src,
+                dst,
+                gate,
+                rows,
+                cols,
+                0,
+                rows,
+                1,
+            ) as (src_tile, dst_tile, in_gate, valid_rows, valid_cols, row_lb, row_ub, row_step):
+                for row in range(row_lb, row_ub, row_step):
+                    if in_gate > 1:
+                        for lane in range(0, valid_cols, 64):
+                            lane_limit = in_gate + 1
+                            mask, _ = pto.make_mask(pto.f32, lane_limit)
+                            vec = pto.vlds(src_tile, lane)
+                            pto.vsts(vec, dst_tile, lane, mask)
+            return None
+
+        selected = pto.select_kernel(
+            "a5",
+            "index_i32_scalar_binary_bridge_unique",
+            (pto.f32, pto.i32, pto.f32),
+        )
+        specialized = selected.specialize(
+            src=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+            dst=pto.TileSpecialization(shape=(8, 64), memory_space=pto.MemorySpace.UB),
+        )
+
+        text = specialized.mlir_text()
+        self.assertRegex(text, r"%tmp_\d+ = arith\.index_cast %c1 : index to i32")
+        self.assertRegex(text, r"%tmp_\d+ = arith\.cmpi sgt, %in_gate_\d+, %tmp_\d+ : i32")
+        self.assertRegex(text, r"%\w+_\d+ = arith\.addi %in_gate_\d+, %tmp_\d+ : i32")
+
+    def test_index_and_narrow_or_float_scalar_binary_ops_still_reject(self) -> None:
+        @pto.vkernel(op="index_i16_scalar_binary_reject_unique", dtypes=[(pto.i16,)], advanced=True)
+        def i16_kernel(gate: pto.i16):
+            _ = gate + 1
+            return None
+
+        @pto.vkernel(op="index_f32_scalar_binary_reject_unique", dtypes=[(pto.f32,)], advanced=True)
+        def f32_kernel(gate: pto.f32):
+            _ = gate + 1
+            return None
+
+        with self.assertRaises(TypeError) as i16_ctx:
+            i16_kernel.specialize().mlir_text()
+        self.assertIn("32/64-bit integer scalars", str(i16_ctx.exception))
+
+        with self.assertRaises(TypeError) as f32_ctx:
+            f32_kernel.specialize().mlir_text()
+        self.assertIn("32/64-bit integer scalars", str(f32_ctx.exception))
+
     def test_index_floordiv_lowers_to_divui_instead_of_floordivsi(self) -> None:
         @pto.vkernel(
             op="index_floordiv_lowering_unique",


### PR DESCRIPTION
## Summary
- allow TileLang DSL binary arithmetic and comparisons to bridge between index literals and 32/64-bit integer scalar operands
- lower mixed index/integer scalar expressions through explicit casts before emitting scalar arith/cmp ops
- add regression tests and keep a minimal issue #246 repro script under lib/TileOps

## Repro
- issue: #246
- repro cmd: `PYTHONPATH=tilelang-dsl/python python3 lib/TileOps/issue_246_repro.py`

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_index_and_i32_scalar_binary_ops_bridge_index_literals`
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_index_and_narrow_or_float_scalar_binary_ops_still_reject`
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_scalar_binary_arithmetic_supports_float_and_integer_paths`
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_index_floordiv_lowers_to_divui_instead_of_floordivsi`
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLDescriptorTests.test_scalar_bitwise_and_shift_ops_lower_for_signed_and_unsigned`
- `PYTHONPATH=tilelang-dsl/python python3 lib/TileOps/issue_246_repro.py`

Closes #246