### PR TITLE
Support cross-file TileLang inline_proc imports

### DIFF
--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/design.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/design.md
@@ -1,0 +1,169 @@
+## Context
+
+### 范围
+
+本 design 覆盖 TileLang DSL 模板库中的跨文件 `@pto.inline_proc` helper 复用：
+
+- 模板目录扫描和 Python import 搜索路径。
+- `from shared_helper import helper` 形式导入的 `InlineProcDescriptor` 收集。
+- 导入 helper 的 frontend AST 构建、semantic 分析和 lowering。
+- 导入 helper 的 backend-inline 收敛验证。
+
+它不覆盖：
+
+- high precision divide 的算法实现。
+- 普通 Python 函数的静态分析或自动内联。
+- 模块限定调用 `shared_helper.helper(...)`。
+- 任意第三方 Python 包作为 DSL helper 源。
+
+### 当前状态
+
+当前仓库已有以下事实：
+
+1. `@pto.inline_proc` 可以注册 source-visible helper，并由 `vkernel` 收集。
+2. `vkernel` 当前会收集当前模块内可见的 `InlineProcDescriptor`，包括从其它模块导入后绑定到当前模块 globals 的 descriptor。
+3. `frontend_ast` 已能把 reachable inline proc 构造成 `FrontendInlineProcNode`，并处理 helper 互调、递归检测与 capture 校验。
+4. `lowering` 已能把 inline helper 合并到输出 module，并标记 `pto.tilelang.inline_proc`。
+5. `expand_helper` 负责扫描 `--template-dir` 下的 `.py` 文件，但模板 import 搜索路径和跨文件 helper 契约尚未正式冻结。
+
+因此，本 change 优先补齐模板 import 环境、诊断和测试契约，而不是新建一套 helper lowering 机制。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 让模板文件可以直接导入同目录共享 helper 文件中的 `@pto.inline_proc`。
+- 让导入 helper 与当前文件 helper 走同一套 frontend/semantic/lowering/backend-inline 主线。
+- 保持 DSL 静态可分析边界：只有 `@pto.inline_proc` helper 被当作可调用 DSL helper。
+- 用轻量 helper 建立回归测试，不引入 high precision 算法复杂度。
+
+**Non-Goals:**
+
+- 不支持普通 Python 函数作为 DSL helper。
+- 不支持用户在 DSL body 中调用 arbitrary external function。
+- 不支持 `**kwargs` unpacking、varargs、递归等现有 `inline_proc` 禁止行为。
+- 不要求公共 helper 文件本身包含 `@pto.vkernel`。
+
+## Decisions
+
+### 1. 首期支持直接导入后的简单名字调用
+
+决策：
+
+- 支持如下形式：
+
+```python
+from shared_helper import shared_op
+
+@pto.vkernel(target="a5", op="pto.some_op")
+def template(src: pto.Tile, dst: pto.Tile):
+    ...
+    out = shared_op(lhs, rhs, mask)
+```
+
+- 暂不把 `import shared_helper; shared_helper.shared_op(...)` 纳入首期 contract。
+
+原因：
+
+- 当前 frontend call model 以简单名字匹配 inline proc，直接导入可以复用既有实现。
+- 模块限定调用需要扩展 `ast.Attribute` 解析、helper identity 和同名冲突处理，适合作为后续增量。
+
+### 2. 共享 helper 必须由 `@pto.inline_proc` 装饰
+
+决策：
+
+- 公共文件中的可复用 helper MUST 是 source-visible top-level `@pto.inline_proc`。
+- 普通 Python 函数即便被 import，也 MUST 继续按 unsupported external call 处理。
+
+原因：
+
+- DSL lowering 需要读取 helper AST 并生成受控 IR。
+- 放开普通 Python 函数会破坏当前受限 Python 子集和静态分析边界。
+
+### 3. `expand_helper` 提供模板目录级 import context
+
+决策：
+
+- 在扫描 `--template-dir` 时，helper 进程 SHOULD 临时把以下路径加入 import 搜索：
+  - `template_dir`
+  - `template_dir.parent`
+- 这样同时支持：
+  - `from shared_helper import helper`
+  - `from TileOps.shared_helper import helper`
+
+原因：
+
+- issue 示例使用裸模块名导入。
+- 当前 `lib/TileOps` 下已有 `__init__.py`，保留 package import 形式有利于兼容现有布局。
+
+### 4. 导入 helper 与本文件 helper 使用同一 lowering contract
+
+决策：
+
+- frontend MUST 将导入 helper 纳入当前 kernel 的 reachable inline proc 集合。
+- semantic MUST 对导入 helper 按参数类型和静态值生成必要 specializations。
+- lowering MUST emit private `func.func ... attributes { pto.tilelang.inline_proc }`。
+- 后续 backend-inline MUST 能消除 helper call 和 helper function。
+
+原因：
+
+- 用户只需要关心 helper 能否复用，不应观察到“本文件 helper”和“跨文件 helper”在 IR contract 上有差异。
+
+### 5. 同名 helper 冲突应 fail fast
+
+决策：
+
+- 如果当前模板模块通过多个来源暴露了同名 `@pto.inline_proc` helper，frontend SHOULD 报出明确诊断，而不是静默选择一个。
+
+原因：
+
+- 当前 call surface 以简单名字调用，静默覆盖会让模板行为依赖 import 顺序。
+- 在没有引入 qualified helper identity 前，重复名字最好被显式拒绝。
+
+## 测试策略
+
+- Python/frontend 单测：
+  - 临时模板目录中创建 `shared_helper.py` 和 `import_user_template.py`。
+  - `shared_helper.py` 定义简单 `@pto.inline_proc`，例如返回 `pto.vadd(lhs, rhs, mask)` 或简单 pass-through。
+  - 模板通过 `from shared_helper import helper` 调用。
+  - 断言 descriptor 能被 `expand_helper` 找到，`build_frontend_kernel_node()` 包含导入 helper。
+  - 断言 `mlir_text()` 中出现 `pto.tilelang.inline_proc` 和对应 helper call。
+- Helper 互调单测：
+  - 共享文件中 `helper_a()` 调用 `helper_b()`。
+  - 模板只 import `helper_a()`。
+  - 断言 `helper_b()` 也被纳入 reachable helper materialization。
+- 负向单测：
+  - import 普通 Python 函数后调用，仍按 arbitrary external call 报错。
+  - 导入 helper 递归或互递归，仍报 recursive inline_proc。
+  - 导入 helper 非法捕获动态值，仍报 implicit capture。
+  - 同名 helper 冲突报明确错误。
+- lit / end-to-end 回归：
+  - 新增一个小型 TileOp/template case，只验证跨文件 helper 被调用和内联。
+  - FileCheck `pto-inline-libcall` 后不残留 inline helper call/function。
+
+## Risks / Trade-offs
+
+- [Risk] 把 `template_dir` 加入 `sys.path` 可能与标准库或第三方模块同名冲突  
+  Mitigation：只在 `expand_helper` 扫描模板期间使用 scoped import context，并在文档中建议共享 helper 文件避免使用标准库同名文件名。
+
+- [Risk] 简单名字调用可能遇到同名 helper 冲突  
+  Mitigation：首期 fail fast；后续若需要再支持 qualified call。
+
+- [Risk] 测试若直接使用 high precision div 会把算法风险混入 import 能力验证  
+  Mitigation：本 change 明确只使用轻量 helper 验证跨文件引用，不实现 high precision 算法。
+
+## Migration Plan
+
+1. 先冻结 OpenSpec contract，明确跨文件 helper 的支持形式和非目标。
+2. 在 `expand_helper` 中补模板目录 scoped import context。
+3. 补 frontend/diagnostic 对导入 helper、冲突和负向场景的测试。
+4. 补一个端到端回归，验证导入 helper materialize 并被 backend inline 消除。
+5. 更新 TileLang DSL 用户文档，说明共享 helper 写法和限制。
+
+## Open Questions
+
+- 后续是否需要支持 `import shared_helper; shared_helper.helper(...)` qualified call。  
+  本 change 暂不承诺，优先完成直接导入形式。
+
+- 是否需要为共享 helper 建立专门的 `lib/TileOps/shared/` 子目录。  
+  本 change 不强制目录结构，只要求 template-dir import contract 稳定。

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/proposal.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/proposal.md
@@ -1,0 +1,109 @@
+# Proposal: 支持 TileLang DSL 模板跨文件复用 `@pto.inline_proc`
+
+## 概述
+
+当前 TileLang DSL 模板已经支持在单个模板文件内定义并调用 `@pto.inline_proc` helper。  
+Issue #190 提出的新需求是：多个模板文件需要复用同一份可被 DSL 前端分析和 lowering 的公共 helper，例如未来的 high-precision divide 逻辑应该只维护一份，而不是在 `trowexpanddiv`、`tcolexpanddiv`、`trsqrt` 等模板里重复实现。
+
+本 change 只落定并验证“跨文件引用函数生效”这条能力：
+
+- 公共文件中定义 `@pto.inline_proc` helper。
+- 模板文件通过 Python import 引入该 helper。
+- DSL frontend / semantic / lowering 能把导入的 helper 纳入当前 `vkernel` 实例化。
+- 输出 MLIR 中出现 private inline-proc helper，并继续通过既有 backend-inline 主线收敛。
+
+本 change 不实现 high precision divide 算法本身；测试可以使用简单 helper 验证跨文件接线。
+
+## 背景与动机
+
+DIV/EXP 类模板后续会有公共近似或高精度算法需求。如果每个 TileOp 模板各自复制一份 helper，会带来：
+
+1. 模板文件膨胀，review 成本变高。
+2. 同一算法多处维护，修复容易遗漏。
+3. DSL 现有 `inline_proc` 能力被限制在单文件使用，无法成为模板库级公共机制。
+
+当前实现中已经有可复用基础：
+
+- `@pto.inline_proc` 可以描述可分析 helper。
+- `vkernel` descriptor 会收集当前模块可见的 inline proc。
+- frontend AST、semantic 和 lowering 已能 materialize inline helper。
+- 后端已有 `pto.tilelang.inline_proc` 的 inline 主线。
+
+缺口主要在模板加载和 import contract：`expand_helper` 扫描模板目录时，需要让模板文件可以稳定 import 同目录或模板包内的共享 helper，并把导入的 `InlineProcDescriptor` 纳入当前 kernel。
+
+## 目标
+
+- 支持模板文件直接导入同一 template-dir 中定义的 `@pto.inline_proc` helper。
+- 支持公共 helper 内部继续调用同文件中其它 `@pto.inline_proc` helper。
+- 保持跨文件 helper 与单文件 helper 相同的 frontend diagnostics、semantic lowering 和 backend-inline 行为。
+- 增加针对跨文件 import 的单测和定向 end-to-end 回归。
+- 在文档中说明共享 helper 的支持形式和限制。
+
+## 非目标
+
+- 不实现 high precision divide / exp / rsqrt 等具体算法。
+- 不支持任意普通 Python 函数作为 DSL helper。
+- 不承诺 `import shared; shared.helper(...)` 形式；首期以 `from shared import helper` 的直接导入调用为正式支持形式。
+- 不设计新的 public helper namespace。
+- 不改变现有 `@pto.inline_proc` 的语法限制、递归限制、capture 规则或 backend-inline pass。
+
+## What Changes
+
+- `tilelang-dsl-surface`：
+  - 明确 TileLang DSL 模板 MAY 从同一模板目录或模板包导入 `@pto.inline_proc` helper。
+  - 明确首期支持直接导入后的简单名字调用，例如 `from shared_div import high_precision_div` 后调用 `high_precision_div(...)`。
+  - 明确普通 Python 函数 import 不属于 DSL 可分析 helper surface。
+- `tilelang-dsl-diagnostics`：
+  - 明确跨文件导入 helper 仍使用现有 `inline_proc` 诊断规则。
+  - 明确普通外部函数、不可见 helper、递归 helper、非法 capture、重复 helper 名等错误需要 fail fast。
+- `tilelang-dsl-vpto-lowering`：
+  - 明确跨文件导入的 helper MUST materialize 为 private inline-proc helper function。
+  - 明确 helper call MUST 继续通过现有 backend-inline 主线消除。
+
+## Capabilities
+
+### New Capabilities
+
+- 无。
+
+### Modified Capabilities
+
+- `tilelang-dsl-surface`: 新增模板跨文件直接导入 `@pto.inline_proc` helper 的 public authoring contract。
+- `tilelang-dsl-diagnostics`: 新增跨文件 helper 导入场景下的 fail-fast 诊断契约。
+- `tilelang-dsl-vpto-lowering`: 新增跨文件导入 helper 的 frontend-to-MLIR materialization 与 backend-inline 收敛契约。
+
+## 预期结果
+
+- 模板库可以把公共可分析算法写在共享 Python 文件中。
+- 多个 TileOp 模板可以通过 import 复用该 helper，而不复制 helper body。
+- `.mlir_text()` 阶段可以看到来自共享文件的 private inline-proc helper。
+- 后续 `pto-inline-libcall` 仍能消除 helper 边界，不把共享 helper 作为最终 IR contract 暴露。
+
+## 成功标准
+
+- 新增 `openspec/changes/support-tilelang-cross-file-inline-proc-imports/`，包含 `proposal.md`、`design.md`、`tasks.md`。
+- 新增 spec delta：
+  - `specs/tilelang-dsl-surface/spec.md`
+  - `specs/tilelang-dsl-diagnostics/spec.md`
+  - `specs/tilelang-dsl-vpto-lowering/spec.md`
+- 测试中使用轻量 helper 验证：
+  - `shared_helper.py` 定义 `@pto.inline_proc`
+  - `*_template.py` 通过 `from shared_helper import helper` 调用
+  - frontend 能收集 helper
+  - lowering 输出 inline-proc helper
+  - backend inline 后不残留 helper call/function
+- 不要求新增或完成 high precision divide 实现。
+
+## Impact
+
+- 受影响目录：
+  - `tilelang-dsl/python/tilelang_dsl/`
+  - `tilelang-dsl/tests/`
+  - `tilelang-dsl/docs/user_guide/`
+  - `lib/TileOps/`
+  - `test/basic/`
+  - `openspec/changes/support-tilelang-cross-file-inline-proc-imports/`
+- 受影响 public authoring behavior：
+  - `from shared_helper import helper` 形式的跨文件 `@pto.inline_proc` 复用。
+- 受影响 lowering 行为：
+  - 导入 helper 与当前文件 helper 一样生成 inline-proc helper function，并走既有 backend inline。

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-diagnostics/spec.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-diagnostics/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: imported helper diagnostics MUST preserve `@pto.inline_proc` restrictions
+
+跨文件导入的 helper MUST 继续遵守现有 `@pto.inline_proc` 诊断规则。  
+frontend MUST 在 IR 生成之前拒绝以下情况：
+
+- 被调用对象不是 `InlineProcDescriptor`
+- helper 使用 unsupported Python syntax
+- helper 使用 positional-only、varargs、kwargs 或 keyword-only 参数
+- helper 发生递归或互递归
+- helper 隐式捕获非允许的动态值
+
+#### Scenario: imported ordinary Python function is rejected
+
+- **WHEN** 模板从其它文件导入普通 Python 函数
+- **AND** `@pto.vkernel` body 调用该函数
+- **THEN** frontend MUST 把该调用视为 unsupported external call
+- **AND** 诊断 MUST NOT 暗示普通 Python 函数会被自动 lowering
+
+#### Scenario: imported inline proc recursion is rejected
+
+- **WHEN** 跨文件导入的 `@pto.inline_proc` helper 直接或间接递归调用自身
+- **THEN** frontend MUST 在 materialization 前报错
+- **AND** 诊断 MUST 明确指出 recursive inline_proc call 不受支持
+
+#### Scenario: imported inline proc illegal capture is rejected
+
+- **WHEN** 跨文件导入的 `@pto.inline_proc` helper 隐式捕获非字面量或非允许的动态值
+- **THEN** frontend MUST 报出 inline_proc capture 相关诊断
+- **AND** 诊断位置 SHOULD 指向共享 helper 源文件中的相关 helper
+
+### Requirement: duplicate imported inline-proc names MUST fail fast
+
+当一个模板模块中可见多个同名 `@pto.inline_proc` helper，且 DSL body 只能通过简单名字调用该 helper 时，frontend MUST fail fast。  
+实现 MUST NOT 静默依赖 import 顺序选择其中一个 helper。
+
+#### Scenario: duplicate helper names are visible in one template module
+
+- **WHEN** 模板通过多个 import 来源暴露同名 `@pto.inline_proc` helper
+- **AND** kernel body 调用该简单名字
+- **THEN** frontend MUST 报出重复 helper 名或 ambiguous inline_proc call 诊断
+- **AND** MUST NOT 静默选择任意一个实现
+
+### Requirement: Qualified imported helper calls SHALL be rejected until specified
+
+The frontend SHALL treat `import shared_helper; shared_helper.helper(...)` as outside this change surface.  
+Until qualified helper calls are specified by a follow-up change, the frontend SHALL reject this call form as an unsupported external or attribute call.
+
+#### Scenario: qualified imported helper call is not part of this change
+
+- **WHEN** 用户写 `import shared_helper` 并在 DSL body 中调用 `shared_helper.helper(...)`
+- **THEN** frontend SHALL reject the call
+- **AND** the rejection SHALL be treated as this change's controlled boundary

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-surface/spec.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-surface/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: TileLang DSL templates MUST support directly imported `@pto.inline_proc` helpers
+
+TileLang DSL 模板文件 MUST 支持从同一模板目录或模板包中直接导入 source-visible `@pto.inline_proc` helper，并在 `@pto.vkernel` body 中以简单名字调用该 helper。  
+支持形式 MUST 至少包含：
+
+- `from shared_helper import helper`
+- `from TileOps.shared_helper import helper`
+
+导入 helper MUST 与当前模板文件内定义的 `@pto.inline_proc` helper 使用同一 authoring contract。  
+普通 Python 函数即便被 import，也 MUST NOT 因跨文件 import 而变成 TileLang DSL 可分析 helper。
+
+#### Scenario: template imports a shared inline proc from the same template directory
+
+- **WHEN** `shared_helper.py` 定义 `@pto.inline_proc def helper(...)`
+- **AND** `some_template.py` 通过 `from shared_helper import helper` 导入它
+- **AND** `some_template.py` 的 `@pto.vkernel` body 调用 `helper(...)`
+- **THEN** frontend MUST 接受该调用作为合法 inline-proc call
+- **AND** 用户 MUST NOT 需要在 `some_template.py` 中复制 helper body
+
+#### Scenario: template imports a shared inline proc through the template package
+
+- **WHEN** 模板目录可作为 Python package 导入
+- **AND** 模板通过 `from TileOps.shared_helper import helper` 导入 `@pto.inline_proc`
+- **THEN** frontend MUST 接受该 helper 的简单名字调用
+- **AND** 该行为 MUST 与同目录裸模块导入保持一致
+
+### Requirement: shared helper files MUST be usable without vkernel descriptors
+
+共享 helper 文件 MUST 允许只包含 `@pto.inline_proc` helper，而不包含任何 `@pto.vkernel` descriptor。  
+模板扫描和导入流程 MUST NOT 要求共享 helper 文件本身匹配 TileOp 或注册 kernel descriptor。
+
+#### Scenario: shared helper file has no vkernel descriptor
+
+- **WHEN** `shared_helper.py` 只定义一个或多个 `@pto.inline_proc`
+- **AND** 没有定义 `@pto.vkernel`
+- **THEN** 该文件仍 MAY 被其它模板导入复用
+- **AND** 模板扫描 MUST NOT 因该共享文件没有 descriptor 而拒绝使用它
+
+### Requirement: cross-file helper support MUST NOT imply high precision algorithm implementation
+
+跨文件 helper import 能力 MUST 独立于具体算法实现。  
+验证该能力时 MAY 使用简单 helper，例如 pass-through、vector add 或 small arithmetic helper。  
+本 change MUST NOT 要求实现 high precision divide、exp、rsqrt 或其它复杂近似算法。
+
+#### Scenario: lightweight helper validates the import contract
+
+- **WHEN** 测试使用一个简单 `@pto.inline_proc` 验证跨文件调用
+- **THEN** 该测试 MUST 足以证明模板 import、frontend collection、lowering 和 inline path 生效
+- **AND** 测试 MUST NOT 依赖 high precision divide 的具体算法正确性

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-vpto-lowering/spec.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/specs/tilelang-dsl-vpto-lowering/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: imported inline-proc helpers MUST materialize like local inline-proc helpers
+
+跨文件导入的 `@pto.inline_proc` helper 一旦被 `@pto.vkernel` body 调用，frontend、semantic 和 lowering MUST 将其视为当前 kernel 的 reachable inline helper。  
+`.mlir_text()` materialization MUST 为该 helper 生成 private helper function，并带有 `pto.tilelang.inline_proc` marker。  
+该 helper 的 call MUST 使用与本文件 `@pto.inline_proc` helper 相同的 call/specialization contract。
+
+#### Scenario: imported helper appears in materialized MLIR
+
+- **WHEN** 模板调用从共享文件直接导入的 `@pto.inline_proc` helper
+- **THEN** `.mlir_text()` 输出 MUST 包含对该 helper specialization 的 `func.call`
+- **AND** 输出 MUST 包含对应的 private `func.func`
+- **AND** helper function MUST 标记 `pto.tilelang.inline_proc`
+
+#### Scenario: imported helper can call another helper from the same shared file
+
+- **WHEN** 模板只导入并调用共享文件中的入口 helper
+- **AND** 该入口 helper 调用同共享文件中的另一个 `@pto.inline_proc`
+- **THEN** lowering MUST materialize reachable helper call graph 中需要的 helper specializations
+- **AND** helper 互调 MUST 继续遵守现有递归检测规则
+
+### Requirement: imported inline-proc helpers MUST be compatible with backend-inline cleanup
+
+跨文件导入 helper 生成的 `pto.tilelang.inline_proc` private function MUST 与现有 backend-inline 主线兼容。  
+经过 inline cleanup pipeline 后，导入 helper 的 `func.call` 和 private helper function MUST 被消除，除非该 pipeline 已按既有规则明确跳过对应 helper。
+
+#### Scenario: backend inline removes imported helper boundary
+
+- **WHEN** materialized MLIR 中包含跨文件导入 helper 的 private inline-proc function
+- **AND** 该 MLIR 经过现有 `pto-inline-libcall` 或等价 backend-inline cleanup
+- **THEN** helper call SHOULD 被内联
+- **AND** private helper function SHOULD 不再残留为最终用户可见边界
+
+### Requirement: cross-file helper import MUST not require algorithm-specific lowering
+
+跨文件 helper import 的 lowering 验证 MUST 只依赖 generic inline-proc materialization 行为。  
+实现和测试 MAY 使用简单 arithmetic helper 验证该能力，不得要求 high precision divide 或其它复杂算法先完成。
+
+#### Scenario: simple imported helper proves the lowering path
+
+- **WHEN** 共享 helper 只执行简单 vector operation 或 pass-through operation
+- **THEN** frontend/lowering/backend-inline 测试仍 MUST 覆盖跨文件 helper 的完整接线
+- **AND** 复杂 high precision 算法缺失 MUST NOT 阻塞该能力验收

