### PR TITLE
fix(dsl): allow integer vdiv vector types

### DIFF
--- a/lib/TileOps/math.py
+++ b/lib/TileOps/math.py
@@ -10,7 +10,55 @@ import tilelang_dsl as pto
 
 
 @pto.inline_proc
-def _vdiv_u16(vec, scalar_vec, mask):
+def _tl_soft_vdiv_u8(vec, scalar_vec, mask):
+    zero = pto.ui8(0)
+    zero_q = pto.ui8(0xFF)
+    full_mask_b8 = pto.pset_b8(pto.PAT.ALL)
+
+    zero_mask = pto.vcmps(scalar_vec, zero, mask, pto.CmpMode.EQ)
+    active_mask = pto.pnot(zero_mask, mask)
+    active_low = pto.punpack(active_mask, pto.PredicatePart.LOWER)
+    active_high = pto.punpack(active_mask, pto.PredicatePart.HIGHER)
+
+    vec_low = pto.vzunpack(vec, 0)
+    vec_high = pto.vzunpack(vec, 1)
+    scalar_low = pto.vzunpack(scalar_vec, 0)
+    scalar_high = pto.vzunpack(scalar_vec, 1)
+
+    q_low = _tl_soft_vdiv_u16(vec_low, scalar_low, active_low)
+    q_high = _tl_soft_vdiv_u16(vec_high, scalar_high, active_high)
+    packed_low = pto.vpack(q_low, pto.PredicatePart.LOWER)
+    packed_high = pto.vpack(q_high, pto.PredicatePart.HIGHER)
+    q = pto.vor(packed_low, packed_high, full_mask_b8)
+    return pto.vsel(pto.vbr(zero_q), q, zero_mask)
+
+
+@pto.inline_proc
+def _tl_soft_vdiv_i8(vec, scalar_vec, mask):
+    zero = pto.i8(0)
+    neg_one = pto.i8(-1)
+    full_mask_b8 = pto.pset_b8(pto.PAT.ALL)
+
+    zero_mask = pto.vcmps(scalar_vec, zero, mask, pto.CmpMode.EQ)
+    active_mask = pto.pnot(zero_mask, mask)
+    active_low = pto.punpack(active_mask, pto.PredicatePart.LOWER)
+    active_high = pto.punpack(active_mask, pto.PredicatePart.HIGHER)
+
+    vec_low = pto.vsunpack(vec, 0)
+    vec_high = pto.vsunpack(vec, 1)
+    scalar_low = pto.vsunpack(scalar_vec, 0)
+    scalar_high = pto.vsunpack(scalar_vec, 1)
+
+    q_low = _tl_soft_vdiv_i16(vec_low, scalar_low, active_low)
+    q_high = _tl_soft_vdiv_i16(vec_high, scalar_high, active_high)
+    packed_low = pto.vpack(q_low, pto.PredicatePart.LOWER)
+    packed_high = pto.vpack(q_high, pto.PredicatePart.HIGHER)
+    q = pto.vbitcast(pto.vor(packed_low, packed_high, full_mask_b8), pto.i8)
+    return pto.vsel(pto.vbr(neg_one), q, zero_mask)
+
+
+@pto.inline_proc
+def _tl_soft_vdiv_u16(vec, scalar_vec, mask):
     zero = pto.ui16(0)
     one = pto.ui16(1)
     fp32_one = pto.f32(1.0)