--- a/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/tasks.md
+++ b/openspec/changes/archive/2026-04-27-support-tilelang-cross-file-inline-proc-imports/tasks.md
@@ -1,0 +1,35 @@
+## 1. OpenSpec 契约落定
+
+- [x] 1.1 完成 `proposal.md`，明确本 change 只验证跨文件引用 helper 生效，不实现 high precision 算法。
+- [x] 1.2 完成 `design.md`，固定直接导入 `@pto.inline_proc` helper 的设计边界。
+- [x] 1.3 完成 `specs/tilelang-dsl-surface/spec.md`，定义跨文件共享 helper authoring surface。
+- [x] 1.4 完成 `specs/tilelang-dsl-diagnostics/spec.md`，定义导入 helper 的负向诊断。
+- [x] 1.5 完成 `specs/tilelang-dsl-vpto-lowering/spec.md`，定义导入 helper 的 materialization 和 backend-inline 契约。
+
+## 2. Frontend / template import
+
+- [x] 2.1 在 `tilelang-dsl/python/tilelang_dsl/expand_helper.py` 中为模板扫描增加 scoped import context，至少包含 `template_dir` 与 `template_dir.parent`。
+- [x] 2.2 确保 `from shared_helper import helper` 导入的 `InlineProcDescriptor` 会被当前 `vkernel` descriptor 收集。
+- [x] 2.3 确保共享 helper 文件不需要包含 `@pto.vkernel` 也能被模板导入使用。
+- [x] 2.4 对同名导入 helper 冲突增加 fail-fast 诊断，避免静默依赖 import 顺序。
+
+## 3. Lowering / backend path
+
+- [x] 3.1 确保跨文件导入 helper 与本文件 helper 一样生成 `FrontendInlineProcNode`。
+- [x] 3.2 确保导入 helper 在 `mlir_text()` 中 materialize 为 private `pto.tilelang.inline_proc` helper function。
+- [x] 3.3 确保现有 `pto-inline-libcall` 能消除导入 helper 的 call 和 private helper function。
+
+## 4. 回归测试与文档
+
+- [x] 4.1 在 TileLang DSL Python 单测中新增“共享文件定义 helper，模板直接导入并调用”的正向测试。
+- [x] 4.2 新增共享 helper 互调测试：模板只导入入口 helper，被入口 helper 调用的同文件 helper 也能被 materialize。
+- [x] 4.3 新增负向测试：普通 Python 函数 import 后调用仍被拒绝。
+- [x] 4.4 新增负向测试：导入 helper 的递归、非法 capture、同名冲突均给出明确诊断。
+- [x] 4.5 新增或更新 lit 回归，验证导入 helper 经 backend-inline 后不残留 helper call/function。
+- [x] 4.6 更新 TileLang DSL 用户文档，说明共享 `@pto.inline_proc` helper 的推荐写法和限制。
+
+## 5. 验证
+
+- [x] 5.1 执行针对跨文件 helper import 的 TileLang DSL 单测。
+- [x] 5.2 执行覆盖 helper + backend-inline 收敛路径的定向回归。
+- [x] 5.3 执行 `openspec validate support-tilelang-cross-file-inline-proc-imports --type change --strict --json --no-interactive`。

--- a/openspec/specs/tilelang-dsl-diagnostics/spec.md
+++ b/openspec/specs/tilelang-dsl-diagnostics/spec.md
@@ -2,7 +2,6 @@
 
 ## Purpose
 TBD - created by archiving change add-tilelang-dsl-core-foundation. Update Purpose after archive.
-
 ## Requirements
 ### Requirement: v1 MUST fail fast on unsupported matcher and decorator features
 
@@ -92,3 +91,57 @@ selector diagnostics MUST 让调用方能仅凭 report 判定候选究竟挂在 
 - **WHEN** 某个候选通过 `dtype` 与 `constraints`，但在 `mlir_text()` materialization 时失败
 - **THEN** selection diagnostics MUST 将该候选标记为 materialization 相关失败
 - **AND** MUST NOT 把该失败重新表述为 `dtype` mismatch 或 constraint failure
+
+### Requirement: imported helper diagnostics MUST preserve `@pto.inline_proc` restrictions
+
+跨文件导入的 helper MUST 继续遵守现有 `@pto.inline_proc` 诊断规则。  
+frontend MUST 在 IR 生成之前拒绝以下情况：
+
+- 被调用对象不是 `InlineProcDescriptor`
+- helper 使用 unsupported Python syntax
+- helper 使用 positional-only、varargs、kwargs 或 keyword-only 参数
+- helper 发生递归或互递归
+- helper 隐式捕获非允许的动态值
+
+#### Scenario: imported ordinary Python function is rejected
+
+- **WHEN** 模板从其它文件导入普通 Python 函数
+- **AND** `@pto.vkernel` body 调用该函数
+- **THEN** frontend MUST 把该调用视为 unsupported external call
+- **AND** 诊断 MUST NOT 暗示普通 Python 函数会被自动 lowering
+
+#### Scenario: imported inline proc recursion is rejected
+
+- **WHEN** 跨文件导入的 `@pto.inline_proc` helper 直接或间接递归调用自身
+- **THEN** frontend MUST 在 materialization 前报错
+- **AND** 诊断 MUST 明确指出 recursive inline_proc call 不受支持
+
+#### Scenario: imported inline proc illegal capture is rejected
+
+- **WHEN** 跨文件导入的 `@pto.inline_proc` helper 隐式捕获非字面量或非允许的动态值
+- **THEN** frontend MUST 报出 inline_proc capture 相关诊断
+- **AND** 诊断位置 SHOULD 指向共享 helper 源文件中的相关 helper
+
+### Requirement: duplicate imported inline-proc names MUST fail fast
+
+当一个模板模块中可见多个同名 `@pto.inline_proc` helper，且 DSL body 只能通过简单名字调用该 helper 时，frontend MUST fail fast。  
+实现 MUST NOT 静默依赖 import 顺序选择其中一个 helper。
+
+#### Scenario: duplicate helper names are visible in one template module
+
+- **WHEN** 模板通过多个 import 来源暴露同名 `@pto.inline_proc` helper
+- **AND** kernel body 调用该简单名字
+- **THEN** frontend MUST 报出重复 helper 名或 ambiguous inline_proc call 诊断
+- **AND** MUST NOT 静默选择任意一个实现
+
+### Requirement: Qualified imported helper calls SHALL be rejected until specified
+
+The frontend SHALL treat `import shared_helper; shared_helper.helper(...)` as outside this change surface.  
+Until qualified helper calls are specified by a follow-up change, the frontend SHALL reject this call form as an unsupported external or attribute call.
+
+#### Scenario: qualified imported helper call is not part of this change
+
+- **WHEN** 用户写 `import shared_helper` 并在 DSL body 中调用 `shared_helper.helper(...)`
+- **THEN** frontend SHALL reject the call
+- **AND** the rejection SHALL be treated as this change's controlled boundary
+