@@ -75,12 +123,7 @@ def _vdiv_u16(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vdiv_u16(vec, scalar_vec, mask):
-    return _vdiv_u16(vec, scalar_vec, mask)
-
-
-@pto.inline_proc
-def vdiv_i16(vec, scalar_vec, mask):
+def _tl_soft_vdiv_i16(vec, scalar_vec, mask):
     zero = pto.i16(0)
     neg_one = pto.i16(-1)
 
@@ -92,14 +135,62 @@ def vdiv_i16(vec, scalar_vec, mask):
     x_xor_y = pto.vxor(vec, scalar_vec, active_mask)
     p_pos = pto.vcmps(x_xor_y, zero, active_mask, pto.CmpMode.GE)
 
-    q_abs = _vdiv_u16(abs_x, abs_y, active_mask)
+    q_abs = _tl_soft_vdiv_u16(abs_x, abs_y, active_mask)
     neg_q = pto.vneg(pto.vbitcast(q_abs, pto.i16), active_mask)
     q = pto.vsel(pto.vbitcast(q_abs, pto.i16), neg_q, p_pos)
     return pto.vsel(pto.vbr(neg_one), q, zero_mask)
 
 
 @pto.inline_proc
-def vmod_u16(vec, scalar_vec, mask):
+def _tl_soft_vmod_u8(vec, scalar_vec, mask):
+    zero = pto.ui8(0)
+    zero_r = pto.ui8(0xFF)
+    full_mask_b8 = pto.pset_b8(pto.PAT.ALL)
+
+    zero_mask = pto.vcmps(scalar_vec, zero, mask, pto.CmpMode.EQ)
+    active_mask = pto.pnot(zero_mask, mask)
+    active_low = pto.punpack(active_mask, pto.PredicatePart.LOWER)
+    active_high = pto.punpack(active_mask, pto.PredicatePart.HIGHER)
+
+    vec_low = pto.vzunpack(vec, 0)
+    vec_high = pto.vzunpack(vec, 1)
+    scalar_low = pto.vzunpack(scalar_vec, 0)
+    scalar_high = pto.vzunpack(scalar_vec, 1)
+
+    r_low = _tl_soft_vmod_u16(vec_low, scalar_low, active_low)
+    r_high = _tl_soft_vmod_u16(vec_high, scalar_high, active_high)
+    packed_low = pto.vpack(r_low, pto.PredicatePart.LOWER)
+    packed_high = pto.vpack(r_high, pto.PredicatePart.HIGHER)
+    r = pto.vor(packed_low, packed_high, full_mask_b8)
+    return pto.vsel(pto.vbr(zero_r), r, zero_mask)
+
+
+@pto.inline_proc
+def _tl_soft_vmod_i8(vec, scalar_vec, mask):
+    zero = pto.i8(0)
+    neg_one = pto.i8(-1)
+    full_mask_b8 = pto.pset_b8(pto.PAT.ALL)
+
+    zero_mask = pto.vcmps(scalar_vec, zero, mask, pto.CmpMode.EQ)
+    active_mask = pto.pnot(zero_mask, mask)
+    active_low = pto.punpack(active_mask, pto.PredicatePart.LOWER)
+    active_high = pto.punpack(active_mask, pto.PredicatePart.HIGHER)
+
+    vec_low = pto.vsunpack(vec, 0)
+    vec_high = pto.vsunpack(vec, 1)
+    scalar_low = pto.vsunpack(scalar_vec, 0)
+    scalar_high = pto.vsunpack(scalar_vec, 1)
+
+    r_low = _tl_soft_vmod_i16(vec_low, scalar_low, active_low)
+    r_high = _tl_soft_vmod_i16(vec_high, scalar_high, active_high)
+    packed_low = pto.vpack(r_low, pto.PredicatePart.LOWER)
+    packed_high = pto.vpack(r_high, pto.PredicatePart.HIGHER)
+    r = pto.vbitcast(pto.vor(packed_low, packed_high, full_mask_b8), pto.i8)
+    return pto.vsel(pto.vbr(neg_one), r, zero_mask)
+
+
+@pto.inline_proc
+def _tl_soft_vmod_u16(vec, scalar_vec, mask):
     zero = pto.ui16(0)
     one = pto.ui16(1)
     zero_r = pto.ui16(0xFFFF)
@@ -164,7 +255,7 @@ def vmod_u16(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vdiv_u32(vec, scalar_vec, mask):
+def _tl_soft_vdiv_u32(vec, scalar_vec, mask):
     zero = pto.ui32(0)
     one = pto.ui32(1)
     zero_q = pto.ui32(0xFFFFFFFF)
@@ -225,7 +316,7 @@ def vdiv_u32(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vmod_i16(vec, scalar_vec, mask):
+def _tl_soft_vmod_i16(vec, scalar_vec, mask):
     zero = pto.i16(0)
     neg_one = pto.i16(-1)
 
@@ -237,7 +328,7 @@ def vmod_i16(vec, scalar_vec, mask):
     x_xor_y = pto.vxor(vec, scalar_vec, active_mask)
     p_pos = pto.vcmps(x_xor_y, zero, active_mask, pto.CmpMode.GE)
 
-    q_abs = _vdiv_u16(abs_x, abs_y, active_mask)
+    q_abs = _tl_soft_vdiv_u16(abs_x, abs_y, active_mask)
     neg_q = pto.vneg(pto.vbitcast(q_abs, pto.i16), active_mask)
     q = pto.vsel(pto.vbitcast(q_abs, pto.i16), neg_q, p_pos)
 
@@ -255,7 +346,7 @@ def vmod_i16(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vdiv_i32(vec, scalar_vec, mask):
+def _tl_soft_vdiv_i32(vec, scalar_vec, mask):
     zero = pto.i32(0)
     neg_one = pto.i32(-1)
     fp32_one = pto.f32(1.0)
@@ -322,7 +413,7 @@ def vdiv_i32(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vmod_u32(vec, scalar_vec, mask):
+def _tl_soft_vmod_u32(vec, scalar_vec, mask):
     zero = pto.ui32(0)
     one = pto.ui32(1)
     zero_r = pto.ui32(0xFFFFFFFF)
@@ -383,7 +474,7 @@ def vmod_u32(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vmod_i32(vec, scalar_vec, mask):
+def _tl_soft_vmod_i32(vec, scalar_vec, mask):
     zero = pto.i32(0)
     neg_one = pto.i32(-1)
     fp32_one = pto.f32(1.0)
@@ -460,26 +551,34 @@ def vmod_i32(vec, scalar_vec, mask):
 
 
 @pto.inline_proc
-def vmod(vec, scalar_vec, mask, dtype):
-    if pto.constexpr(dtype == pto.ui16):
-        result = vmod_u16(vec, scalar_vec, mask)
+def _tl_soft_vmod(vec, scalar_vec, mask, dtype):
+    if pto.constexpr(dtype == pto.ui8):
+        result = _tl_soft_vmod_u8(vec, scalar_vec, mask)
+    elif pto.constexpr(dtype == pto.i8):
+        result = _tl_soft_vmod_i8(vec, scalar_vec, mask)
+    elif pto.constexpr(dtype == pto.ui16):
+        result = _tl_soft_vmod_u16(vec, scalar_vec, mask)
     elif pto.constexpr(dtype == pto.i16):
-        result = vmod_i16(vec, scalar_vec, mask)
+        result = _tl_soft_vmod_i16(vec, scalar_vec, mask)
     elif pto.constexpr(dtype == pto.ui32):
-        result = vmod_u32(vec, scalar_vec, mask)
+        result = _tl_soft_vmod_u32(vec, scalar_vec, mask)
     else:
-        result = vmod_i32(vec, scalar_vec, mask)
+        result = _tl_soft_vmod_i32(vec, scalar_vec, mask)
     return result
 
 
 @pto.inline_proc
-def vdiv(vec, scalar_vec, mask, dtype):
-    if pto.constexpr(dtype == pto.ui16):
-        result = vdiv_u16(vec, scalar_vec, mask)
+def _tl_soft_vdiv(vec, scalar_vec, mask, dtype):
+    if pto.constexpr(dtype == pto.ui8):
+        result = _tl_soft_vdiv_u8(vec, scalar_vec, mask)
+    elif pto.constexpr(dtype == pto.i8):
+        result = _tl_soft_vdiv_i8(vec, scalar_vec, mask)
+    elif pto.constexpr(dtype == pto.ui16):
+        result = _tl_soft_vdiv_u16(vec, scalar_vec, mask)
     elif pto.constexpr(dtype == pto.i16):
-        result = vdiv_i16(vec, scalar_vec, mask)
+        result = _tl_soft_vdiv_i16(vec, scalar_vec, mask)
     elif pto.constexpr(dtype == pto.ui32):
-        result = vdiv_u32(vec, scalar_vec, mask)
+        result = _tl_soft_vdiv_u32(vec, scalar_vec, mask)
     else:
-        result = vdiv_i32(vec, scalar_vec, mask)
+        result = _tl_soft_vdiv_i32(vec, scalar_vec, mask)
     return result

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/.openspec.yaml
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/design.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/design.md
@@ -1,0 +1,139 @@
+## Context
+
+### 范围
+
+本 design 只覆盖 TileLang DSL 中与 `pto.vdiv` / `pto.vmod` 直接相关的 public surface、frontend diagnostics 与 lowering contract：
+
+- `pto.vdiv`
+- `pto.vmod`
+- internal soft helper 注入与调用建模
+- integer `i8/i16/i32` soft div/mod 路径
+- `f16/f32` `vdiv` 的 VPTO authoring path
+
+它不覆盖：
+
+- `bf16` div/mod 支持
+- floating-point `vmod` / `fmod` 语义扩展
+- 新的 backend inline 机制设计
+- 非 vector `tdiv*` / `trem*` / `tfmod*` tile op 的独立语义重构
+
+### 当前状态
+
+当前仓库中已经有以下事实：
+
+1. `pto.vdiv` 已是 TileLang DSL public surface，但 lowering 仍按统一 `pto.vdiv` 语义继续往下走，没有在 spec 层冻结 dtype-directed 分流。
+2. `lib/TileOps/math.py` 已有整数 `vdiv` / `vmod` soft helper，但它们仍以 helper 形式存在，容易泄漏成用户可见实现细节。
+3. `vmod` 还没有完整的 `pto.vmod` public surface / semantic / lowering 链路。
+4. `i8` 虽然已被纳入 `pto.vdiv` public support matrix，但当前 soft helper 的正式 contract 还没有覆盖 `i8/u8` widen / narrow profile。
+5. 仓库已经具备 `inline_proc` backend-inline 主线，因此“frontend 保留 helper call，backend 主线消除 helper”是可复用路径。
+
+### 设计约束
+
+- 用户编写 DSL 时只能面向 `pto.vdiv` / `pto.vmod`，不能要求显式调用 soft helper。
+- `f16/f32` `vdiv` 不能被无差别改写到 soft path；需要保留现有 VPTO 指令 authoring contract。
+- `vmod` 本次优先收敛整数族，不在没有明确语义的前提下把 floating `vmod` 一起公开承诺。
+- soft helper 的可见性必须是 internal-only，即便其底层继续以 `inline_proc` 或等价 helper 形式存在。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 统一 `vdiv` / `vmod` 的用户 surface。
+- 让 `vdiv` 在 semantic/lowering 层按 dtype 分流。
+- 让 `vmod` 有正式 public surface，但不暴露 soft helper 细节。
+- 把 `i8` 族 soft path 补成正式契约的一部分。
+
+**Non-Goals:**
+
+- 不把 `vmod` 定义成新的 VPTO public op。
+- 不重新设计整数除零、饱和或 exceptional-value 语义之外的更大算术模型。
+- 不让用户通过新的 public helper surface 显式选择“硬件路径”或“软实现路径”。
+
+## Decisions
+
+### 1. `pto.vdiv` 保持单一 public surface，但 lowering 按 dtype 分流
+
+决策：
+
+- `pto.vdiv` 继续是用户唯一可见的 vector division API。
+- `f16/f32` `pto.vdiv` 在 frontend/semantic/lowering 中继续保留为 `namespace="pto"` 的 VPTO authoring op。
+- `i8/i16/i32` `pto.vdiv` 在 semantic 阶段重写为 internal helper call，再通过 backend-inline 主线消除。
+
+原因：
+
+- 这能保持用户心智统一，同时允许浮点复用现有 VPTO path，整数则走 soft algorithm。
+
+备选方案：
+
+- 让所有 `pto.vdiv` 都走 soft path。
+  - 放弃原因：会破坏现有 `f16/f32` VPTO authoring / backend contract，也会丢失已经存在的硬件路径价值。
+
+### 2. `pto.vmod` 作为 public surface 新增，但优先只承诺整数族
+
+决策：
+
+- 用户 surface 新增 `pto.vmod(vec0, vec1, mask)`。
+- 本 change 中，`pto.vmod` 的正式支持矩阵优先限定为 `i8/i16/i32` 家族。
+- `pto.vmod` 不新增新的 VPTO public op，而是直接走 internal soft helper path。
+
+原因：
+
+- 当前仓库中已经有整数 soft `vmod` 算法，可以形成闭环。
+- floating `vmod` / `fmod` 语义尚未被冻结，不适合在本 change 中一起 over-commit。
+
+### 3. soft helper 继续存在，但必须 internal-only
+
+决策：
+
+- soft helper 可以继续以 `inline_proc` 或等价 helper 形式保留。
+- helper 命名与接线路径只属于实现细节，不属于 public surface。
+- frontend diagnostics 对这些 internal helper 名字仍按“unsupported public call surface”处理。
+
+原因：
+
+- 用户 contract 要以 `pto.vdiv` / `pto.vmod` 为唯一入口，不能让 `math.py` helper 变成事实上的次级 API。
+
+### 4. `i8` 族必须通过 widen / narrow profile 完成 soft div/mod
+
+决策：
+
+- `i8/u8` soft `vdiv` / `vmod` 采用 widen -> soft div/mod -> narrow 的正式实现路线。
+- 该 widen / narrow 过程属于实现细节，但其存在本身是本 change 的 contract 一部分。
+
+原因：
+
+- 当前 soft helper 主要覆盖 16/32-bit 家族；如果不把 `i8` 单独写进 contract，就会继续出现“surface 允许、实现无正式路径”的漂移。
+
+## 测试策略
+
+- Python/frontend 单测：
+  - `f16/f32` `pto.vdiv` 继续产出 `pto.vdiv`
+  - 整数 `pto.vdiv` 产出 internal helper call，而不是 authoring-form `pto.vdiv`
+  - `pto.vmod` public surface 的正向/负向测试
+  - internal helper 名字 direct call 仍被 reject
+- lowering / backend 回归：
+  - 验证整数 `vdiv` / `vmod` 通过 helper + backend-inline 收敛
+  - 验证 `f16/f32` `vdiv` 保持 VPTO path
+
+## Risks / Trade-offs
+
+- [Risk] `vdiv` 同名但双路径 lowering 可能让测试断言更复杂  
+  Mitigation：把测试分成浮点 path 和整数 path 两类，不再只断言统一文本形态。
+
+- [Risk] `vmod` public surface 若过早承诺浮点 family，会让语义边界变模糊  
+  Mitigation：本 change 只先冻结整数族，floating `vmod` 另开 change。
+
+- [Risk] internal helper 注入机制会增加 frontend/semantic 复杂度  
+  Mitigation：复用已有 inline-proc helper/call 模型，而不是再开第三套 helper 体系。
+
+## Migration Plan
+
+1. 先冻结 OpenSpec contract，明确 `vdiv` / `vmod` 的 public/lowering 边界。
+2. 在 frontend/semantic 中补 internal helper 注入与 dtype-directed rewrite。
+3. 补齐 `i8` 族 soft div/mod helper。
+4. 补测试与文档，验证 `f16/f32` 和整数 path 均符合新契约。
+
+## Open Questions
+
+- 浮点 `pto.vmod` 是否需要在后续 change 中定义为 `fmod` 还是 remainder 语义。  
+  本 change 暂不回答该问题。

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/proposal.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/proposal.md
@@ -1,0 +1,107 @@
+# Proposal: 用 `pto.vdiv` / `pto.vmod` 收敛 TileLang DSL 的软实现细节
+
+## 概述
+
+当前仓库中已经存在整数 `vdiv` / `vmod` 的软实现算法，但这套实现仍以 `lib/TileOps/math.py` 中的 helper 形式存在，尚未完全收敛到 TileLang DSL 的正式 public surface。  
+与此同时，`pto.vdiv` 在 DSL 侧已经是公开 API，但其 lowering 仍缺少按 dtype 分流的稳定契约：`f16/f32` 需要继续走现有 VPTO `vdiv` 指令路径，`i8/i16/i32` 需要改走内部软实现路径，而不把软实现 helper 暴露给用户。
+
+本 change 的目标是把 `vdiv` / `vmod` 的用户心智统一收敛为：
+
+- 用户只写 `pto.vdiv(...)` / `pto.vmod(...)`
+- `f16/f32` `vdiv` 继续保留硬件/VPTO 指令 lowering
+- 整数 `vdiv` 与 `vmod` 通过内部 soft helper lowering
+- 软实现 helper 不作为 TileLang DSL public API 暴露
+
+## 背景与动机
+
+当前实现存在四个直接问题：
+
+1. `pto.vdiv` 已经是 public surface，但没有冻结“浮点走 VPTO、整数走 soft path”的 lowering 契约。
+2. `vmod` 目前只有内部 soft helper，没有完整的 `pto.vmod` public surface 和 end-to-end lowering 链路。
+3. 现有 soft helper 仍以可见名字存在，容易把实现细节泄漏给 DSL 用户。
+4. `i8` 族虽然已经被当成 `pto.vdiv` 的支持范围之一，但当前 soft helper 还没有形成明确、可验证的 `i8/u8 -> widen -> div/mod -> narrow` 契约。
+
+如果不把这几层契约一次性写清楚，后续实现很容易出现：
+
+- 文档支持范围与真实 lowering 分叉
+- 用户直接依赖内部 helper 名字
+- `f16/f32` 与整数 `vdiv` 走出两套无 spec 约束的隐式路径
+- `vmod` 继续停留在“有算法、无 public surface”的半完成状态
+
+## 目标
+
+- 把 TileLang DSL 的除法/取模 public surface 统一为 `pto.vdiv` / `pto.vmod`。
+- 明确 `pto.vdiv` 的 dtype-directed lowering：
+  - `f16/f32` 走 authoring-form VPTO `pto.vdiv`
+  - `i8/i16/i32` 走内部 soft helper
+- 为 `pto.vmod` 补齐完整 public surface 和内部 soft lowering 链路。
+- 规定 soft helper 只作为内部实现细节存在，不作为用户可依赖 API 暴露。
+- 把 `i8` 族 soft div/mod 的 widen / narrow 路径纳入正式实现范围。
+
+## 非目标
+
+- 不在本 change 中扩展 `bf16` 的 `vdiv` / `vmod` 支持。
+- 不在本 change 中重新定义 floating-point remainder/fmod 语义；`pto.vmod` 本次优先收敛整数族 public surface。
+- 不在本 change 中引入新的 public helper 命名空间或让用户显式调用 soft helper。
+- 不在本 change 中改变现有 `inline_proc` backend-inline 主线；本 change 仅复用该能力承载内部 soft helper lowering。
+
+## What Changes
+
+- `tilelang-dsl-surface`：
+  - 明确 `pto.vdiv` 是唯一公开的 vector division surface，支持 `i8/i16/i32/f16/f32`。
+  - 新增 `pto.vmod` 作为公开 vector modulo surface，优先覆盖整数族。
+  - 明确用户不得依赖内部 soft helper 名字。
+- `tilelang-dsl-diagnostics`：
+  - 明确 `pto.vdiv` / `pto.vmod` 的 dtype reject 行为。
+  - 明确内部 soft helper 名字不属于 public DSL call surface。
+- `tilelang-dsl-vpto-lowering`：
+  - 为 `pto.vdiv` 新增 dtype-directed lowering 契约。
+  - 为 `pto.vmod` 新增“public call -> internal helper -> backend-inline -> legal VPTO”契约。
+  - 明确整数 `i8` 族 soft path 需要通过 widen / narrow profile 实现。
+
+## Capabilities
+
+### New Capabilities
+
+- 无
+
+### Modified Capabilities
+
+- `tilelang-dsl-surface`: 统一 `vdiv` / `vmod` 的 public API，隐藏 soft helper 实现细节。
+- `tilelang-dsl-diagnostics`: 明确 `vdiv` / `vmod` 的支持范围与内部 helper reject 行为。
+- `tilelang-dsl-vpto-lowering`: 为 `vdiv` 增加 dtype-directed lowering，并为 `vmod` 补齐 public-to-soft-lowering 链路。
+
+## 预期结果
+
+- DSL 用户只需要面向 `pto.vdiv` / `pto.vmod` 编程，不再接触 `math.py` 中的 soft helper 名字。
+- `f16/f32` `vdiv` 继续保留现有 VPTO 指令 authoring/lowering 路径。
+- 整数 `vdiv` / `vmod` 通过内部 soft helper 统一落到 backend-inline 主线，不把软实现细节暴露为 public contract。
+- `i8` 族 support matrix 和实现路径重新一致，不再只有表层放行而无清晰 lowering 契约。
+
+## 成功标准
+
+- 新增 `openspec/changes/hide-soft-divmod-behind-pto-surface/`，包含 `proposal.md`、`design.md`、`tasks.md`。
+- 新增 spec delta：
+  - `specs/tilelang-dsl-surface/spec.md`
+  - `specs/tilelang-dsl-diagnostics/spec.md`
+  - `specs/tilelang-dsl-vpto-lowering/spec.md`
+- 变更文本明确写清：
+  - `pto.vdiv` 的双 lowering 路径
+  - `pto.vmod` 的 public surface 与 soft lowering
+  - soft helper 的 internal-only 定位
+  - `i8` 族 widen / narrow soft path 要求
+
+## Impact
+
+- 受影响目录：
+  - `tilelang-dsl/python/tilelang_dsl/`
+  - `tilelang-dsl/tests/`
+  - `tilelang-dsl/docs/user_guide/`
+  - `lib/TileOps/`
+  - `openspec/changes/hide-soft-divmod-behind-pto-surface/`
+- 受影响 public API：
+  - `pto.vdiv`
+  - `pto.vmod`
+- 受影响 lowering 行为：
+  - `pto.vdiv` 的 dtype-directed lowering
+  - `pto.vmod` 的 internal soft-helper lowering

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-diagnostics/spec.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-diagnostics/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: diagnostics MUST enforce the public `vdiv` / `vmod` support matrix and reject internal helper names
+
+TileLang DSL diagnostics MUST 对 `pto.vdiv` / `pto.vmod` 的 public support matrix 做 fail-fast 校验。  
+其中：
+
+- `pto.vdiv` MUST 接受 `i8/i16/i32/f16/f32`
+- `pto.vmod` MUST 接受当前公开承诺的整数 family
+- `bf16` 和其他未纳入本 change support matrix 的 dtype MUST 报错
+- internal soft helper 名字 direct call MUST 继续按 unsupported public call surface 报错
+
+#### Scenario: unsupported `pto.vdiv` dtype is rejected explicitly
+
+- **WHEN** 用户以不在 public support matrix 中的 dtype 调用 `pto.vdiv`
+- **THEN** frontend MUST 在生成 IR 之前报错
+- **AND** 诊断 MUST 明确指出 `pto.vdiv` 当前支持的 dtype family
+
+#### Scenario: unsupported `pto.vmod` dtype is rejected explicitly
+
+- **WHEN** 用户以不在当前公开承诺范围内的 dtype 调用 `pto.vmod`
+- **THEN** frontend MUST 在生成 IR 之前报错
+- **AND** 诊断 MUST 明确指出 `pto.vmod` 当前支持范围
+
+#### Scenario: internal soft helper name is not accepted as public DSL surface
+
+- **WHEN** 用户在 TileLang DSL kernel 中直接调用 internal soft helper 名字，而不是 `pto.vdiv` / `pto.vmod`
+- **THEN** frontend MUST 把该调用视为 unsupported public call surface
+- **AND** 诊断 MUST NOT 暗示用户应该直接依赖该 helper 名字

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-surface/spec.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-surface/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: TileLang DSL MUST expose `pto.vdiv` / `pto.vmod` as the only public vector div/mod surface
+
+TileLang DSL public surface 中，vector division / modulo MUST 统一通过 `pto.vdiv(...)` 与 `pto.vmod(...)` 暴露。  
+用户 MUST NOT 被要求显式调用 `lib/TileOps/math.py` 中的 helper，或依赖任何 internal soft helper 名字来获得整数 `div/mod` 能力。  
+`pto.vdiv` MUST 支持 `i8/i16/i32/f16/f32`。  
+`pto.vmod` 在本 change 中 MUST 至少支持整数 8/16/32-bit family。
+
+#### Scenario: user writes integer vector division through `pto.vdiv`
+
+- **WHEN** 用户在 TileLang DSL kernel 中编写 `pto.vdiv(lhs, rhs, mask)`，且向量元素类型为 `i8/i16/i32`
+- **THEN** frontend MUST 接受该 public surface
+- **AND** 用户 MUST NOT 需要额外调用任何 soft helper 名字
+
+#### Scenario: user writes integer vector modulo through `pto.vmod`
+
+- **WHEN** 用户在 TileLang DSL kernel 中编写 `pto.vmod(lhs, rhs, mask)`，且向量元素类型为整数 8/16/32-bit family
+- **THEN** frontend MUST 接受该 public surface
+- **AND** 该能力 MUST 通过正式 DSL API 提供，而不是停留在内部 helper 层
+
+### Requirement: internal soft helper names MUST NOT become TileLang DSL public API
+
+即便实现层继续保留 `inline_proc` 或等价 helper 作为整数 `div/mod` 的软实现承载，这些 helper 名字也 MUST NOT 成为 TileLang DSL public API。  
+用户文档、support matrix 和 surface 说明 MUST 只暴露 `pto.vdiv` / `pto.vmod`，不得把 internal helper 当成推荐或稳定入口。
+
+#### Scenario: public documentation does not advertise soft helper names
+
+- **WHEN** 用户查看 TileLang DSL 的 vector arithmetic public surface
+- **THEN** 文档 MUST 只描述 `pto.vdiv` / `pto.vmod`
+- **AND** MUST NOT 把内部 soft helper 名字写成用户应直接调用的 API

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-vpto-lowering/spec.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/specs/tilelang-dsl-vpto-lowering/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: `pto.vdiv` MUST use dtype-directed lowering
+
+`pto.vdiv` 在 TileLang DSL lowering 中 MUST 按元素类型分流，而不是对所有 dtype 使用同一条后端路径。  
+其中：
+
+- `f16/f32` `pto.vdiv` MUST 保留 authoring-form VPTO `pto.vdiv` 路径
+- `i8/i16/i32` `pto.vdiv` MUST 改写为 internal soft helper path
+
+整数 `pto.vdiv` 的 soft helper path MAY 以 helper `func.func` + `func.call` 的形式存在于 `mlir_text()` 阶段，但该 helper call MUST 通过现有 backend-inline 主线在后续阶段被消除。
+
+#### Scenario: floating `pto.vdiv` stays on the VPTO path
+
+- **WHEN** 用户以 `f16` 或 `f32` 向量调用 `pto.vdiv`
+- **THEN** lowering MUST 保留合法的 authoring-form `pto.vdiv`
+- **AND** 后续 VPTO backend/emitter MUST 继续沿用现有 `vdiv` 指令路径
+
+#### Scenario: integer `pto.vdiv` is rewritten to an internal soft helper
+
+- **WHEN** 用户以 `i8/i16/i32` 向量调用 `pto.vdiv`
+- **THEN** semantic/lowering MUST NOT 继续把该调用保留为 authoring-form `pto.vdiv`
+- **AND** 该调用 MUST 被改写到 internal soft helper path
+- **AND** 最终用户 contract MUST 仍表现为“使用 `pto.vdiv` 获得整数 vector division”
+
+### Requirement: `pto.vmod` MUST lower through the internal soft-helper path
+
+在本 change 中，`pto.vmod` MUST 通过 internal soft helper path 实现，而不是要求新的 VPTO public op。  
+helper call MAY 出现在 frontend materialized module 中，但它 MUST 通过既有 backend-inline 主线在后续阶段被消除。
+
+#### Scenario: integer `pto.vmod` lowers through helper plus backend-inline
+
+- **WHEN** 用户以当前支持的整数 family 调用 `pto.vmod`
+- **THEN** frontend MUST 生成合法的 helper-based lowering 形态
+- **AND** 后续 backend 主线 MUST 消除对应 helper call
+
+### Requirement: integer 8-bit div/mod MUST be implemented through an explicit widen / narrow profile
+
+对于 `i8/u8` family，本 change 的 `vdiv` / `vmod` 支持 MUST 通过明确的 widen / narrow soft path 完成。  
+也即，实现 MUST 先把 8-bit lane 扩展到更宽整数 profile，完成 soft `div/mod`，再收敛回 8-bit 结果。  
+该 widen / narrow 过程属于实现细节，但其存在本身 MUST 被视为正式 lowering contract 的一部分。
+
+#### Scenario: `i8` vector div/mod does not depend on a fictitious direct 8-bit hardware op
+
+- **WHEN** 用户对 `i8` 向量调用 `pto.vdiv` 或 `pto.vmod`
+- **THEN** lowering MUST 走正式定义的 widen / soft-compute / narrow 路线
+- **AND** MUST NOT 假定存在可直接承载该语义的 8-bit hardware `vdiv` / `vmod` op

--- a/openspec/changes/hide-soft-divmod-behind-pto-surface/tasks.md
+++ b/openspec/changes/hide-soft-divmod-behind-pto-surface/tasks.md
@@ -1,0 +1,38 @@
+## 1. OpenSpec 契约落定
+
+- [x] 1.1 完成 `specs/tilelang-dsl-surface/spec.md`，固定 `pto.vdiv` / `pto.vmod` public surface 与 internal helper 不外露契约。
+- [x] 1.2 完成 `specs/tilelang-dsl-diagnostics/spec.md`，固定 `vdiv` / `vmod` dtype reject 与 internal helper name reject 契约。
+- [x] 1.3 完成 `specs/tilelang-dsl-vpto-lowering/spec.md`，固定 `vdiv` 双路径 lowering、`vmod` soft lowering 与 `i8` widen / narrow 约束。
+
+## 2. Frontend / semantic surface
+
+- [x] 2.1 在 `tilelang-dsl/python/tilelang_dsl/semantic.py` 中为 `pto.vdiv` 增加 dtype-directed rewrite：`f16/f32` 保持 `pto.vdiv`，整数族改写为 internal helper call。
+- [x] 2.2 为 `pto.vmod` 补齐 public surface、semantic 分析与 dtype 校验。
+- [x] 2.3 增加 internal soft helper 注入机制，使 kernel 无需显式 import helper 即可完成 rewrite。
+- [x] 2.4 保持 internal helper 名字不属于 public DSL call surface。
+
+## 3. Soft helper implementation
+
+- [x] 3.1 整理 `lib/TileOps/math.py` 中现有 `vdiv` / `vmod` soft helper，使其 internal-only。
+- [x] 3.2 补齐 `i8/u8` 的 soft `vdiv` 路径，采用 widen -> div -> narrow profile。
+- [x] 3.3 补齐 `i8/u8` 的 soft `vmod` 路径，采用 widen -> mod -> narrow profile。
+- [x] 3.4 明确整数 `vdiv` / `vmod` 的除零返回约定与符号约定，并在测试中锁定。
+
+## 4. Lowering / backend path
+
+- [x] 4.1 确保 `f16/f32` `pto.vdiv` 继续走现有 authoring-form VPTO / backend emitter 路径。
+- [x] 4.2 确保整数 `pto.vdiv` / `pto.vmod` 通过 internal helper + backend-inline 收敛，不把 helper 名字暴露为最终 public contract。
+- [x] 4.3 为 `pto.vmod` 路径补齐与现有 inline-proc backend-inline 主线的接线验证。
+
+## 5. 回归测试与文档
+
+- [x] 5.1 更新 `tilelang-dsl/tests/test_tilelang_dsl_v1.py`，区分浮点 `vdiv` VPTO path 和整数 `vdiv` helper path。
+- [x] 5.2 新增 `pto.vmod` 的 public surface 正向/负向测试。
+- [x] 5.3 新增 `i8` 族 `vdiv` / `vmod` regression，锁定 widen / narrow 行为。
+- [x] 5.4 更新 `tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md`，明确 `vdiv` / `vmod` public contract 与 dtype 支持范围。
+
+## 6. 验证
+
+- [x] 6.1 执行针对 `vdiv` / `vmod` 的 TileLang DSL 单测。
+- [x] 6.2 执行覆盖 helper + backend-inline 收敛路径的定向回归。
+- [x] 6.3 执行 `openspec validate hide-soft-divmod-behind-pto-surface --type change --strict --json --no-interactive`。

--- a/test/basic/tilelang_soft_vmod_backend_inline.pto
+++ b/test/basic/tilelang_soft_vmod_backend_inline.pto
@@ -1,0 +1,126 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s --emit-vpto -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg1: !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance } {
+    %c0 = arith.constant 0 : index
+    %tmp_0 = pto.tile_buf_addr %arg0 : !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<8x16xi16, #pto.address_space<vec>>
+    %tmp_1 = pto.tile_buf_addr %arg1 : !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<8x16xi16, #pto.address_space<vec>>
+    pto.vecscope {
+      %mask_0 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %vec_1 = pto.vlds %tmp_1[%c0] : memref<8x16xi16, #pto.address_space<vec>> -> !pto.vreg<128xi16>
+      %result_81 = func.call @__tl_inline__tl_soft_vmod_2(%vec_1, %vec_1, %mask_0) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+      pto.vsts %result_81, %tmp_0[%c0], %mask_0 : !pto.vreg<128xi16>, memref<8x16xi16, #pto.address_space<vec>>, !pto.mask<b16>
+    }
+    return
+  }
+
+  func.func private @__tl_inline__tl_soft_vdiv_u16_0(%arg0: !pto.vreg<128xui16>, %arg1: !pto.vreg<128xui16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xui16> attributes { pto.tilelang.inline_proc } {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_ui32 = builtin.unrealized_conversion_cast %c0_i32 : i32 to ui32
+    %c65536_0_f32 = arith.constant 65536.0 : f32
+    %c65535_i16 = arith.constant 65535 : i16
+    %c65535_ui16 = builtin.unrealized_conversion_cast %c65535_i16 : i16 to ui16
+    %tmp_0 = arith.constant 0 : i16
+    %zero_10 = builtin.unrealized_conversion_cast %tmp_0 : i16 to ui16
+    %tmp_1 = arith.constant 1 : i16
+    %one_11 = builtin.unrealized_conversion_cast %tmp_1 : i16 to ui16
+    %fp32_one_12 = arith.constant 1.0 : f32
+    %full_mask_b16_13 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %full_mask_b32_14 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %zero_mask_15 = pto.vcmps %arg1, %zero_10, %arg2, "eq" : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.mask<b16>
+    %active_mask_16 = pto.pnot %zero_mask_15, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %zero_u16_17 = pto.vbr %zero_10 : ui16 -> !pto.vreg<128xui16>
+    %vy_lower_u16_18, %vy_higher_u16_19 = pto.vintlv %arg1, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %active_low_22 = pto.vcmps %vy_lower_u32_20, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
+    %active_high_23 = pto.vcmps %vy_higher_u32_21, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
+    %tmp_2 = pto.vbitcast %vy_lower_u32_20 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
+    %vy_lower_f32_24 = pto.vcvt %tmp_2 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %tmp_3 = pto.vbitcast %vy_higher_u32_21 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
+    %vy_higher_f32_25 = pto.vcvt %tmp_3 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %tmp_4 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
+    %vy_rec_lower_26 = pto.vdiv %tmp_4, %vy_lower_f32_24, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_5 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
+    %vy_rec_higher_27 = pto.vdiv %tmp_5, %vy_higher_f32_25, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_6 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
+    %vy_scale_lower_28 = pto.vmul %vy_rec_lower_26, %tmp_6, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_7 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
+    %vy_scale_higher_29 = pto.vmul %vy_rec_higher_27, %tmp_7, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_lower_u32_32 = pto.vbitcast %v_lower_i32_30 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
+    %v_higher_u32_33 = pto.vbitcast %v_higher_i32_31 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
+    %vx_lower_u16_34, %vx_higher_u16_35 = pto.vintlv %arg0, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %q_tmp_lower_38 = pto.vmul %v_lower_u32_32, %vx_lower_u32_36, %active_low_22 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    %q_tmp_higher_39 = pto.vmul %v_higher_u32_33, %vx_higher_u32_37, %active_high_23 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    %tmp_8 = pto.vbitcast %q_tmp_lower_38 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    %tmp_9 = pto.vbitcast %q_tmp_higher_39 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    %_q_lower_40, %q_tmp_41 = pto.vdintlv %tmp_8, %tmp_9 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %yq_tmp_42 = pto.vmul %q_tmp_41, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_43 = pto.vsub %arg0, %yq_tmp_42, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %ge_mask_44 = pto.vcmp %r_tmp_43, %arg1, %active_mask_16, "ge" : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.mask<b16>
+    %refined_r_45 = pto.vsub %r_tmp_43, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_46 = pto.vsel %refined_r_45, %r_tmp_43, %ge_mask_44 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_inc_47 = pto.vadds %q_tmp_41, %one_11, %active_mask_16 : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_tmp_48 = pto.vsel %q_inc_47, %q_tmp_41, %ge_mask_44 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %ge_mask_49 = pto.vcmp %r_tmp_46, %arg1, %active_mask_16, "ge" : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.mask<b16>
+    %refined_r_50 = pto.vsub %r_tmp_46, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_51 = pto.vsel %refined_r_50, %r_tmp_46, %ge_mask_49 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_inc_52 = pto.vadds %q_tmp_48, %one_11, %active_mask_16 : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_tmp_53 = pto.vsel %q_inc_52, %q_tmp_48, %ge_mask_49 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %zero_q_54 = pto.vbr %c65535_ui16 : ui16 -> !pto.vreg<128xui16>
+    %tmp_10 = pto.vsel %zero_q_54, %q_tmp_53, %zero_mask_15 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    return %tmp_10 : !pto.vreg<128xui16>
+  }
+
+  func.func private @__tl_inline__tl_soft_vmod_i16_1(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %zero_60 = arith.constant 0 : i16
+    %neg_one_61 = arith.constant -1 : i16
+    %zero_mask_62 = pto.vcmps %arg1, %zero_60, %arg2, "eq" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %active_mask_63 = pto.pnot %zero_mask_62, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %tmp_11 = pto.vabs %arg0, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_x_64 = pto.vbitcast %tmp_11 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %tmp_12 = pto.vabs %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_y_65 = pto.vbitcast %tmp_12 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %x_xor_y_66 = pto.vxor %arg0, %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %p_pos_67 = pto.vcmps %x_xor_y_66, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %q_abs_68 = func.call @__tl_inline__tl_soft_vdiv_u16_0(%abs_x_64, %abs_y_65, %active_mask_63) : (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16>) -> !pto.vreg<128xui16>
+    %tmp_13 = pto.vbitcast %q_abs_68 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %neg_q_69 = pto.vneg %tmp_13, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_14 = pto.vbitcast %q_abs_68 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %q_70 = pto.vsel %tmp_14, %neg_q_69, %p_pos_67 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %qy_71 = pto.vmul %q_70, %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %remainder_72 = pto.vsub %arg0, %qy_71, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %nonzero_remainder_73 = pto.vcmps %remainder_72, %zero_60, %active_mask_63, "ne" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_x_74 = pto.vcmps %arg0, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_y_75 = pto.vcmps %arg1, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_diff_76 = pto.pxor %sign_x_74, %sign_y_75, %active_mask_63 : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %need_floor_fix_77 = pto.pand %sign_diff_76, %nonzero_remainder_73, %active_mask_63 : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %amended_remainder_78 = pto.vadd %arg1, %remainder_72, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %remainder_79 = pto.vsel %amended_remainder_78, %remainder_72, %need_floor_fix_77 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_15 = pto.vbr %neg_one_61 : i16 -> !pto.vreg<128xi16>
+    %tmp_16 = pto.vsel %tmp_15, %remainder_79, %zero_mask_62 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    return %tmp_16 : !pto.vreg<128xi16>
+  }
+
+  func.func private @__tl_inline__tl_soft_vmod_2(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %result_80 = func.call @__tl_inline__tl_soft_vmod_i16_1(%arg0, %arg1, %arg2) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+    return %result_80 : !pto.vreg<128xi16>
+  }
+}
+
+// CHECK-LABEL: func.func @kernel(
+// CHECK: pto.vecscope {
+// CHECK: pto.vlds
+// CHECK: pto.vdiv
+// CHECK: pto.vmul
+// CHECK: pto.vsub
+// CHECK: pto.pxor
+// CHECK: pto.pand
+// CHECK: pto.vsel
+// CHECK: pto.vsts
+// CHECK-NOT: func.call @__tl_inline__tl_soft_
+// CHECK-NOT: func.func private @__tl_inline__tl_soft_

--- a/test/vpto_tilelang_inline_soft_divmod_fastpath.pto
+++ b/test/vpto_tilelang_inline_soft_divmod_fastpath.pto
@@ -1,0 +1,158 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s --emit-vpto -o - | FileCheck %s
+
+// CHECK-LABEL: func.func @kernel(
+// CHECK: pto.vecscope {
+// CHECK: pto.vlds
+// CHECK: pto.vcmps
+// CHECK: pto.vxor
+// CHECK: pto.vdiv
+// CHECK: pto.vmul
+// CHECK: pto.vsub
+// CHECK: pto.vsts
+// CHECK-NOT: func.call @__tl_inline__tl_soft
+// CHECK-NOT: func.func private @__tl_inline__tl_soft
+// CHECK-NOT: __tl_inline__tl_soft_vdiv_
+// CHECK-NOT: __tl_inline__tl_soft_vmod_
+
+// tilelang.target = a5
+// tilelang.op = dump_i16_divmod_lit_tmp
+// tilelang.dtypes = (i16, i16)
+// tilelang.verify = True
+// tilelang.advanced = False
+// tilelang.specialize dst shape=(8, 16) memory_space=ub config=None
+// tilelang.specialize src shape=(8, 16) memory_space=ub config=None
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg1: !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance } {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %tmp_0 = pto.tile_buf_addr %arg0 : !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<8x16xi16, #pto.address_space<vec>>
+    %tmp_1 = pto.tile_buf_addr %arg1 : !pto.tile_buf<loc=vec, dtype=i16, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<8x16xi16, #pto.address_space<vec>>
+    pto.vecscope {
+      %mask_0 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %vec_1 = pto.vlds %tmp_1[%c0] : memref<8x16xi16, #pto.address_space<vec>> -> !pto.vreg<128xi16>
+      %q_59 = func.call @__tl_inline__tl_soft_vdiv_2(%vec_1, %vec_1, %mask_0) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+      %r_81 = func.call @__tl_inline__tl_soft_vmod_4(%vec_1, %vec_1, %mask_0) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+      pto.vsts %q_59, %tmp_0[%c0], %mask_0 : !pto.vreg<128xi16>, memref<8x16xi16, #pto.address_space<vec>>, !pto.mask<b16>
+      pto.vsts %r_81, %tmp_0[%c1], %mask_0 : !pto.vreg<128xi16>, memref<8x16xi16, #pto.address_space<vec>>, !pto.mask<b16>
+    }
+    return
+  }
+  func.func private @__tl_inline__tl_soft_vdiv_u16_0(%arg0: !pto.vreg<128xui16>, %arg1: !pto.vreg<128xui16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xui16> attributes { pto.tilelang.inline_proc } {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_ui32 = builtin.unrealized_conversion_cast %c0_i32 : i32 to ui32
+    %c65536_0_f32 = arith.constant 65536.0 : f32
+    %c65535_i16 = arith.constant 65535 : i16
+    %c65535_ui16 = builtin.unrealized_conversion_cast %c65535_i16 : i16 to ui16
+    %tmp_0 = arith.constant 0 : i16
+    %zero_10 = builtin.unrealized_conversion_cast %tmp_0 : i16 to ui16
+    %tmp_1 = arith.constant 1 : i16
+    %one_11 = builtin.unrealized_conversion_cast %tmp_1 : i16 to ui16
+    %fp32_one_12 = arith.constant 1.0 : f32
+    %full_mask_b16_13 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %full_mask_b32_14 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %zero_mask_15 = pto.vcmps %arg1, %zero_10, %arg2, "eq" : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.mask<b16>
+    %active_mask_16 = pto.pnot %zero_mask_15, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %zero_u16_17 = pto.vbr %zero_10 : ui16 -> !pto.vreg<128xui16>
+    %vy_lower_u16_18, %vy_higher_u16_19 = pto.vintlv %arg1, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %active_low_22 = pto.vcmps %vy_lower_u32_20, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
+    %active_high_23 = pto.vcmps %vy_higher_u32_21, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
+    %tmp_2 = pto.vbitcast %vy_lower_u32_20 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
+    %vy_lower_f32_24 = pto.vcvt %tmp_2 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %tmp_3 = pto.vbitcast %vy_higher_u32_21 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
+    %vy_higher_f32_25 = pto.vcvt %tmp_3 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %tmp_4 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
+    %vy_rec_lower_26 = pto.vdiv %tmp_4, %vy_lower_f32_24, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_5 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
+    %vy_rec_higher_27 = pto.vdiv %tmp_5, %vy_higher_f32_25, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_6 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
+    %vy_scale_lower_28 = pto.vmul %vy_rec_lower_26, %tmp_6, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %tmp_7 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
+    %vy_scale_higher_29 = pto.vmul %vy_rec_higher_27, %tmp_7, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_lower_u32_32 = pto.vbitcast %v_lower_i32_30 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
+    %v_higher_u32_33 = pto.vbitcast %v_higher_i32_31 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
+    %vx_lower_u16_34, %vx_higher_u16_35 = pto.vintlv %arg0, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %q_tmp_lower_38 = pto.vmul %v_lower_u32_32, %vx_lower_u32_36, %active_low_22 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    %q_tmp_higher_39 = pto.vmul %v_higher_u32_33, %vx_higher_u32_37, %active_high_23 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    %tmp_8 = pto.vbitcast %q_tmp_lower_38 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    %tmp_9 = pto.vbitcast %q_tmp_higher_39 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    %_q_lower_40, %q_tmp_41 = pto.vdintlv %tmp_8, %tmp_9 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+    %yq_tmp_42 = pto.vmul %q_tmp_41, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_43 = pto.vsub %arg0, %yq_tmp_42, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %ge_mask_44 = pto.vcmp %r_tmp_43, %arg1, %active_mask_16, "ge" : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.mask<b16>
+    %refined_r_45 = pto.vsub %r_tmp_43, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_46 = pto.vsel %refined_r_45, %r_tmp_43, %ge_mask_44 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_inc_47 = pto.vadds %q_tmp_41, %one_11, %active_mask_16 : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_tmp_48 = pto.vsel %q_inc_47, %q_tmp_41, %ge_mask_44 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %ge_mask_49 = pto.vcmp %r_tmp_46, %arg1, %active_mask_16, "ge" : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.mask<b16>
+    %refined_r_50 = pto.vsub %r_tmp_46, %arg1, %active_mask_16 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %r_tmp_51 = pto.vsel %refined_r_50, %r_tmp_46, %ge_mask_49 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_inc_52 = pto.vadds %q_tmp_48, %one_11, %active_mask_16 : !pto.vreg<128xui16>, ui16, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %q_tmp_53 = pto.vsel %q_inc_52, %q_tmp_48, %ge_mask_49 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    %zero_q_54 = pto.vbr %c65535_ui16 : ui16 -> !pto.vreg<128xui16>
+    %tmp_10 = pto.vsel %zero_q_54, %q_tmp_53, %zero_mask_15 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    return %tmp_10 : !pto.vreg<128xui16>
+  }
+  func.func private @__tl_inline__tl_soft_vdiv_i16_1(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %zero_2 = arith.constant 0 : i16
+    %neg_one_3 = arith.constant -1 : i16
+    %zero_mask_4 = pto.vcmps %arg1, %zero_2, %arg2, "eq" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %active_mask_5 = pto.pnot %zero_mask_4, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %tmp_0 = pto.vabs %arg0, %active_mask_5 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_x_6 = pto.vbitcast %tmp_0 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %tmp_1 = pto.vabs %arg1, %active_mask_5 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_y_7 = pto.vbitcast %tmp_1 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %x_xor_y_8 = pto.vxor %arg0, %arg1, %active_mask_5 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %p_pos_9 = pto.vcmps %x_xor_y_8, %zero_2, %active_mask_5, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %q_abs_55 = func.call @__tl_inline__tl_soft_vdiv_u16_0(%abs_x_6, %abs_y_7, %active_mask_5) : (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16>) -> !pto.vreg<128xui16>
+    %tmp_2 = pto.vbitcast %q_abs_55 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %neg_q_56 = pto.vneg %tmp_2, %active_mask_5 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_3 = pto.vbitcast %q_abs_55 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %q_57 = pto.vsel %tmp_3, %neg_q_56, %p_pos_9 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_5 = pto.vbr %neg_one_3 : i16 -> !pto.vreg<128xi16>
+    %tmp_4 = pto.vsel %tmp_5, %q_57, %zero_mask_4 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    return %tmp_4 : !pto.vreg<128xi16>
+  }
+  func.func private @__tl_inline__tl_soft_vdiv_2(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %result_58 = func.call @__tl_inline__tl_soft_vdiv_i16_1(%arg0, %arg1, %arg2) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+    return %result_58 : !pto.vreg<128xi16>
+  }
+  func.func private @__tl_inline__tl_soft_vmod_i16_3(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %zero_60 = arith.constant 0 : i16
+    %neg_one_61 = arith.constant -1 : i16
+    %zero_mask_62 = pto.vcmps %arg1, %zero_60, %arg2, "eq" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %active_mask_63 = pto.pnot %zero_mask_62, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %tmp_0 = pto.vabs %arg0, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_x_64 = pto.vbitcast %tmp_0 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %tmp_1 = pto.vabs %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %abs_y_65 = pto.vbitcast %tmp_1 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
+    %x_xor_y_66 = pto.vxor %arg0, %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %p_pos_67 = pto.vcmps %x_xor_y_66, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %q_abs_68 = func.call @__tl_inline__tl_soft_vdiv_u16_0(%abs_x_64, %abs_y_65, %active_mask_63) : (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16>) -> !pto.vreg<128xui16>
+    %tmp_2 = pto.vbitcast %q_abs_68 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %neg_q_69 = pto.vneg %tmp_2, %active_mask_63 : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_3 = pto.vbitcast %q_abs_68 : !pto.vreg<128xui16> -> !pto.vreg<128xi16>
+    %q_70 = pto.vsel %tmp_3, %neg_q_69, %p_pos_67 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %qy_71 = pto.vmul %q_70, %arg1, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %remainder_72 = pto.vsub %arg0, %qy_71, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %nonzero_remainder_73 = pto.vcmps %remainder_72, %zero_60, %active_mask_63, "ne" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_x_74 = pto.vcmps %arg0, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_y_75 = pto.vcmps %arg1, %zero_60, %active_mask_63, "ge" : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.mask<b16>
+    %sign_diff_76 = pto.pxor %sign_x_74, %sign_y_75, %active_mask_63 : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %need_floor_fix_77 = pto.pand %sign_diff_76, %nonzero_remainder_73, %active_mask_63 : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
+    %amended_remainder_78 = pto.vadd %arg1, %remainder_72, %active_mask_63 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %remainder_79 = pto.vsel %amended_remainder_78, %remainder_72, %need_floor_fix_77 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    %tmp_5 = pto.vbr %neg_one_61 : i16 -> !pto.vreg<128xi16>
+    %tmp_4 = pto.vsel %tmp_5, %remainder_79, %zero_mask_62 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    return %tmp_4 : !pto.vreg<128xi16>
+  }
+  func.func private @__tl_inline__tl_soft_vmod_4(%arg0: !pto.vreg<128xi16>, %arg1: !pto.vreg<128xi16>, %arg2: !pto.mask<b16>) -> !pto.vreg<128xi16> attributes { pto.tilelang.inline_proc } {
+    %result_80 = func.call @__tl_inline__tl_soft_vmod_i16_3(%arg0, %arg1, %arg2) : (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>) -> !pto.vreg<128xi16>
+    return %result_80 : !pto.vreg<128xi16>
+  }
+}

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -428,6 +428,12 @@ sum_vec = pto.vadd(vec_a, vec_b, mask32)
 
 **Description**: Element-wise division of two vectors.
 
+- Supported element types are the 8/16/32-bit integer families (`i*`, `si*`, `ui*`) plus `f16` and `f32`.
+- `f16`/`f32` authoring code stays on the public `pto.vdiv` VPTO path.
+- Integer `pto.vdiv` also uses the same public surface, but lowers through an internal soft-helper path.
+- For `i8`/`ui8`, the integer lowering widens to 16-bit lanes, computes the soft division, then narrows back to 8-bit lanes.
+- Internal helper names such as `_tl_soft_vdiv_*` are implementation details and are not part of the supported DSL call surface.
+
 **Parameters**:
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -439,6 +445,28 @@ sum_vec = pto.vadd(vec_a, vec_b, mask32)
 | Return Value | Type | Description |
 |--------------|------|-------------|
 | `result` | `VRegType` | Quotient of vectors |
+
+#### `pto.vmod(vec1: VRegType, vec2: VRegType, mask: MaskType) -> VRegType`
+
+**Description**: Element-wise modulo of two vectors.
+
+- Supported element types are the 8/16/32-bit integer families (`i*`, `si*`, `ui*`).
+- Floating-point `vmod` is not part of the current TileLang DSL v1 public surface.
+- `pto.vmod` is the only public vector modulo entry point in TileLang DSL v1.
+- The current implementation lowers through an internal soft-helper path; helper names such as `_tl_soft_vmod_*` are intentionally hidden implementation details.
+- For `i8`/`ui8`, the modulo path uses an explicit widen-to-16-bit, soft-compute, narrow-back-to-8-bit profile.
+
+**Parameters**:
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vec1` | `VRegType` | Dividend vector |
+| `vec2` | `VRegType` | Divisor vector |
+| `mask` | `MaskType` | Predicate mask |
+
+**Returns**:
+| Return Value | Type | Description |
+|--------------|------|-------------|
+| `result` | `VRegType` | Remainder vector |
 
 #### `pto.vmax(vec1: VRegType, vec2: VRegType, mask: MaskType) -> VRegType`
 

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -206,6 +206,7 @@ class FrontendKernelNode:
     body: tuple[FrontendStmtNode, ...]
     context_attrs: tuple[tuple[str, Any], ...] = ()
     inline_procs: tuple[FrontendInlineProcNode, ...] = ()
+    internal_inline_procs: tuple[FrontendInlineProcNode, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1415,6 +1416,9 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
         local_bindings=local_bindings,
     )
     sorted_inline_procs = tuple(sorted(descriptor.inline_procs.items(), key=lambda item: item[0]))
+    sorted_internal_inline_procs = tuple(
+        sorted(descriptor.internal_inline_procs.items(), key=lambda item: item[0])
+    )
     context = _FrontendBuildContext(
         source_info=source_info,
         module_globals=getattr(descriptor._py_fn, "__globals__", None),
@@ -1518,6 +1522,82 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
         inline_proc_source_infos,
     )
 
+    internal_inline_proc_nodes: tuple[FrontendInlineProcNode, ...] = ()
+    if sorted_internal_inline_procs:
+        merged_inline_proc_descriptors = {
+            name: _FrontendInlineProc(
+                name=name,
+                source_info=proc.source_info,
+                signature=proc.signature,
+            )
+            for name, proc in (*sorted_inline_procs, *sorted_internal_inline_procs)
+        }
+        internal_context = _FrontendBuildContext(
+            source_info=source_info,
+            module_globals=getattr(descriptor._py_fn, "__globals__", None),
+            templates=descriptor.templates,
+            selected_op=descriptor.selected_op,
+            advanced_enabled=descriptor.advanced_enabled,
+            inline_procs=merged_inline_proc_descriptors,
+            global_literal_constants=global_literal_constants,
+            local_bindings=local_bindings,
+        )
+        internal_nodes: list[FrontendInlineProcNode] = []
+        internal_source_infos: dict[str, Any] = {}
+        for name, inline_proc_descriptor in sorted_internal_inline_procs:
+            inline_source = inline_proc_descriptor.source_info
+            if inline_source is None:
+                if source_info is not None:
+                    raise context.error(
+                        source_info.function_def,
+                        f"inline_proc `{name}` requires source-visible Python functions",
+                    )
+                raise ValueError(
+                    f"inline_proc `{name}` requires source-visible Python functions"
+                )
+            internal_source_infos[name] = inline_source
+            helper_context = internal_context.enter_inline_proc(name, inline_source)
+            helper_body = _build_stmt_list(inline_source.function_def.body, helper_context)
+            parameter_specs = _inline_proc_param_specs(
+                _FrontendInlineProc(
+                    name=name,
+                    source_info=inline_source,
+                    signature=inline_proc_descriptor.signature,
+                )
+            )
+            inline_proc_node = FrontendInlineProcNode(
+                name=name,
+                parameters=tuple(
+                    FrontendInlineProcParameterNode(
+                        name=param_name,
+                        annotation=arg.annotation,
+                        default=None
+                        if default_node is None
+                        else _build_expr(default_node, helper_context),
+                    )
+                    for (param_name, default_node), arg in zip(
+                        parameter_specs,
+                        inline_source.function_def.args.args,
+                    )
+                ),
+                body=helper_body,
+            )
+            internal_nodes.append(inline_proc_node)
+
+        internal_inline_proc_nodes = tuple(internal_nodes)
+        for inline_proc_node in internal_inline_proc_nodes:
+            source = internal_source_infos[inline_proc_node.name]
+            helper_context = internal_context.enter_inline_proc(inline_proc_node.name, source)
+            assigned_names: set[str] = set()
+            param_names = {parameter.name for parameter in inline_proc_node.parameters}
+            for stmt in inline_proc_node.body:
+                _validate_inline_capture(
+                    stmt,
+                    param_names,
+                    assigned_names,
+                    context=helper_context,
+                )
+
     return FrontendKernelNode(
         target=descriptor.target,
         op=descriptor.op,
@@ -1532,6 +1612,7 @@ def build_frontend_kernel_node(descriptor: Any) -> FrontendKernelNode:
             sorted(descriptor.constraint_context_attrs.items(), key=lambda item: item[0])
         ),
         inline_procs=reachable_inline_proc_nodes,
+        internal_inline_procs=internal_inline_proc_nodes,
     )
 
 

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import inspect
 import ast
+import importlib.util
 import sys
 import subprocess
 import tempfile
@@ -54,6 +55,7 @@ from .support_matrix import (
 
 _UNSET = object()
 _PTOAS_BIN_ENV = "PTOAS_BIN"
+_INTERNAL_SOFT_MATH_MODULE_NAME = "tilelang_dsl._internal_soft_math"
 _SUPPORTED_TEMPLATE_PTO_CALLS = frozenset(
     SUPPORTED_TOPLEVEL_PTO_CALLS
     | SUPPORTED_VECSCOPE_PTO_CALLS
@@ -85,6 +87,7 @@ _DSL_DTYPE_NAMES = frozenset(
 
 
 _INLINE_PROC_REGISTRY: dict[tuple[str, str], "InlineProcDescriptor"] = {}
+_INTERNAL_INLINE_PROC_CACHE: tuple[tuple[str, "InlineProcDescriptor"], ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -203,6 +206,45 @@ def _collect_inline_procs(module_name: str) -> tuple[tuple[str, InlineProcDescri
                     collected.setdefault(helper_name, helper)
 
     return tuple(sorted(collected.items(), key=lambda item: item[0]))
+
+
+def _load_module_from_path(module_name: str, path: Path) -> Any:
+    module = sys.modules.get(module_name)
+    if module is not None:
+        return module
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load module {module_name!r} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _collect_internal_inline_procs() -> tuple[tuple[str, InlineProcDescriptor], ...]:
+    global _INTERNAL_INLINE_PROC_CACHE
+    if _INTERNAL_INLINE_PROC_CACHE is not None:
+        return _INTERNAL_INLINE_PROC_CACHE
+
+    repo_root = Path(__file__).resolve().parents[3]
+    soft_math_path = repo_root / "lib" / "TileOps" / "math.py"
+    if not soft_math_path.exists():
+        _INTERNAL_INLINE_PROC_CACHE = ()
+        return _INTERNAL_INLINE_PROC_CACHE
+
+    try:
+        module = _load_module_from_path(_INTERNAL_SOFT_MATH_MODULE_NAME, soft_math_path)
+    except Exception:
+        _INTERNAL_INLINE_PROC_CACHE = ()
+        return _INTERNAL_INLINE_PROC_CACHE
+
+    collected: dict[str, InlineProcDescriptor] = {}
+    for symbol, value in vars(module).items():
+        if isinstance(value, InlineProcDescriptor):
+            collected.setdefault(symbol, value)
+
+    _INTERNAL_INLINE_PROC_CACHE = tuple(sorted(collected.items(), key=lambda item: item[0]))
+    return _INTERNAL_INLINE_PROC_CACHE
 
 
 def _register_inline_proc(descriptor: InlineProcDescriptor) -> InlineProcDescriptor:
@@ -847,6 +889,7 @@ class VKernelDescriptor:
     priority: int = 0
     _templates: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = field(default=(), repr=False)
     _inline_procs: tuple[tuple[str, InlineProcDescriptor], ...] = field(default=(), repr=False)
+    _internal_inline_procs: tuple[tuple[str, InlineProcDescriptor], ...] = field(default=(), repr=False)
     _selected_op: str | None = None
     _selected_dtype_signature: tuple[ScalarType | MaskType, ...] | None = None
     _parameters: tuple[BoundKernelParameter, ...] | None = field(default=None, repr=False)
@@ -879,6 +922,10 @@ class VKernelDescriptor:
     @property
     def inline_procs(self) -> dict[str, InlineProcDescriptor]:
         return {name: descriptor for name, descriptor in self._inline_procs}
+
+    @property
+    def internal_inline_procs(self) -> dict[str, InlineProcDescriptor]:
+        return {name: descriptor for name, descriptor in self._internal_inline_procs}
 
     @property
     def dtype_signature(self) -> tuple[ScalarType | MaskType, ...]:
@@ -954,6 +1001,7 @@ class VKernelDescriptor:
             priority=self.priority,
             _templates=self._templates,
             _inline_procs=self._inline_procs,
+            _internal_inline_procs=self._internal_inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -980,6 +1028,7 @@ class VKernelDescriptor:
             priority=self.priority,
             _templates=self._templates,
             _inline_procs=self._inline_procs,
+            _internal_inline_procs=self._internal_inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=dtype_signature,
             _parameters=bound_parameters,
@@ -1009,6 +1058,7 @@ class VKernelDescriptor:
             priority=self.priority,
             _templates=self._templates,
             _inline_procs=self._inline_procs,
+            _internal_inline_procs=self._internal_inline_procs,
             _selected_op=normalized_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -1050,6 +1100,7 @@ class VKernelDescriptor:
             priority=self.priority,
             _templates=self._templates,
             _inline_procs=self._inline_procs,
+            _internal_inline_procs=self._internal_inline_procs,
             _selected_op=self._selected_op,
             _selected_dtype_signature=self._selected_dtype_signature,
             _parameters=self._parameters,
@@ -2121,6 +2172,7 @@ def _build_descriptor(
     source_info = _load_function_source_info(py_fn)
     advanced_enabled = _validate_advanced(advanced)
     inline_procs = _collect_inline_procs(py_fn.__module__)
+    internal_inline_procs = _collect_internal_inline_procs()
     _validate_function_body(
         source_info,
         advanced_enabled=advanced_enabled,
@@ -2157,6 +2209,7 @@ def _build_descriptor(
         priority=_validate_priority(priority),
         _templates=frozen_templates,
         _inline_procs=inline_procs,
+        _internal_inline_procs=internal_inline_procs,
         _selected_op=selected_op,
         _selected_dtype_signature=selected_dtype_signature,
         _parameters=bound_parameters,

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -246,6 +246,7 @@ _BINARY_VECTOR_OPS = {
     "vsub",
     "vmul",
     "vdiv",
+    "vmod",
     "vmax",
     "vmin",
     "vand",
@@ -776,6 +777,9 @@ class _SemanticAnalyzer:
         self._hidden_parameters: list[SemanticParameter] = []
         self._inline_proc_nodes: dict[str, FrontendInlineProcNode] = {
             inline_proc.name: inline_proc for inline_proc in node.inline_procs
+        }
+        self._internal_inline_proc_nodes: dict[str, FrontendInlineProcNode] = {
+            inline_proc.name: inline_proc for inline_proc in node.internal_inline_procs
         }
         self._inline_proc_specializations: dict[
             tuple[str, tuple[tuple[SemanticType, object], ...]], SemanticKernel
@@ -1427,9 +1431,12 @@ class _SemanticAnalyzer:
         self,
         name: str,
         args: tuple[SemanticExpr, ...],
+        *,
+        internal: bool = False,
     ) -> tuple[str, tuple[tuple[SemanticType, object], ...]]:
+        specialization_name = f"__internal__::{name}" if internal else name
         return (
-            name,
+            specialization_name,
             tuple(
                 (arg.type, self._inline_proc_static_specialization_token(arg))
                 for arg in args
@@ -1508,12 +1515,17 @@ class _SemanticAnalyzer:
         self,
         name: str,
         args: tuple[SemanticExpr, ...],
+        *,
+        internal: bool = False,
     ) -> SemanticKernel:
-        inline_proc_node = self._inline_proc_nodes.get(name)
+        inline_proc_nodes = (
+            self._internal_inline_proc_nodes if internal else self._inline_proc_nodes
+        )
+        inline_proc_node = inline_proc_nodes.get(name)
         if inline_proc_node is None:
             raise TypeError(f"inline_proc `{name}` is not registered in the current TileLang module")
 
-        key = self._inline_proc_specialization_key(name, args)
+        key = self._inline_proc_specialization_key(name, args, internal=internal)
         existing = self._inline_proc_specializations.get(key)
         if existing is not None:
             return existing
@@ -1597,6 +1609,27 @@ class _SemanticAnalyzer:
             args=args,
             type=self._inline_proc_return_types.get(key),
         )
+
+    def _analyze_internal_inline_proc_call_expr(
+        self,
+        name: str,
+        args: tuple[SemanticExpr, ...],
+    ) -> SemanticExpr:
+        helper_kernel = self._materialize_inline_proc_specialization(
+            name,
+            args,
+            internal=True,
+        )
+        key = self._inline_proc_specialization_key(name, args, internal=True)
+        return SemanticCallExpr(
+            namespace=None,
+            name=helper_kernel.symbol_name,
+            args=args,
+            type=self._inline_proc_return_types.get(key),
+        )
+
+    def _is_internal_inline_proc_context(self) -> bool:
+        return any(key[0].startswith("__internal__::") for key in self._inline_proc_active_stack)
 
     def _contains_explicit_vecscope(self, statements: tuple[FrontendStmtNode, ...]) -> bool:
         for stmt in statements:
@@ -3976,6 +4009,10 @@ class _SemanticAnalyzer:
         if namespace is None and name == "range":
             return SemanticCallExpr(namespace=namespace, name=name, args=args, type=None)
         if namespace is None:
+            if name in self._inline_proc_nodes:
+                return self._analyze_inline_proc_call_expr(name, args)
+            if name in self._internal_inline_proc_nodes and self._is_internal_inline_proc_context():
+                return self._analyze_internal_inline_proc_call_expr(name, args)
             raise TypeError(
                 f"call surface `{name}` is not supported in TileLang DSL v1"
             )
@@ -4854,6 +4891,20 @@ class _SemanticAnalyzer:
             raise TypeError(f"pto.{name} requires lhs/rhs vector types to match")
         self._require_mask_for_vreg(mask, lhs, f"pto.{name}")
         self._validate_binary_dtype(name, lhs.element_dtype)
+        if (
+            name in {"vdiv", "vmod"}
+            and is_integer_dtype(lhs.element_dtype)
+            and integer_bitwidth(lhs.element_dtype) in {8, 16, 32}
+        ):
+            return self._analyze_internal_inline_proc_call_expr(
+                "_tl_soft_vdiv" if name == "vdiv" else "_tl_soft_vmod",
+                (
+                    lhs_expr,
+                    rhs_expr,
+                    mask,
+                    self._dtype_symbol_expr(lhs.element_dtype),
+                ),
+            )
         return SemanticCallExpr(namespace="pto", name=name, args=args, type=lhs)
 
     def _analyze_vector_scalar_op(
@@ -5375,6 +5426,14 @@ class _SemanticAnalyzer:
                 return expr.binding.value
             raise TypeError(f"{context} must be a TileLang scalar dtype symbol in TileLang DSL v1")
         return expr.value
+
+    def _dtype_symbol_expr(self, dtype: ScalarType) -> SemanticSymbolExpr:
+        return SemanticSymbolExpr(
+            namespace="pto",
+            name=dtype.name,
+            value=dtype,
+            type=SemanticMetaType(kind="dtype"),
+        )
 
     def _require_memory_space_symbol(self, expr: SemanticExpr, context: str) -> MemorySpace:
         if (
@@ -6180,9 +6239,18 @@ class _SemanticAnalyzer:
 
     def _validate_binary_dtype(self, name: str, dtype: ScalarType) -> None:
         if name == "vdiv" and not (
-            dtype.name in {"f16", "f32"} or (is_integer_dtype(dtype) and integer_bitwidth(dtype) == 16)
+            (is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32})
+            or dtype.name in {"f16", "f32"}
         ):
-            raise TypeError("pto.vdiv only supports f16/f32/i16/ui16 in TileLang DSL v1")
+            raise TypeError(
+                "pto.vdiv only supports 8/16/32-bit integer families and f16/f32 in TileLang DSL v1"
+            )
+        if name == "vmod" and not (
+            is_integer_dtype(dtype) and integer_bitwidth(dtype) in {8, 16, 32}
+        ):
+            raise TypeError(
+                "pto.vmod only supports 8/16/32-bit integer families in TileLang DSL v1"
+            )
         if name == "vprelu" and dtype.name not in {"f16", "f32"}:
             raise TypeError("pto.vprelu only supports f16/f32 in TileLang DSL v1")
         if name in {"vaddreluconv", "vmulconv"} and dtype.name not in {"f16", "bf16", "f32"}:

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -113,6 +113,7 @@ SUPPORTED_VECSCOPE_PTO_CALLS = frozenset(
         "vsub",
         "vmul",
         "vdiv",
+        "vmod",
         "vmax",
         "vmin",
         "vand",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -47,6 +47,7 @@ from tilelang_dsl.semantic import (
     SemanticAlignStoreStmt,
     SemanticAlignType,
     SemanticAssignStmt,
+    SemanticBindingRef,
     SemanticBinaryExpr,
     SemanticCallExpr,
     SemanticDmaConfigStmt,
@@ -65,6 +66,7 @@ from tilelang_dsl.semantic import (
     SemanticPipeBarrierStmt,
     SemanticPtrType,
     SemanticPredicateStoreStmt,
+    SemanticReturnStmt,
     SemanticRlsBufStmt,
     SemanticScalarStoreStmt,
     SemanticScalarType,
@@ -90,6 +92,62 @@ from tilelang_dsl.semantic import (
 
 GLOBAL_TILELANG_LITERAL_BLOCK_SIZE = 32
 INLINE_PROC_GLOBAL_LANE = 0
+
+
+def _walk_semantic_stmts(statements):
+    for stmt in statements:
+        yield stmt
+        if isinstance(stmt, SemanticVecscopeStmt):
+            yield from _walk_semantic_stmts(stmt.body)
+        elif isinstance(stmt, SemanticForStmt):
+            yield from _walk_semantic_stmts(stmt.body)
+        elif isinstance(stmt, SemanticIfStmt):
+            yield from _walk_semantic_stmts(stmt.then_body)
+            yield from _walk_semantic_stmts(stmt.else_body)
+
+
+def _find_inline_helper(semantic_kernel, symbol_prefix):
+    return next(
+        helper for helper in semantic_kernel.inline_helpers if helper.symbol_name.startswith(symbol_prefix)
+    )
+
+
+def _find_helper_assign_by_ssa(helper, ssa_name):
+    return next(
+        stmt
+        for stmt in helper.body
+        if isinstance(stmt, SemanticAssignStmt)
+        and any(target.ssa_name == ssa_name for target in stmt.targets)
+    )
+
+
+def _find_last_helper_assign_by_name(helper, name):
+    return next(
+        stmt
+        for stmt in reversed(helper.body)
+        if isinstance(stmt, SemanticAssignStmt)
+        and any(target.name == name for target in stmt.targets)
+    )
+
+
+def _find_helper_return_stmt(helper):
+    return next(stmt for stmt in helper.body if isinstance(stmt, SemanticReturnStmt))
+
+
+def _resolve_helper_expr(helper, expr):
+    if isinstance(expr, SemanticBindingRef):
+        assign = _find_helper_assign_by_ssa(helper, expr.binding.ssa_name)
+        return _resolve_helper_expr(helper, assign.value)
+    return expr
+
+
+def _resolve_helper_broadcast_scalar_literal(helper, expr):
+    resolved = _resolve_helper_expr(helper, expr)
+    if isinstance(resolved, SemanticLiteralExpr):
+        return resolved.value
+    if isinstance(resolved, SemanticCallExpr) and resolved.namespace == "pto" and resolved.name == "vbr":
+        return _resolve_helper_broadcast_scalar_literal(helper, resolved.args[0])
+    raise AssertionError(f"expected helper scalar literal or broadcast, got {resolved!r}")
 
 
 class TileLangDSLPackageTests(unittest.TestCase):
@@ -419,6 +477,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertIn("pto.vsts", AUTHORING_TIER_SURFACE_GROUPS["base_vector_ops"])
         self.assertIn("pto.vadd", AUTHORING_TIER_SURFACE_GROUPS["base_vector_ops"])
         self.assertIn("pto.vmuls", AUTHORING_TIER_SURFACE_GROUPS["base_vector_ops"])
+        self.assertIn("pto.vmod", AUTHORING_TIER_SURFACE_GROUPS["base_vector_ops"])
         self.assertIn("tile[start:]", BASIC_TILE_INDEXING_SURFACES)
         self.assertIn("tile[row, col:]", BASIC_TILE_INDEXING_SURFACES)
 
@@ -428,6 +487,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertEqual(get_feature_tier("pto.vsts"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vadd"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.vmuls"), BASIC_TIER)
+        self.assertEqual(get_feature_tier("pto.vmod"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.get_buf"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.rls_buf"), BASIC_TIER)
         self.assertEqual(get_feature_tier("pto.get_block_idx"), BASIC_TIER)
@@ -7033,6 +7093,731 @@ class TileLangDSLInlineProcTests(unittest.TestCase):
         self.assertIn("func.call", text)
         self.assertRegex(text, r"= func\.call @__tl_inline_")
         self.assertIn("pto.vsts", text)
+
+    def test_vdiv_integer_vector_types_rewrite_to_internal_helper(self) -> None:
+        @pto.vkernel(op="vdiv_i16_dtype_support_unique", dtypes=[(pto.i16, pto.i16)])
+        def kernel_i16(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        @pto.vkernel(op="vdiv_i32_dtype_support_unique", dtypes=[(pto.i32, pto.i32)])
+        def kernel_i32(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized_i16 = kernel_i16.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i16 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_i16))
+        assign_i16 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i16.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i16.value.namespace)
+        self.assertRegex(assign_i16.value.name, r"^__tl_inline__tl_soft_vdiv_")
+        self.assertEqual(assign_i16.value.type, SemanticVRegType(element_dtype=pto.i16, lanes=128))
+        self.assertGreaterEqual(len(semantic_i16.inline_helpers), 1)
+        self.assertRegex(specialized_i16.mlir_text(), r"func\.call @__tl_inline__tl_soft_vdiv_")
+
+        text_i32 = kernel_i32.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i32 = analyze_frontend_kernel(build_frontend_kernel_node(text_i32))
+        assign_i32 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i32.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i32.value.namespace)
+        self.assertRegex(assign_i32.value.name, r"^__tl_inline__tl_soft_vdiv_")
+        self.assertEqual(assign_i32.value.type, SemanticVRegType(element_dtype=pto.i32, lanes=64))
+        self.assertGreaterEqual(len(semantic_i32.inline_helpers), 1)
+        self.assertRegex(text_i32.mlir_text(), r"func\.call @__tl_inline__tl_soft_vdiv_")
+
+    def test_vdiv_f16_and_f32_vector_types_keep_authoring_form_vpto_path(self) -> None:
+        @pto.vkernel(
+            op="vdiv_float_dtype_support_unique",
+            dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32)],
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        cases = [
+            (pto.f16, 128),
+            (pto.f32, 64),
+        ]
+
+        for dtype, lanes in cases:
+            with self.subTest(dtype=dtype):
+                selected = pto.select_kernel("a5", "vdiv_float_dtype_support_unique", (dtype, dtype))
+                specialized = selected.specialize(
+                    dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                    src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                )
+                semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+
+                assign_stmt = next(
+                    stmt
+                    for stmt in _walk_semantic_stmts(semantic_kernel.body)
+                    if isinstance(stmt, SemanticAssignStmt)
+                    and len(stmt.targets) == 1
+                    and stmt.targets[0].name == "out"
+                    and isinstance(stmt.value, SemanticCallExpr)
+                )
+                self.assertEqual(assign_stmt.value.namespace, "pto")
+                self.assertEqual(assign_stmt.value.name, "vdiv")
+                self.assertEqual(
+                    assign_stmt.value.type,
+                    SemanticVRegType(element_dtype=dtype, lanes=lanes),
+                )
+                self.assertEqual(len(semantic_kernel.inline_helpers), 0)
+
+                text = lower_semantic_kernel(semantic_kernel).render()
+                self.assertEqual(text, specialized.mlir_text())
+                self.assertIn("= pto.vdiv ", text)
+                self.assertNotIn("__tl_inline__tl_soft_vdiv_", text)
+
+    def test_vdiv_i8_and_ui8_vector_types_rewrite_to_internal_helper(self) -> None:
+        @pto.vkernel(op="vdiv_i8_dtype_support_unique", dtypes=[(pto.i8, pto.i8)])
+        def kernel_i8(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.i8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        @pto.vkernel(op="vdiv_ui8_dtype_support_unique", dtypes=[(pto.ui8, pto.ui8)])
+        def kernel_ui8(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.ui8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized_i8 = kernel_i8.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i8 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_i8))
+        assign_i8 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i8.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i8.value.namespace)
+        self.assertRegex(assign_i8.value.name, r"^__tl_inline__tl_soft_vdiv_")
+        self.assertEqual(assign_i8.value.type, SemanticVRegType(element_dtype=pto.i8, lanes=256))
+        self.assertGreaterEqual(len(semantic_i8.inline_helpers), 1)
+        self.assertRegex(specialized_i8.mlir_text(), r"func\.call @__tl_inline__tl_soft_vdiv_")
+
+        specialized_ui8 = kernel_ui8.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_ui8 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_ui8))
+        assign_ui8 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_ui8.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_ui8.value.namespace)
+        self.assertRegex(assign_ui8.value.name, r"^__tl_inline__tl_soft_vdiv_")
+        self.assertEqual(assign_ui8.value.type, SemanticVRegType(element_dtype=pto.ui8, lanes=256))
+        self.assertGreaterEqual(len(semantic_ui8.inline_helpers), 1)
+        self.assertRegex(specialized_ui8.mlir_text(), r"func\.call @__tl_inline__tl_soft_vdiv_")
+
+    def test_vdiv_rejects_bf16_vector_type(self) -> None:
+        @pto.vkernel(op="vdiv_bf16_reject_unique", dtypes=[(pto.bf16, pto.bf16)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.bf16, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            specialized.mlir_text()
+
+        self.assertIn(
+            "pto.vdiv only supports 8/16/32-bit integer families and f16/f32 in TileLang DSL v1",
+            str(ctx.exception),
+        )
+
+    def test_vmod_integer_vector_types_rewrite_to_internal_helper(self) -> None:
+        @pto.vkernel(op="vmod_i16_dtype_support_unique", dtypes=[(pto.i16, pto.i16)])
+        def kernel_i16(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        @pto.vkernel(op="vmod_i32_dtype_support_unique", dtypes=[(pto.i32, pto.i32)])
+        def kernel_i32(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized_i16 = kernel_i16.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i16 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_i16))
+        assign_i16 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i16.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i16.value.namespace)
+        self.assertRegex(assign_i16.value.name, r"^__tl_inline__tl_soft_vmod_")
+        self.assertEqual(assign_i16.value.type, SemanticVRegType(element_dtype=pto.i16, lanes=128))
+        self.assertGreaterEqual(len(semantic_i16.inline_helpers), 1)
+        self.assertRegex(specialized_i16.mlir_text(), r"func\.call @__tl_inline__tl_soft_vmod_")
+
+        specialized_i32 = kernel_i32.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i32 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_i32))
+        assign_i32 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i32.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i32.value.namespace)
+        self.assertRegex(assign_i32.value.name, r"^__tl_inline__tl_soft_vmod_")
+        self.assertEqual(assign_i32.value.type, SemanticVRegType(element_dtype=pto.i32, lanes=64))
+        self.assertGreaterEqual(len(semantic_i32.inline_helpers), 1)
+        self.assertRegex(specialized_i32.mlir_text(), r"func\.call @__tl_inline__tl_soft_vmod_")
+
+    def test_vmod_i8_and_ui8_vector_types_rewrite_to_internal_helper(self) -> None:
+        @pto.vkernel(op="vmod_i8_dtype_support_unique", dtypes=[(pto.i8, pto.i8)])
+        def kernel_i8(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.i8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        @pto.vkernel(op="vmod_ui8_dtype_support_unique", dtypes=[(pto.ui8, pto.ui8)])
+        def kernel_ui8(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.ui8, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized_i8 = kernel_i8.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_i8 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_i8))
+        assign_i8 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_i8.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_i8.value.namespace)
+        self.assertRegex(assign_i8.value.name, r"^__tl_inline__tl_soft_vmod_")
+        self.assertEqual(assign_i8.value.type, SemanticVRegType(element_dtype=pto.i8, lanes=256))
+        self.assertGreaterEqual(len(semantic_i8.inline_helpers), 1)
+        self.assertRegex(specialized_i8.mlir_text(), r"func\.call @__tl_inline__tl_soft_vmod_")
+
+        specialized_ui8 = kernel_ui8.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        semantic_ui8 = analyze_frontend_kernel(build_frontend_kernel_node(specialized_ui8))
+        assign_ui8 = next(
+            stmt
+            for stmt in _walk_semantic_stmts(semantic_ui8.body)
+            if isinstance(stmt, SemanticAssignStmt)
+            and len(stmt.targets) == 1
+            and stmt.targets[0].name == "out"
+            and isinstance(stmt.value, SemanticCallExpr)
+        )
+        self.assertIsNone(assign_ui8.value.namespace)
+        self.assertRegex(assign_ui8.value.name, r"^__tl_inline__tl_soft_vmod_")
+        self.assertEqual(assign_ui8.value.type, SemanticVRegType(element_dtype=pto.ui8, lanes=256))
+        self.assertGreaterEqual(len(semantic_ui8.inline_helpers), 1)
+        self.assertRegex(specialized_ui8.mlir_text(), r"func\.call @__tl_inline__tl_soft_vmod_")
+
+    def test_vmod_rejects_f32_vector_type(self) -> None:
+        @pto.vkernel(op="vmod_f32_reject_unique", dtypes=[(pto.f32, pto.f32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            specialized.mlir_text()
+
+        self.assertIn(
+            "pto.vmod only supports 8/16/32-bit integer families in TileLang DSL v1",
+            str(ctx.exception),
+        )
+
+    def test_integer_divmod_helpers_lock_zero_divisor_sentinel_convention(self) -> None:
+        @pto.vkernel(
+            op="integer_divmod_zero_divisor_contract_unique",
+            dtypes=[
+                (pto.i8, pto.i8),
+                (pto.ui8, pto.ui8),
+                (pto.i16, pto.i16),
+                (pto.ui16, pto.ui16),
+                (pto.i32, pto.i32),
+                (pto.ui32, pto.ui32),
+            ],
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            quot = pto.vdiv(vec, vec, mask)
+            rem = pto.vmod(vec, vec, mask)
+            pto.vsts(quot, dst, 0, mask)
+            pto.vsts(rem, dst, 0, mask)
+            return None
+
+        cases = [
+            ("vdiv", pto.i8, "__tl_inline__tl_soft_vdiv_i8_", -1),
+            ("vdiv", pto.ui8, "__tl_inline__tl_soft_vdiv_u8_", 0xFF),
+            ("vdiv", pto.i16, "__tl_inline__tl_soft_vdiv_i16_", -1),
+            ("vdiv", pto.ui16, "__tl_inline__tl_soft_vdiv_u16_", 0xFFFF),
+            ("vdiv", pto.i32, "__tl_inline__tl_soft_vdiv_i32_", -1),
+            ("vdiv", pto.ui32, "__tl_inline__tl_soft_vdiv_u32_", 0xFFFFFFFF),
+            ("vmod", pto.i8, "__tl_inline__tl_soft_vmod_i8_", -1),
+            ("vmod", pto.ui8, "__tl_inline__tl_soft_vmod_u8_", 0xFF),
+            ("vmod", pto.i16, "__tl_inline__tl_soft_vmod_i16_", -1),
+            ("vmod", pto.ui16, "__tl_inline__tl_soft_vmod_u16_", 0xFFFF),
+            ("vmod", pto.i32, "__tl_inline__tl_soft_vmod_i32_", -1),
+            ("vmod", pto.ui32, "__tl_inline__tl_soft_vmod_u32_", 0xFFFFFFFF),
+        ]
+
+        for op_name, dtype, helper_prefix, expected_sentinel in cases:
+            with self.subTest(op=op_name, dtype=dtype):
+                selected = pto.select_kernel(
+                    "a5",
+                    "integer_divmod_zero_divisor_contract_unique",
+                    (dtype, dtype),
+                )
+                specialized = selected.specialize(
+                    dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                    src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                )
+                semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+                helper = _find_inline_helper(semantic_kernel, helper_prefix)
+
+                zero_mask_assign = _find_last_helper_assign_by_name(helper, "zero_mask")
+                self.assertIsInstance(zero_mask_assign.value, SemanticCallExpr)
+                self.assertEqual(zero_mask_assign.value.namespace, "pto")
+                self.assertEqual(zero_mask_assign.value.name, "vcmps")
+                self.assertEqual(zero_mask_assign.value.args[3].value, "eq")
+                self.assertEqual(
+                    _resolve_helper_broadcast_scalar_literal(helper, zero_mask_assign.value.args[1]),
+                    0,
+                )
+
+                return_stmt = _find_helper_return_stmt(helper)
+                self.assertIsInstance(return_stmt.value, SemanticCallExpr)
+                self.assertEqual(return_stmt.value.namespace, "pto")
+                self.assertEqual(return_stmt.value.name, "vsel")
+                self.assertIsInstance(return_stmt.value.args[2], SemanticBindingRef)
+                self.assertEqual(return_stmt.value.args[2].binding.name, "zero_mask")
+                self.assertEqual(
+                    _resolve_helper_broadcast_scalar_literal(helper, return_stmt.value.args[0]),
+                    expected_sentinel,
+                )
+
+    def test_signed_vdiv_helpers_derive_result_sign_from_operand_signs(self) -> None:
+        @pto.vkernel(
+            op="signed_vdiv_sign_contract_unique",
+            dtypes=[(pto.i16, pto.i16), (pto.i32, pto.i32)],
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vdiv(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        cases = [
+            (pto.i16, "__tl_inline__tl_soft_vdiv_i16_", "i16"),
+            (pto.i32, "__tl_inline__tl_soft_vdiv_i32_", "i32"),
+        ]
+
+        for dtype, helper_prefix, dtype_name in cases:
+            with self.subTest(dtype=dtype):
+                selected = pto.select_kernel("a5", "signed_vdiv_sign_contract_unique", (dtype, dtype))
+                specialized = selected.specialize(
+                    dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                    src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                )
+                semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+                helper = _find_inline_helper(semantic_kernel, helper_prefix)
+
+                xor_assign = _find_last_helper_assign_by_name(helper, "x_xor_y")
+                self.assertIsInstance(xor_assign.value, SemanticCallExpr)
+                self.assertEqual(xor_assign.value.namespace, "pto")
+                self.assertEqual(xor_assign.value.name, "vxor")
+                self.assertEqual(xor_assign.value.args[0].binding.name, "vec")
+                self.assertEqual(xor_assign.value.args[1].binding.name, "scalar_vec")
+                self.assertEqual(xor_assign.value.args[2].binding.name, "active_mask")
+
+                p_pos_assign = _find_last_helper_assign_by_name(helper, "p_pos")
+                self.assertIsInstance(p_pos_assign.value, SemanticCallExpr)
+                self.assertEqual(p_pos_assign.value.namespace, "pto")
+                self.assertEqual(p_pos_assign.value.name, "vcmps")
+                self.assertEqual(p_pos_assign.value.args[0].binding.name, "x_xor_y")
+                self.assertEqual(p_pos_assign.value.args[1].binding.name, "zero")
+                self.assertEqual(p_pos_assign.value.args[2].binding.name, "active_mask")
+                self.assertEqual(p_pos_assign.value.args[3].value, "ge")
+
+                q_assign = _find_last_helper_assign_by_name(helper, "q")
+                self.assertIsInstance(q_assign.value, SemanticCallExpr)
+                self.assertEqual(q_assign.value.namespace, "pto")
+                self.assertEqual(q_assign.value.name, "vsel")
+                self.assertEqual(q_assign.value.args[1].binding.name, "neg_q")
+                self.assertEqual(q_assign.value.args[2].binding.name, "p_pos")
+                self.assertIsInstance(q_assign.value.args[0], SemanticCallExpr)
+                self.assertEqual(q_assign.value.args[0].namespace, "pto")
+                self.assertEqual(q_assign.value.args[0].name, "vbitcast")
+                self.assertIsInstance(q_assign.value.args[0].args[0], SemanticBindingRef)
+                self.assertEqual(q_assign.value.args[0].args[1].name, dtype_name)
+
+    def test_signed_vmod_helpers_apply_floor_fix_when_signs_differ(self) -> None:
+        @pto.vkernel(
+            op="signed_vmod_sign_contract_unique",
+            dtypes=[(pto.i16, pto.i16), (pto.i32, pto.i32)],
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            out = pto.vmod(vec, vec, mask)
+            pto.vsts(out, dst, 0, mask)
+            return None
+
+        cases = [
+            (pto.i16, "__tl_inline__tl_soft_vmod_i16_"),
+            (pto.i32, "__tl_inline__tl_soft_vmod_i32_"),
+        ]
+
+        for dtype, helper_prefix in cases:
+            with self.subTest(dtype=dtype):
+                selected = pto.select_kernel("a5", "signed_vmod_sign_contract_unique", (dtype, dtype))
+                specialized = selected.specialize(
+                    dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                    src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                )
+                semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+                helper = _find_inline_helper(semantic_kernel, helper_prefix)
+
+                nonzero_assign = _find_last_helper_assign_by_name(helper, "nonzero_remainder")
+                self.assertIsInstance(nonzero_assign.value, SemanticCallExpr)
+                self.assertEqual(nonzero_assign.value.namespace, "pto")
+                self.assertEqual(nonzero_assign.value.name, "vcmps")
+                self.assertEqual(nonzero_assign.value.args[1].binding.name, "zero")
+                self.assertEqual(nonzero_assign.value.args[2].binding.name, "active_mask")
+                self.assertEqual(nonzero_assign.value.args[3].value, "ne")
+
+                sign_diff_assign = _find_last_helper_assign_by_name(helper, "sign_diff")
+                self.assertIsInstance(sign_diff_assign.value, SemanticCallExpr)
+                self.assertEqual(sign_diff_assign.value.namespace, "pto")
+                self.assertEqual(sign_diff_assign.value.name, "pxor")
+                self.assertEqual(sign_diff_assign.value.args[0].binding.name, "sign_x")
+                self.assertEqual(sign_diff_assign.value.args[1].binding.name, "sign_y")
+                self.assertEqual(sign_diff_assign.value.args[2].binding.name, "active_mask")
+
+                need_fix_assign = _find_last_helper_assign_by_name(helper, "need_floor_fix")
+                self.assertIsInstance(need_fix_assign.value, SemanticCallExpr)
+                self.assertEqual(need_fix_assign.value.namespace, "pto")
+                self.assertEqual(need_fix_assign.value.name, "pand")
+                self.assertEqual(need_fix_assign.value.args[0].binding.name, "sign_diff")
+                self.assertEqual(need_fix_assign.value.args[1].binding.name, "nonzero_remainder")
+                self.assertEqual(need_fix_assign.value.args[2].binding.name, "active_mask")
+
+                amended_assign = _find_last_helper_assign_by_name(helper, "amended_remainder")
+                self.assertIsInstance(amended_assign.value, SemanticCallExpr)
+                self.assertEqual(amended_assign.value.namespace, "pto")
+                self.assertEqual(amended_assign.value.name, "vadd")
+                self.assertEqual(amended_assign.value.args[0].binding.name, "scalar_vec")
+                self.assertEqual(amended_assign.value.args[1].binding.name, "remainder")
+                self.assertEqual(amended_assign.value.args[2].binding.name, "active_mask")
+
+                remainder_assign = _find_last_helper_assign_by_name(helper, "remainder")
+                self.assertIsInstance(remainder_assign.value, SemanticCallExpr)
+                self.assertEqual(remainder_assign.value.namespace, "pto")
+                self.assertEqual(remainder_assign.value.name, "vsel")
+                self.assertEqual(remainder_assign.value.args[0].binding.name, "amended_remainder")
+                self.assertEqual(remainder_assign.value.args[2].binding.name, "need_floor_fix")
+
+    def test_i8_divmod_helpers_use_explicit_widen_narrow_profile(self) -> None:
+        @pto.vkernel(
+            op="i8_divmod_widen_narrow_contract_unique",
+            dtypes=[
+                (pto.i8, pto.i8),
+                (pto.ui8, pto.ui8),
+            ],
+        )
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            dtype = dst.element_type
+            mask = pto.make_mask(dtype, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            quot = pto.vdiv(vec, vec, mask)
+            rem = pto.vmod(vec, vec, mask)
+            pto.vsts(quot, dst, 0, mask)
+            pto.vsts(rem, dst, 1, mask)
+            return None
+
+        cases = [
+            (
+                pto.i8,
+                "__tl_inline__tl_soft_vdiv_i8_",
+                "__tl_inline__tl_soft_vdiv_i16_",
+                "vsunpack",
+                "q",
+                "q_low",
+                "q_high",
+                "vbitcast",
+            ),
+            (
+                pto.ui8,
+                "__tl_inline__tl_soft_vdiv_u8_",
+                "__tl_inline__tl_soft_vdiv_u16_",
+                "vzunpack",
+                "q",
+                "q_low",
+                "q_high",
+                "vor",
+            ),
+            (
+                pto.i8,
+                "__tl_inline__tl_soft_vmod_i8_",
+                "__tl_inline__tl_soft_vmod_i16_",
+                "vsunpack",
+                "r",
+                "r_low",
+                "r_high",
+                "vbitcast",
+            ),
+            (
+                pto.ui8,
+                "__tl_inline__tl_soft_vmod_u8_",
+                "__tl_inline__tl_soft_vmod_u16_",
+                "vzunpack",
+                "r",
+                "r_low",
+                "r_high",
+                "vor",
+            ),
+        ]
+
+        for (
+            dtype,
+            helper_prefix,
+            widened_helper_prefix,
+            unpack_name,
+            packed_result_name,
+            lower_result_name,
+            higher_result_name,
+            packed_result_op,
+        ) in cases:
+            with self.subTest(dtype=dtype, helper=helper_prefix):
+                selected = pto.select_kernel(
+                    "a5",
+                    "i8_divmod_widen_narrow_contract_unique",
+                    (dtype, dtype),
+                )
+                specialized = selected.specialize(
+                    dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                    src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+                )
+                semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+                helper = _find_inline_helper(semantic_kernel, helper_prefix)
+
+                active_low_assign = _find_last_helper_assign_by_name(helper, "active_low")
+                self.assertIsInstance(active_low_assign.value, SemanticCallExpr)
+                self.assertEqual(active_low_assign.value.namespace, "pto")
+                self.assertEqual(active_low_assign.value.name, "punpack")
+                self.assertEqual(active_low_assign.value.args[0].binding.name, "active_mask")
+
+                active_high_assign = _find_last_helper_assign_by_name(helper, "active_high")
+                self.assertIsInstance(active_high_assign.value, SemanticCallExpr)
+                self.assertEqual(active_high_assign.value.namespace, "pto")
+                self.assertEqual(active_high_assign.value.name, "punpack")
+                self.assertEqual(active_high_assign.value.args[0].binding.name, "active_mask")
+
+                for name, expected_half in (
+                    ("vec_low", 0),
+                    ("vec_high", 1),
+                    ("scalar_low", 0),
+                    ("scalar_high", 1),
+                ):
+                    assign = _find_last_helper_assign_by_name(helper, name)
+                    self.assertIsInstance(assign.value, SemanticCallExpr)
+                    self.assertEqual(assign.value.namespace, "pto")
+                    self.assertEqual(assign.value.name, unpack_name)
+                    self.assertEqual(assign.value.args[1].value, expected_half)
+
+                lower_assign = _find_last_helper_assign_by_name(helper, lower_result_name)
+                self.assertIsInstance(lower_assign.value, SemanticCallExpr)
+                self.assertIsNone(lower_assign.value.namespace)
+                self.assertRegex(lower_assign.value.name, rf"^{widened_helper_prefix}")
+                self.assertEqual(lower_assign.value.args[2].binding.name, "active_low")
+
+                higher_assign = _find_last_helper_assign_by_name(helper, higher_result_name)
+                self.assertIsInstance(higher_assign.value, SemanticCallExpr)
+                self.assertIsNone(higher_assign.value.namespace)
+                self.assertRegex(higher_assign.value.name, rf"^{widened_helper_prefix}")
+                self.assertEqual(higher_assign.value.args[2].binding.name, "active_high")
+
+                packed_low_assign = _find_last_helper_assign_by_name(helper, "packed_low")
+                self.assertIsInstance(packed_low_assign.value, SemanticCallExpr)
+                self.assertEqual(packed_low_assign.value.namespace, "pto")
+                self.assertEqual(packed_low_assign.value.name, "vpack")
+                self.assertEqual(packed_low_assign.value.args[0].binding.name, lower_result_name)
+
+                packed_high_assign = _find_last_helper_assign_by_name(helper, "packed_high")
+                self.assertIsInstance(packed_high_assign.value, SemanticCallExpr)
+                self.assertEqual(packed_high_assign.value.namespace, "pto")
+                self.assertEqual(packed_high_assign.value.name, "vpack")
+                self.assertEqual(packed_high_assign.value.args[0].binding.name, higher_result_name)
+
+                packed_result_assign = _find_last_helper_assign_by_name(helper, packed_result_name)
+                self.assertIsInstance(packed_result_assign.value, SemanticCallExpr)
+                self.assertEqual(packed_result_assign.value.namespace, "pto")
+                self.assertEqual(packed_result_assign.value.name, packed_result_op)
+                if packed_result_op == "vor":
+                    combined_expr = packed_result_assign.value
+                else:
+                    self.assertIsInstance(packed_result_assign.value.args[0], SemanticCallExpr)
+                    combined_expr = packed_result_assign.value.args[0]
+                    self.assertEqual(combined_expr.namespace, "pto")
+                    self.assertEqual(combined_expr.name, "vor")
+                self.assertEqual(combined_expr.args[0].binding.name, "packed_low")
+                self.assertEqual(combined_expr.args[1].binding.name, "packed_high")
+                self.assertEqual(combined_expr.args[2].binding.name, "full_mask_b8")
+
+    def test_integer_divmod_rewrite_uses_injected_internal_helpers(self) -> None:
+        @pto.vkernel(op="divmod_internal_helper_injection_unique", dtypes=[(pto.i32, pto.i32)])
+        def kernel(dst: pto.Tile, src: pto.Tile):
+            mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+            vec = pto.vlds(src, 0)
+            quot = pto.vdiv(vec, vec, mask)
+            rem = pto.vmod(vec, vec, mask)
+            pto.vsts(quot, dst, 0, mask)
+            pto.vsts(rem, dst, 1, mask)
+            return None
+
+        self.assertNotIn("vdiv", kernel.py_fn.__globals__)
+        self.assertNotIn("vmod", kernel.py_fn.__globals__)
+        self.assertNotIn("_tl_soft_vdiv_i32", kernel.inline_procs)
+        self.assertNotIn("_tl_soft_vmod_i32", kernel.inline_procs)
+
+        specialized = kernel.specialize(
+            dst=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+            src=pto.TileSpecialization(shape=(8, 16), memory_space=pto.MemorySpace.UB),
+        )
+        frontend_kernel = build_frontend_kernel_node(specialized)
+
+        self.assertEqual({proc.name for proc in frontend_kernel.inline_procs}, set())
+        internal_names = {proc.name for proc in frontend_kernel.internal_inline_procs}
+        self.assertIn("_tl_soft_vdiv", internal_names)
+        self.assertIn("_tl_soft_vmod", internal_names)
+        self.assertIn("_tl_soft_vdiv_i32", internal_names)
+        self.assertIn("_tl_soft_vmod_i32", internal_names)
+
+        semantic_kernel = analyze_frontend_kernel(frontend_kernel)
+        helper_symbols = {helper.symbol_name for helper in semantic_kernel.inline_helpers}
+        self.assertTrue(any(name.startswith("__tl_inline__tl_soft_vdiv_") for name in helper_symbols))
+        self.assertTrue(any(name.startswith("__tl_inline__tl_soft_vmod_") for name in helper_symbols))
+
+    def test_internal_vdiv_helper_name_is_not_public_surface(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="internal_vdiv_helper_reject_unique", dtypes=[(pto.i32, pto.i32)])
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = _tl_soft_vdiv_i32(vec, vec, mask)
+                pto.vsts(out, dst, 0, mask)
+                return None
+
+        self.assertIn(
+            "arbitrary external call `_tl_soft_vdiv_i32` is not supported in TileLang DSL v1",
+            str(ctx.exception),
+        )
+
+    def test_internal_vmod_helper_name_is_not_public_surface(self) -> None:
+        with self.assertRaises(pto.TileLangFrontendError) as ctx:
+
+            @pto.vkernel(op="internal_vmod_helper_reject_unique", dtypes=[(pto.i32, pto.i32)])
+            def kernel(dst: pto.Tile, src: pto.Tile):
+                mask = pto.make_mask(pto.i32, pto.PAT.ALL)
+                vec = pto.vlds(src, 0)
+                out = _tl_soft_vmod_i32(vec, vec, mask)
+                pto.vsts(out, dst, 0, mask)
+                return None
+
+        self.assertIn(
+            "arbitrary external call `_tl_soft_vmod_i32` is not supported in TileLang DSL v1",
+            str(ctx.exception),
+        )
 
     def test_inline_proc_and_pto_surface_can_share_basename(self) -> None:
         @pto.inline_proc

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -482,6 +482,17 @@ static bool hasUnexpandedTileOps(ModuleOp module) {
   return found;
 }
 
+static bool hasTilelangInlineHelpers(ModuleOp module) {
+  bool found = false;
+  module.walk([&](func::FuncOp func) {
+    if (found)
+      return;
+    if (func->hasAttr("pto.tilelang.inline_proc"))
+      found = true;
+  });
+  return found;
+}
+
 // --------------------------------------------------------------------------
 // Post-process C++ output: rewrite marker calls into Tile member calls.
 //
@@ -1177,6 +1188,21 @@ static LogicalResult lowerPTOToVPTOBackend(ModuleOp module) {
   return success();
 }
 
+static LogicalResult inlineTilelangHelpersOnVPTOInput(ModuleOp module) {
+  PassManager inlinePM(module.getContext());
+  inlinePM.addPass(pto::createPTOInlineLibCallPass());
+  inlinePM.addPass(mlir::createSCCPPass());
+  inlinePM.addPass(mlir::createCanonicalizerPass());
+  if (failed(applyConfiguredPassManagerCLOptions(
+          inlinePM, "VPTO TileLang helper inlining")))
+    return failure();
+  if (failed(inlinePM.run(module))) {
+    llvm::errs() << "Error: VPTO TileLang helper inlining failed.\n";
+    return failure();
+  }
+  return success();
+}
+
 static pto::VPTOEmissionOptions buildVPTOEmissionOptions() {
   pto::VPTOEmissionOptions options;
   options.dumpVPTOIR = false;
@@ -1485,6 +1511,7 @@ int main(int argc, char **argv) {
   }
 
   const bool hasTileOpsToExpand = hasUnexpandedTileOps(*module);
+  const bool hasTilelangHelpers = hasTilelangInlineHelpers(*module);
 
   if (effectiveBackend == PTOBackend::VPTO && inputIsVPTOIR &&
       !hasTileOpsToExpand) {
@@ -1493,6 +1520,10 @@ int main(int argc, char **argv) {
                       "the input is already VPTO IR.\n";
       return 1;
     }
+
+    if (hasTilelangHelpers &&
+        failed(inlineTilelangHelpersOnVPTOInput(*module)))
+      return 1;
 
     return emitVPTOBackendResult(*module, outputFile);
   }


### PR DESCRIPTION
## Summary
- unify TileLang DSL vector div/mod public surface around `pto.vdiv` and `pto.vmod`
- keep `f16`/`f32` `pto.vdiv` on the existing VPTO authoring-form path, while lowering integer `vdiv` through internal soft helpers
- add `pto.vmod` public surface for integer 8/16/32-bit families and lower it through internal soft helpers instead of exposing helper names to users
- complete `i8`/`ui8` soft `vdiv`/`vmod` support with an explicit widen -> soft compute -> narrow profile
- ensure integer soft helper calls are absorbed by the existing backend-inline mainline so helper names do not leak into the final public contract
- refresh DSL tests, backend regression tests, user guide, and OpenSpec change docs for the div/mod surface and lowering contract

## What Changed
- frontend / semantic
  - add dtype-directed `pto.vdiv` lowering: `f16`/`f32` stay as public `pto.vdiv`, integer families rewrite to internal soft helpers
  - add `pto.vmod` public surface plus dtype validation
  - inject internal soft helper library automatically so kernels do not need to import helper names explicitly
  - reject direct use of `_tl_soft_vdiv_*` / `_tl_soft_vmod_*` as non-public DSL surface
- soft helper implementation
  - reorganize integer `vdiv` / `vmod` helpers in `lib/TileOps/math.py` as internal-only implementation details
  - add `i8` / `ui8` helper paths using widen -> soft div/mod -> narrow
  - lock zero-divisor sentinel behavior and signed div/mod sign conventions in DSL tests
- lowering / backend
  - preserve floating-point `pto.vdiv` on the existing VPTO path
  - add regression coverage that integer helper-based `vdiv` / `vmod` lowerings converge through backend inline cleanup
  - fix the VPTO fast-path so TileLang inline soft div/mod helpers are still inlined when the input module is already recognized as VPTO IR
- docs / spec
  - add and validate the OpenSpec change `hide-soft-divmod-behind-pto-surface`
  - update the vector arithmetic user guide to document public `pto.vdiv` / `pto.vmod` contract and supported dtypes

## Validation
- `PYTHONPATH=tilelang-dsl/python:tilelang-dsl/tests python3 -m unittest test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vdiv_integer_vector_types_rewrite_to_internal_helper test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vdiv_f16_and_f32_vector_types_keep_authoring_form_vpto_path test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vdiv_i8_and_ui8_vector_types_rewrite_to_internal_helper test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vdiv_rejects_bf16_vector_type test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vmod_integer_vector_types_rewrite_to_internal_helper test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vmod_i8_and_ui8_vector_types_rewrite_to_internal_helper test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_vmod_rejects_f32_vector_type test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_integer_divmod_helpers_lock_zero_divisor_sentinel_convention test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_signed_vdiv_helpers_derive_result_sign_from_operand_signs test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_signed_vmod_helpers_apply_floor_fix_when_signs_differ test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_i8_divmod_helpers_use_explicit_widen_narrow_profile test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_integer_divmod_rewrite_uses_injected_internal_helpers test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_internal_vdiv_helper_name_is_not_public_surface test_tilelang_dsl_v1.TileLangDSLInlineProcTests.test_internal_vmod_helper_name_is_not_public_surface`
- `PTOAS_BIN=/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas /home/zhangzhendong/.local/bin/lit -sv test/vpto_tilelang_inline_soft_divmod_fastpath.pto test/basic/tilelang_soft_vmod_backend_inline.pto`
- `openspec validate hide-soft-divmod-behind-pto-surface --type change --strict --json --no-interactive`

## Notes
- this PR has grown beyond the original issue-267-only `vdiv` surface update and now also covers the `vmod` public surface plus the shared soft-helper/backend-inline contract
- there are unrelated untracked files in the local workspace; they are not part of this PR update

Closes #267
Closes #270 