--- a/openspec/specs/tilelang-dsl-surface/spec.md
+++ b/openspec/specs/tilelang-dsl-surface/spec.md
@@ -2,7 +2,6 @@
 
 ## Purpose
 TBD - created by archiving change add-tilelang-dsl-core-foundation. Update Purpose after archive.
-
 ## Requirements
 ### Requirement: TileLang DSL v1 MUST live under `tilelang-dsl/` and expose a dedicated `tilelang_dsl` package
 
@@ -86,3 +85,54 @@ frontend MUST 将这些 surface 识别为对应 `!pto.mask<b8>`、`!pto.mask<b16
 - **WHEN** 用户查看或使用 TileLang DSL v1 public type surface
 - **THEN** 文档和 package surface MUST 只暴露 `TensorView`、`Tile`、typed pointer、`pto.vreg(...)`、typed mask 等 authoring type
 - **AND** MUST NOT 将 `pto.memref(...)` 描述为 DSL 侧可用 constructor
+
+### Requirement: TileLang DSL templates MUST support directly imported `@pto.inline_proc` helpers
+
+TileLang DSL 模板文件 MUST 支持从同一模板目录或模板包中直接导入 source-visible `@pto.inline_proc` helper，并在 `@pto.vkernel` body 中以简单名字调用该 helper。  
+支持形式 MUST 至少包含：
+
+- `from shared_helper import helper`
+- `from TileOps.shared_helper import helper`
+
+导入 helper MUST 与当前模板文件内定义的 `@pto.inline_proc` helper 使用同一 authoring contract。  
+普通 Python 函数即便被 import，也 MUST NOT 因跨文件 import 而变成 TileLang DSL 可分析 helper。
+
+#### Scenario: template imports a shared inline proc from the same template directory
+
+- **WHEN** `shared_helper.py` 定义 `@pto.inline_proc def helper(...)`
+- **AND** `some_template.py` 通过 `from shared_helper import helper` 导入它
+- **AND** `some_template.py` 的 `@pto.vkernel` body 调用 `helper(...)`
+- **THEN** frontend MUST 接受该调用作为合法 inline-proc call
+- **AND** 用户 MUST NOT 需要在 `some_template.py` 中复制 helper body
+
+#### Scenario: template imports a shared inline proc through the template package
+
+- **WHEN** 模板目录可作为 Python package 导入
+- **AND** 模板通过 `from TileOps.shared_helper import helper` 导入 `@pto.inline_proc`
+- **THEN** frontend MUST 接受该 helper 的简单名字调用
+- **AND** 该行为 MUST 与同目录裸模块导入保持一致
+
+### Requirement: shared helper files MUST be usable without vkernel descriptors
+
+共享 helper 文件 MUST 允许只包含 `@pto.inline_proc` helper，而不包含任何 `@pto.vkernel` descriptor。  
+模板扫描和导入流程 MUST NOT 要求共享 helper 文件本身匹配 TileOp 或注册 kernel descriptor。
+
+#### Scenario: shared helper file has no vkernel descriptor
+
+- **WHEN** `shared_helper.py` 只定义一个或多个 `@pto.inline_proc`
+- **AND** 没有定义 `@pto.vkernel`
+- **THEN** 该文件仍 MAY 被其它模板导入复用
+- **AND** 模板扫描 MUST NOT 因该共享文件没有 descriptor 而拒绝使用它
+
+### Requirement: cross-file helper support MUST NOT imply high precision algorithm implementation
+
+跨文件 helper import 能力 MUST 独立于具体算法实现。  
+验证该能力时 MAY 使用简单 helper，例如 pass-through、vector add 或 small arithmetic helper。  
+本 change MUST NOT 要求实现 high precision divide、exp、rsqrt 或其它复杂近似算法。
+
+#### Scenario: lightweight helper validates the import contract
+
+- **WHEN** 测试使用一个简单 `@pto.inline_proc` 验证跨文件调用
+- **THEN** 该测试 MUST 足以证明模板 import、frontend collection、lowering 和 inline path 生效
+- **AND** 测试 MUST NOT 依赖 high precision divide 的具体算法正确性
+

--- a/openspec/specs/tilelang-dsl-vpto-lowering/spec.md
+++ b/openspec/specs/tilelang-dsl-vpto-lowering/spec.md
@@ -1,0 +1,48 @@
+# tilelang-dsl-vpto-lowering Specification
+
+## Purpose
+TBD - created by archiving change support-tilelang-cross-file-inline-proc-imports. Update Purpose after archive.
+## Requirements
+### Requirement: imported inline-proc helpers MUST materialize like local inline-proc helpers
+
+跨文件导入的 `@pto.inline_proc` helper 一旦被 `@pto.vkernel` body 调用，frontend、semantic 和 lowering MUST 将其视为当前 kernel 的 reachable inline helper。  
+`.mlir_text()` materialization MUST 为该 helper 生成 private helper function，并带有 `pto.tilelang.inline_proc` marker。  
+该 helper 的 call MUST 使用与本文件 `@pto.inline_proc` helper 相同的 call/specialization contract。
+
+#### Scenario: imported helper appears in materialized MLIR
+
+- **WHEN** 模板调用从共享文件直接导入的 `@pto.inline_proc` helper
+- **THEN** `.mlir_text()` 输出 MUST 包含对该 helper specialization 的 `func.call`
+- **AND** 输出 MUST 包含对应的 private `func.func`
+- **AND** helper function MUST 标记 `pto.tilelang.inline_proc`
+
+#### Scenario: imported helper can call another helper from the same shared file
+
+- **WHEN** 模板只导入并调用共享文件中的入口 helper
+- **AND** 该入口 helper 调用同共享文件中的另一个 `@pto.inline_proc`
+- **THEN** lowering MUST materialize reachable helper call graph 中需要的 helper specializations
+- **AND** helper 互调 MUST 继续遵守现有递归检测规则
+
+### Requirement: imported inline-proc helpers MUST be compatible with backend-inline cleanup
+
+跨文件导入 helper 生成的 `pto.tilelang.inline_proc` private function MUST 与现有 backend-inline 主线兼容。  
+经过 inline cleanup pipeline 后，导入 helper 的 `func.call` 和 private helper function MUST 被消除，除非该 pipeline 已按既有规则明确跳过对应 helper。
+
+#### Scenario: backend inline removes imported helper boundary
+
+- **WHEN** materialized MLIR 中包含跨文件导入 helper 的 private inline-proc function
+- **AND** 该 MLIR 经过现有 `pto-inline-libcall` 或等价 backend-inline cleanup
+- **THEN** helper call SHOULD 被内联
+- **AND** private helper function SHOULD 不再残留为最终用户可见边界
+
+### Requirement: cross-file helper import MUST not require algorithm-specific lowering
+
+跨文件 helper import 的 lowering 验证 MUST 只依赖 generic inline-proc materialization 行为。  
+实现和测试 MAY 使用简单 arithmetic helper 验证该能力，不得要求 high precision divide 或其它复杂算法先完成。
+
+#### Scenario: simple imported helper proves the lowering path
+
+- **WHEN** 共享 helper 只执行简单 vector operation 或 pass-through operation
+- **THEN** frontend/lowering/backend-inline 测试仍 MUST 覆盖跨文件 helper 的完整接线
+- **AND** 复杂 high precision 算法缺失 MUST NOT 阻塞该能力验收
+

--- a/test/basic/tilelang_cross_file_inline_proc_backend_inline.pto
+++ b/test/basic/tilelang_cross_file_inline_proc_backend_inline.pto
@@ -1,0 +1,25 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto -o - %s | FileCheck %s
+
+// Models MLIR produced by a template that imported a shared @pto.inline_proc
+// helper from another Python file. At this stage imported and local helpers use
+// the same pto.tilelang.inline_proc contract; the backend must erase the helper
+// boundary.
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance } {
+    func.call @__tl_inline_shared_touch_0() : () -> ()
+    return
+  }
+
+  func.func private @__tl_inline_shared_touch_0() attributes { pto.tilelang.inline_proc } {
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: module
+// CHECK-NOT: func.call @__tl_inline_shared_touch
+// CHECK-NOT: func.func private @__tl_inline_shared_touch
+// CHECK-NOT: pto.tilelang.inline_proc

--- a/tilelang-dsl/docs/user_guide/06-control-flow.md
+++ b/tilelang-dsl/docs/user_guide/06-control-flow.md
@@ -119,6 +119,36 @@ Important semantics:
 - Recursive/mutually-recursive helper call graphs are rejected.
 - `*args`, `**kwargs`, and keyword-only parameters are unsupported in current version.
 
+Shared helpers can live in a separate Python file in the template directory and
+be imported directly by templates:
+
+```python
+# shared_rows.py
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def touch_row(dst: pto.Tile, row: pto.i32):
+    mask = pto.make_mask(dst.element_type, pto.PAT.ALL)
+    vec = pto.vlds(dst[row, 0:])
+    pto.vsts(vec, dst[row, 0:], mask)
+    return None
+
+# trow_template.py
+import tilelang_dsl as pto
+from shared_rows import touch_row
+
+@pto.vkernel(op="pto.row_touch", dtypes=[(pto.f32, pto.i32)])
+def row_touch(dst: pto.Tile, row: pto.i32):
+    touch_row(dst, row)
+    return None
+```
+
+Only directly imported `@pto.inline_proc` helpers are part of this shared-helper
+surface. Ordinary Python functions remain unsupported in DSL bodies, and
+qualified calls such as `shared_rows.touch_row(...)` are not part of this
+version. If multiple imported helpers expose the same bare name, the frontend
+rejects the template instead of choosing one by import order.
+
 ### Loops
 
 Counted loops use Python's `range` syntax:

--- a/tilelang-dsl/python/tilelang_dsl/expand_helper.py
+++ b/tilelang-dsl/python/tilelang_dsl/expand_helper.py
@@ -25,6 +25,7 @@ prints the materialized MLIR module to stdout.
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import importlib.util
 import json
 import sys
@@ -85,11 +86,34 @@ def _find_descriptors(module) -> list[VKernelDescriptor]:
     return result
 
 
+@contextmanager
+def _template_import_context(template_dir: Path):
+    """Temporarily expose a template directory and package parent to imports."""
+    import_roots: list[str] = []
+    for root in (template_dir, template_dir.parent):
+        root_text = str(root)
+        if root_text not in import_roots:
+            import_roots.append(root_text)
+
+    added_roots: list[str] = []
+    for root_text in reversed(import_roots):
+        if root_text in sys.path:
+            continue
+        sys.path.insert(0, root_text)
+        added_roots.append(root_text)
+
+    try:
+        yield
+    finally:
+        for root_text in added_roots:
+            try:
+                sys.path.remove(root_text)
+            except ValueError:
+                pass
+
+
 def _import_py_file(path: Path):
     """Import a .py file as a module and return it."""
-    template_parent = path.parent.parent
-    if str(template_parent) not in sys.path:
-        sys.path.insert(0, str(template_parent))
     module_name = f"_tl_template_{path.stem}"
     spec = importlib.util.spec_from_file_location(module_name, str(path))
     if spec is None or spec.loader is None:
@@ -413,11 +437,12 @@ def main(argv: list[str] | None = None) -> int:
 
     # Scan all .py files for descriptors.
     all_descriptors: list[VKernelDescriptor] = []
-    for py_path in sorted(template_dir.glob("*.py")):
-        mod = _import_py_file(py_path)
-        if mod is None:
-            continue
-        all_descriptors.extend(_find_descriptors(mod))
+    with _template_import_context(template_dir):
+        for py_path in sorted(template_dir.glob("*.py")):
+            mod = _import_py_file(py_path)
+            if mod is None:
+                continue
+            all_descriptors.extend(_find_descriptors(mod))
 
     if not all_descriptors:
         print(f"expand_helper: error: no @vkernel descriptors found in {template_dir}", file=sys.stderr)

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -187,23 +187,52 @@ def _validate_inline_proc_call_surface(
         ) from exc
 
 
+def _same_inline_proc_descriptor(
+    lhs: InlineProcDescriptor,
+    rhs: InlineProcDescriptor,
+) -> bool:
+    return lhs is rhs or lhs.py_fn is rhs.py_fn
+
+
+def _format_inline_proc_origin(descriptor: InlineProcDescriptor) -> str:
+    return f"{descriptor.py_fn.__module__}.{descriptor.py_fn.__name__}"
+
+
+def _add_collected_inline_proc(
+    collected: dict[str, InlineProcDescriptor],
+    symbol: str,
+    descriptor: InlineProcDescriptor,
+) -> None:
+    existing = collected.get(symbol)
+    if existing is None:
+        collected[symbol] = descriptor
+        return
+    if _same_inline_proc_descriptor(existing, descriptor):
+        return
+    raise ValueError(
+        "ambiguous inline_proc name "
+        f"`{symbol}` in TileLang DSL module: "
+        f"{_format_inline_proc_origin(existing)} conflicts with "
+        f"{_format_inline_proc_origin(descriptor)}"
+    )
+
+
 def _collect_inline_procs(module_name: str) -> tuple[tuple[str, InlineProcDescriptor], ...]:
-    collected: dict[str, InlineProcDescriptor] = {
-        symbol: descriptor
-        for (registered_module, symbol), descriptor in _INLINE_PROC_REGISTRY.items()
-        if registered_module == module_name
-    }
+    collected: dict[str, InlineProcDescriptor] = {}
+    for (registered_module, symbol), descriptor in _INLINE_PROC_REGISTRY.items():
+        if registered_module == module_name:
+            _add_collected_inline_proc(collected, symbol, descriptor)
 
     module = sys.modules.get(module_name)
     if module is not None:
         for symbol, value in vars(module).items():
             if not isinstance(value, InlineProcDescriptor):
                 continue
-            collected.setdefault(symbol, value)
+            _add_collected_inline_proc(collected, symbol, value)
             origin_module = value.py_fn.__module__
             for (registered_module, helper_name), helper in _INLINE_PROC_REGISTRY.items():
                 if registered_module == origin_module:
-                    collected.setdefault(helper_name, helper)
+                    _add_collected_inline_proc(collected, helper_name, helper)
 
     return tuple(sorted(collected.items(), key=lambda item: item[0]))
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -8,6 +8,9 @@
 
 import tempfile
 import unittest
+import io
+import sys
+from contextlib import redirect_stderr
 from unittest import mock
 from importlib import util
 from pathlib import Path
@@ -302,6 +305,313 @@ class TileLangDSLPackageTests(unittest.TestCase):
 
 
 class TileLangDSLExpandHelperTests(unittest.TestCase):
+    def test_cross_file_inline_proc_direct_import_materializes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            shared_name = "shared_cross_file_positive_unique"
+            (root / f"{shared_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def shared_touch():
+    return
+""",
+                encoding="utf-8",
+            )
+            template_path = root / "cross_file_positive_template_unique.py"
+            template_path.write_text(
+                f"""
+import tilelang_dsl as pto
+from {shared_name} import shared_touch
+
+@pto.vkernel(op="pto.cross_file_positive_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    shared_touch()
+    return
+""",
+                encoding="utf-8",
+            )
+
+            with expand_helper._template_import_context(root):
+                mod = expand_helper._import_py_file(template_path)
+            self.assertIsNotNone(mod)
+            desc = expand_helper._find_descriptors(mod)[0]
+            self.assertIn("shared_touch", desc.inline_procs)
+
+            specialized = desc.specialize(
+                src=pto.TileSpecialization(shape=(1, 64), memory_space=pto.MemorySpace.UB)
+            )
+            frontend = build_frontend_kernel_node(specialized)
+            self.assertIn("shared_touch", {proc.name for proc in frontend.inline_procs})
+
+            text = specialized.mlir_text()
+            self.assertRegex(text, r"func\.call @__tl_inline_shared_touch_")
+            self.assertRegex(text, r"func\.func private @__tl_inline_shared_touch_")
+            self.assertIn("pto.tilelang.inline_proc", text)
+
+    def test_cross_file_inline_proc_package_import_materializes_without_leaking_sys_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_root = Path(tmpdir)
+            template_dir = package_root / "TileOps"
+            template_dir.mkdir()
+            (template_dir / "__init__.py").write_text("", encoding="utf-8")
+
+            shared_name = "shared_cross_file_package_unique"
+            (template_dir / f"{shared_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def shared_touch():
+    return
+""",
+                encoding="utf-8",
+            )
+            template_path = template_dir / "cross_file_package_template_unique.py"
+            template_path.write_text(
+                f"""
+import tilelang_dsl as pto
+from TileOps.{shared_name} import shared_touch
+
+@pto.vkernel(op="pto.cross_file_package_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    shared_touch()
+    return
+""",
+                encoding="utf-8",
+            )
+
+            before_counts = {
+                str(template_dir): sys.path.count(str(template_dir)),
+                str(package_root): sys.path.count(str(package_root)),
+            }
+            with expand_helper._template_import_context(template_dir):
+                self.assertGreaterEqual(
+                    sys.path.count(str(template_dir)),
+                    before_counts[str(template_dir)] + 1,
+                )
+                self.assertGreaterEqual(
+                    sys.path.count(str(package_root)),
+                    before_counts[str(package_root)] + 1,
+                )
+                mod = expand_helper._import_py_file(template_path)
+            self.assertIsNotNone(mod)
+            self.assertEqual(sys.path.count(str(template_dir)), before_counts[str(template_dir)])
+            self.assertEqual(sys.path.count(str(package_root)), before_counts[str(package_root)])
+
+            desc = expand_helper._find_descriptors(mod)[0]
+            self.assertIn("shared_touch", desc.inline_procs)
+
+            specialized = desc.specialize(
+                src=pto.TileSpecialization(shape=(1, 64), memory_space=pto.MemorySpace.UB)
+            )
+            frontend = build_frontend_kernel_node(specialized)
+            self.assertIn("shared_touch", {proc.name for proc in frontend.inline_procs})
+
+            text = specialized.mlir_text()
+            self.assertRegex(text, r"func\.call @__tl_inline_shared_touch_")
+            self.assertRegex(text, r"func\.func private @__tl_inline_shared_touch_")
+            self.assertIn("pto.tilelang.inline_proc", text)
+
+    def test_cross_file_inline_proc_collects_shared_helper_callees(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            shared_name = "shared_cross_file_nested_unique"
+            (root / f"{shared_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def shared_leaf():
+    return
+
+@pto.inline_proc
+def shared_entry():
+    shared_leaf()
+    return
+""",
+                encoding="utf-8",
+            )
+            template_path = root / "cross_file_nested_template_unique.py"
+            template_path.write_text(
+                f"""
+import tilelang_dsl as pto
+from {shared_name} import shared_entry
+
+@pto.vkernel(op="pto.cross_file_nested_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    shared_entry()
+    return
+""",
+                encoding="utf-8",
+            )
+
+            with expand_helper._template_import_context(root):
+                mod = expand_helper._import_py_file(template_path)
+            self.assertIsNotNone(mod)
+            desc = expand_helper._find_descriptors(mod)[0]
+            self.assertIn("shared_entry", desc.inline_procs)
+            self.assertIn("shared_leaf", desc.inline_procs)
+
+            specialized = desc.specialize(
+                src=pto.TileSpecialization(shape=(1, 64), memory_space=pto.MemorySpace.UB)
+            )
+            frontend = build_frontend_kernel_node(specialized)
+            self.assertEqual(
+                {proc.name for proc in frontend.inline_procs},
+                {"shared_entry", "shared_leaf"},
+            )
+
+            text = specialized.mlir_text()
+            self.assertRegex(text, r"func\.call @__tl_inline_shared_entry_")
+            self.assertRegex(text, r"func\.func private @__tl_inline_shared_entry_")
+            self.assertRegex(text, r"func\.func private @__tl_inline_shared_leaf_")
+
+    def test_cross_file_imported_plain_function_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            shared_name = "shared_cross_file_plain_unique"
+            (root / f"{shared_name}.py").write_text(
+                """
+def plain_helper():
+    return
+""",
+                encoding="utf-8",
+            )
+            template_path = root / "cross_file_plain_template_unique.py"
+            template_path.write_text(
+                f"""
+import tilelang_dsl as pto
+from {shared_name} import plain_helper
+
+@pto.vkernel(op="pto.cross_file_plain_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    plain_helper()
+    return
+""",
+                encoding="utf-8",
+            )
+
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), expand_helper._template_import_context(root):
+                mod = expand_helper._import_py_file(template_path)
+
+        self.assertIsNone(mod)
+        self.assertIn(
+            "arbitrary external call `plain_helper` is not supported",
+            stderr.getvalue(),
+        )
+
+    def test_cross_file_inline_proc_negative_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            recursive_name = "shared_cross_file_recursive_unique"
+            (root / f"{recursive_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def shared_recur():
+    shared_recur()
+    return
+""",
+                encoding="utf-8",
+            )
+            recursive_template = root / "cross_file_recursive_template_unique.py"
+            recursive_template.write_text(
+                f"""
+import tilelang_dsl as pto
+from {recursive_name} import shared_recur
+
+@pto.vkernel(op="pto.cross_file_recursive_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    shared_recur()
+    return
+""",
+                encoding="utf-8",
+            )
+            with expand_helper._template_import_context(root):
+                recursive_mod = expand_helper._import_py_file(recursive_template)
+            self.assertIsNotNone(recursive_mod)
+            recursive_desc = expand_helper._find_descriptors(recursive_mod)[0]
+            with self.assertRaises(pto.TileLangFrontendError) as recursive_ctx:
+                recursive_desc.specialize(
+                    src=pto.TileSpecialization(shape=(1, 64), memory_space=pto.MemorySpace.UB)
+                ).mlir_text()
+            self.assertIn("recursive inline_proc call `shared_recur`", str(recursive_ctx.exception))
+
+            capture_name = "shared_cross_file_capture_unique"
+            (root / f"{capture_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+scale = object()
+
+@pto.inline_proc
+def shared_capture():
+    value = scale
+    return
+""",
+                encoding="utf-8",
+            )
+            capture_template = root / "cross_file_capture_template_unique.py"
+            capture_template.write_text(
+                f"""
+import tilelang_dsl as pto
+from {capture_name} import shared_capture
+
+@pto.vkernel(op="pto.cross_file_capture_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    shared_capture()
+    return
+""",
+                encoding="utf-8",
+            )
+            with expand_helper._template_import_context(root):
+                capture_mod = expand_helper._import_py_file(capture_template)
+            self.assertIsNotNone(capture_mod)
+            capture_desc = expand_helper._find_descriptors(capture_mod)[0]
+            with self.assertRaises(pto.TileLangFrontendError) as capture_ctx:
+                capture_desc.specialize(
+                    src=pto.TileSpecialization(shape=(1, 64), memory_space=pto.MemorySpace.UB)
+                ).mlir_text()
+            self.assertIn("implicit capture of 'scale' is not allowed", str(capture_ctx.exception))
+
+            conflict_name = "shared_cross_file_conflict_unique"
+            (root / f"{conflict_name}.py").write_text(
+                """
+import tilelang_dsl as pto
+
+@pto.inline_proc
+def helper():
+    return
+
+@pto.inline_proc
+def entry():
+    return
+""",
+                encoding="utf-8",
+            )
+            conflict_template = root / "cross_file_conflict_template_unique.py"
+            conflict_template.write_text(
+                f"""
+import tilelang_dsl as pto
+from {conflict_name} import entry as helper
+
+@pto.vkernel(op="pto.cross_file_conflict_unique", dtypes=[(pto.f32,)])
+def kernel(src: pto.Tile):
+    helper()
+    return
+""",
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), expand_helper._template_import_context(root):
+                conflict_mod = expand_helper._import_py_file(conflict_template)
+            self.assertIsNone(conflict_mod)
+            self.assertIn("ambiguous inline_proc name `helper`", stderr.getvalue())
+
     def test_operand_specs_preserve_tile_valid_shape_and_pad_value(self) -> None:
         source = """
 import tilelang_dsl as pto


### PR DESCRIPTION
## Summary
- follow up the cross-file `@pto.inline_proc` import support that landed in PR #265
- scope template import-path exposure to the materialization walk so helper imports do not leak `sys.path` mutations
- reject ambiguous imported inline-proc names instead of silently depending on import order
- add focused tests for direct import, package import, nested helper collection, unsupported imported plain functions, and diagnostics
- document the supported shared-helper surface and archive the corresponding OpenSpec change

## Why this PR still exists after #265
PR #265 already introduced the core cross-file helper path while improving DSL function calls and adding `vdiv`/`vmod` support. This PR narrows itself to follow-up hardening around that surface:
- temporary import context management
- duplicate imported helper diagnostics
- broader regression coverage
- user-facing docs/spec updates

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 tilelang-dsl/tests/test_tilelang_dsl_v1.py TileLangDSLExpandHelperTests.test_cross_file_inline_proc_direct_import_materializes TileLangDSLExpandHelperTests.test_cross_file_inline_proc_package_import_materializes_without_leaking_sys_path TileLangDSLExpandHelperTests.test_cross_file_inline_proc_collects_shared_helper_callees TileLangDSLExpandHelperTests.test_cross_file_imported_plain_function_is_rejected TileLangDSLExpandHelperTests.test_cross_file_inline_proc_negative_diagnostics`
- `source scripts/ptoas_env.sh && ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto -o - test/basic/tilelang_cross_file_inline_proc_backend_inline.pto | FileCheck test/basic/tilelang_cross_file_inline_proc_backend_inline.pto`
- `openspec validate tilelang-dsl-surface --type spec --strict --json --no-interactive`
- `openspec validate tilelang-dsl-diagnostics --type spec --strict --json --no-interactive`
- `openspec validate tilelang-dsl-vpto-lowering --type spec --strict --json --no-interactive`

Refs #190