### PR TITLE
Fix VPTO vcvt and vaxpy mask lowering

### DIFF
--- a/docs/isa/13-dsa-sfu-ops.md
+++ b/docs/isa/13-dsa-sfu-ops.md
@@ -84,7 +84,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vaxpy`
 
-- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha : !pto.vreg<NxT>, !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** AXPY — scalar-vector multiply-add.
 
@@ -93,8 +93,8 @@ for (int i = 0; i < N; i++)
     dst[i] = alpha * src0[i] + src1[i];
 ```
 
-- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector, and
-  `%alpha` is the scalar multiplier.
+- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector,
+  `%alpha` is the scalar multiplier, and `%mask` selects active lanes.
 - **outputs:** `%result` is the fused AXPY result.
 - **constraints and limitations:** Floating-point element types only on the
   current documented surface.

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -877,7 +877,7 @@ pto.vstsx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vre
 **Conversion (one vector in, different-typed vector out):**
 
 ```mlir
-%result = pto.vcvt %input {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0> -> !pto.vreg<MxT1>
+%result = pto.vcvt %input, %mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0>, !pto.mask<G> -> !pto.vreg<MxT1>
 ```
 
 **Predicate construction:**

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -1330,6 +1330,7 @@ def PTO_VtrcOp : PTO_Op<"vtrc", [Pure]> {
 def PTO_VcvtOp : PTO_Op<"vcvt", [Pure]> {
   let arguments = (ins
     PTO_VectorType:$input,
+    PTO_MaskTypeConstraint:$mask,
     OptionalAttr<StrAttr>:$rnd,
     OptionalAttr<StrAttr>:$sat,
     OptionalAttr<StrAttr>:$part
@@ -1841,14 +1842,15 @@ def PTO_VaxpyOp : PTO_Op<"vaxpy", [Pure]> {
   let arguments = (ins
     PTO_VectorType:$src0,
     PTO_VectorType:$src1,
-    AnyType:$alpha
+    AnyType:$alpha,
+    PTO_MaskTypeConstraint:$mask
   );
   let results = (outs PTO_VectorType:$result);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $src0 `,` $src1 `,` $alpha attr-dict `:` type($src0) `,` type($src1) `,` type($alpha) `->` type($result)
+    $src0 `,` $src1 `,` $alpha `,` $mask attr-dict `:` type($src0) `,` type($src1) `,` type($alpha) `,` type($mask) `->` type($result)
   }];
 }
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <optional>
 
 using namespace mlir;
@@ -2868,11 +2869,14 @@ LogicalResult VtrcOp::verify() {
 
 ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand input;
+  OpAsmParser::UnresolvedOperand mask;
   NamedAttrList attrs;
-  Type inputType, resultType;
+  Type inputType, maskType, resultType;
 
-  if (parser.parseOperand(input) || parser.parseOptionalAttrDict(attrs) ||
-      parser.parseColonType(inputType) || parser.parseArrow() ||
+  if (parser.parseOperand(input) || parser.parseComma() ||
+      parser.parseOperand(mask) || parser.parseOptionalAttrDict(attrs) ||
+      parser.parseColonType(inputType) || parser.parseComma() ||
+      parser.parseType(maskType) || parser.parseArrow() ||
       parser.parseType(resultType))
     return failure();
 
@@ -2910,16 +2914,18 @@ ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
 
   result.addAttributes(attrs);
-  if (parser.resolveOperand(input, inputType, result.operands))
+  if (parser.resolveOperand(input, inputType, result.operands) ||
+      parser.resolveOperand(mask, maskType, result.operands))
     return failure();
   result.addTypes(resultType);
   return success();
 }
 
 void VcvtOp::print(OpAsmPrinter &printer) {
-  printer << ' ' << getInput();
+  printer << ' ' << getInput() << ", " << getMask();
   printer.printOptionalAttrDict((*this)->getAttrs());
-  printer << " : " << getInput().getType() << " -> " << getResult().getType();
+  printer << " : " << getInput().getType() << ", " << getMask().getType()
+          << " -> " << getResult().getType();
 }
 
 LogicalResult VcvtOp::verify() {
@@ -2927,6 +2933,8 @@ LogicalResult VcvtOp::verify() {
   auto resultType = dyn_cast<VRegType>(getResult().getType());
   if (!inputType || !resultType)
     return emitOpError("input and result must be !pto.vreg<...>");
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+    return failure();
 
   VcvtElemKind inputElemKind = classifyVcvtElemType(inputType.getElementType());
   VcvtElemKind resultElemKind = classifyVcvtElemType(resultType.getElementType());
@@ -2938,6 +2946,16 @@ LogicalResult VcvtOp::verify() {
   auto resultElemBits = getVcvtElemBitWidth(resultElemKind);
   if (!inputElemBits || !resultElemBits)
     return emitOpError("could not determine vcvt element bit width");
+  unsigned maskBitWidth = std::min(*inputElemBits, 32u);
+  StringRef expectedMaskGranularity = maskBitWidth == 8    ? "b8"
+                                      : maskBitWidth == 16 ? "b16"
+                                      : maskBitWidth == 32 ? "b32"
+                                                           : "";
+  if (expectedMaskGranularity.empty())
+    return emitOpError("could not determine vcvt mask granularity");
+  if (failed(verifyMaskTypeWithGranularityLike(
+          *this, getMask().getType(), "mask type", expectedMaskGranularity)))
+    return failure();
   if (inputType.getElementCount() * static_cast<int64_t>(*inputElemBits) !=
       resultType.getElementCount() * static_cast<int64_t>(*resultElemBits)) {
     return emitOpError("requires source and result vectors to carry the same "
@@ -3201,7 +3219,8 @@ LogicalResult VexpdifOp::verify() {
 LogicalResult VaxpyOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc0().getType(), "src0 type")) ||
       failed(verifyVRegTypeLike(*this, getSrc1().getType(), "src1 type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")) ||
+      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
     return failure();
   auto src0Type = cast<VRegType>(getSrc0().getType());
   auto src1Type = cast<VRegType>(getSrc1().getType());
@@ -3211,6 +3230,13 @@ LogicalResult VaxpyOp::verify() {
   Type elemType = src0Type.getElementType();
   if (!elemType.isF16() && !elemType.isF32())
     return emitOpError("requires f16 or f32 vector element type");
+  auto expectedGranularity = getVdupMaskGranularity(elemType);
+  if (!expectedGranularity)
+    return emitOpError("requires element type with supported predicate granularity");
+  if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
+                                               "mask type",
+                                               *expectedGranularity)))
+    return failure();
   if (getAlpha().getType() != elemType)
     return emitOpError("requires alpha type to match vector element type");
   return success();

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5691,16 +5691,9 @@ public:
   LogicalResult
   matchAndRewrite(pto::VaxpyOp op, pto::VaxpyOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto laneCount = getElementCountFromVectorLike(op.getResult().getType());
     Type elemType = getElementTypeFromVectorLike(op.getResult().getType());
-    if (!laneCount || !elemType)
+    if (!elemType)
       return rewriter.notifyMatchFailure(op, "unsupported vaxpy signature");
-
-    FailureOr<Value> mask = materializeDynamicPltMask(
-        rewriter, state, op.getLoc(), getI32Constant(rewriter, op.getLoc(), *laneCount),
-        elemType);
-    if (failed(mask))
-      return rewriter.notifyMatchFailure(op, "failed to materialize vaxpy mask");
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -5713,12 +5706,12 @@ public:
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSrc1().getType(), adaptor.getSrc0().getType(),
-                  adaptor.getAlpha().getType(), (*mask).getType()},
+                  adaptor.getAlpha().getType(), adaptor.getMask().getType()},
         TypeRange{resultType});
     auto call = rewriter.create<func::CallOp>(
         op.getLoc(), *calleeName, TypeRange{resultType},
         ValueRange{adaptor.getSrc1(), adaptor.getSrc0(), adaptor.getAlpha(),
-                   *mask});
+                   adaptor.getMask()});
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.replaceOp(op, call.getResults());
     return success();
@@ -5945,20 +5938,9 @@ public:
   LogicalResult
   matchAndRewrite(pto::VcvtOp op, pto::VcvtOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto inputLanes = getElementCountFromVectorLike(op.getInput().getType());
-    if (!inputLanes)
-      return rewriter.notifyMatchFailure(op, "unsupported vcvt input shape");
-
     FailureOr<VcvtContract> contract = buildVcvtContract(op);
     if (failed(contract))
       return rewriter.notifyMatchFailure(op, "unsupported vcvt type pair");
-
-    Type maskElemType = rewriter.getIntegerType((*contract).maskBitWidth);
-    FailureOr<Value> mask = materializeDynamicPltMask(
-        rewriter, state, op.getLoc(),
-        getI32Constant(rewriter, op.getLoc(), *inputLanes), maskElemType);
-    if (failed(mask))
-      return rewriter.notifyMatchFailure(op, "failed to materialize vcvt mask");
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -5968,8 +5950,8 @@ public:
     SmallVector<Type> argTypes;
     callArgs.push_back(adaptor.getInput());
     argTypes.push_back(adaptor.getInput().getType());
-    callArgs.push_back(*mask);
-    argTypes.push_back((*mask).getType());
+    callArgs.push_back(adaptor.getMask());
+    argTypes.push_back(adaptor.getMask().getType());
 
     auto appendRndArg = [&]() -> LogicalResult {
       auto roundMode =

--- a/test/basic/expand_tile_op_tilelang_tcvt.pto
+++ b/test/basic/expand_tile_op_tilelang_tcvt.pto
@@ -20,25 +20,25 @@
 // CHECK-LABEL: func.func @TCVT_F32_TO_I32
 // CHECK-NOT: pto.tcvt ins
 // CHECK: pto.vecscope
-// CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
-// CHECK: pto.vcvt {{.*}} {rnd = "A", sat = "SAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+// CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+// CHECK: pto.vcvt {{.*}} {rnd = "A", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 
 // CHECK-LABEL: func.func @TCVT_I32_TO_F32
 // CHECK-NOT: pto.tcvt ins
 // CHECK: pto.vecscope
-// CHECK: pto.vcvt {{.*}} {rnd = "R"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
-// CHECK: pto.vcvt {{.*}} {rnd = "A"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+// CHECK: pto.vcvt {{.*}} {rnd = "R"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: pto.vcvt {{.*}} {rnd = "A"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @TCVT_F16_TO_F32
 // CHECK-NOT: pto.tcvt ins
 // CHECK: pto.vecscope
 // CHECK: pto.vlds {{.*}} {dist = "UNPK_B16"} : {{.*}} -> !pto.vreg<128xf16>
-// CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+// CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @TCVT_F32_TO_F16
 // CHECK-NOT: pto.tcvt ins
 // CHECK: pto.vecscope
-// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
 // CHECK: pto.vsts {{.*}} {dist = "PK_B32"} : !pto.vreg<128xf16>, {{.*}}, !pto.mask<b32>
 
 module {

--- a/test/basic/tilelang_soft_vmod_backend_inline.pto
+++ b/test/basic/tilelang_soft_vmod_backend_inline.pto
@@ -31,14 +31,14 @@ module attributes {pto.target_arch = "a5"} {
     %active_mask_16 = pto.pnot %zero_mask_15, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
     %zero_u16_17 = pto.vbr %zero_10 : ui16 -> !pto.vreg<128xui16>
     %vy_lower_u16_18, %vy_higher_u16_19 = pto.vintlv %arg1, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
-    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
     %active_low_22 = pto.vcmps %vy_lower_u32_20, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
     %active_high_23 = pto.vcmps %vy_higher_u32_21, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
     %tmp_2 = pto.vbitcast %vy_lower_u32_20 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
-    %vy_lower_f32_24 = pto.vcvt %tmp_2 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %vy_lower_f32_24 = pto.vcvt %tmp_2, %active_low_22 {rnd = "F"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_3 = pto.vbitcast %vy_higher_u32_21 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
-    %vy_higher_f32_25 = pto.vcvt %tmp_3 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %vy_higher_f32_25 = pto.vcvt %tmp_3, %active_high_23 {rnd = "F"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_4 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
     %vy_rec_lower_26 = pto.vdiv %tmp_4, %vy_lower_f32_24, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_5 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
@@ -47,13 +47,13 @@ module attributes {pto.target_arch = "a5"} {
     %vy_scale_lower_28 = pto.vmul %vy_rec_lower_26, %tmp_6, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_7 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
     %vy_scale_higher_29 = pto.vmul %vy_rec_higher_27, %tmp_7, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
-    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28, %active_low_22 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29, %active_high_23 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
     %v_lower_u32_32 = pto.vbitcast %v_lower_i32_30 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
     %v_higher_u32_33 = pto.vbitcast %v_higher_i32_31 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
     %vx_lower_u16_34, %vx_higher_u16_35 = pto.vintlv %arg0, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
-    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
     %q_tmp_lower_38 = pto.vmul %v_lower_u32_32, %vx_lower_u32_36, %active_low_22 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
     %q_tmp_higher_39 = pto.vmul %v_higher_u32_33, %vx_higher_u32_37, %active_high_23 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
     %tmp_8 = pto.vbitcast %q_tmp_lower_38 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>

--- a/test/basic/vcvt_part_modes_verify_invalid_even_odd.pto
+++ b/test/basic/vcvt_part_modes_verify_invalid_even_odd.pto
@@ -8,14 +8,14 @@
 
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
 
-// CHECK: error: 'pto.vcvt' op part must be P0, P1, P2, or P3 for 8/32 vcvt forms
+// CHECK: error: 'pto.vcvt' op part must be EVEN or ODD for 8/16 and 16/32 vcvt forms
 
 module attributes {pto.target_arch = "a5"} {
-  func.func @vcvt_u32_to_u8_rejects_even(%seed: ui32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_u16_to_u8_rejects_p0(%seed: ui16) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
     pto.vecscope {
-      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-      %src = pto.vbr %seed : ui32 -> !pto.vreg<64xui32>
-      %bad = pto.vcvt %src, %mask {sat = "SAT", part = "EVEN"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %src = pto.vbr %seed : ui16 -> !pto.vreg<128xui16>
+      %bad = pto.vcvt %src, %mask {sat = "SAT", part = "P0"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<256xui8>
     }
     return
   }

--- a/test/basic/vcvt_part_modes_vpto_llvm.pto
+++ b/test/basic/vcvt_part_modes_vpto_llvm.pto
@@ -13,11 +13,12 @@ module attributes {pto.target_arch = "a5"} {
     %c0 = arith.constant 0 : index
     pto.vecscope {
       %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %src_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
       %src = pto.vbr %seed : ui32 -> !pto.vreg<64xui32>
-      %p0 = pto.vcvt %src {sat = "SAT", part = "P0"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-      %p1 = pto.vcvt %src {sat = "SAT", part = "P1"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-      %p2 = pto.vcvt %src {sat = "SAT", part = "P2"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-      %p3 = pto.vcvt %src {sat = "SAT", part = "P3"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+      %p0 = pto.vcvt %src, %src_mask {sat = "SAT", part = "P0"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+      %p1 = pto.vcvt %src, %src_mask {sat = "SAT", part = "P1"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+      %p2 = pto.vcvt %src, %src_mask {sat = "SAT", part = "P2"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+      %p3 = pto.vcvt %src, %src_mask {sat = "SAT", part = "P3"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
       %m01 = pto.vor %p0, %p1, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
       %m23 = pto.vor %p2, %p3, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
       %out = pto.vor %m01, %m23, %mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
@@ -28,7 +29,8 @@ module attributes {pto.target_arch = "a5"} {
 }
 
 // CHECK-LABEL: define void @vcvt_u32_to_u8_packed_parts(
-// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 0)
-// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 1)
-// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 2)
-// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}} i32 0, i32 3)
+// CHECK: [[SRC_MASK:%[0-9]+]] = call <256 x i1> @llvm.hivm.pset.b32(i32 0)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}}, <256 x i1> [[SRC_MASK]], i32 0, i32 0)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}}, <256 x i1> [[SRC_MASK]], i32 0, i32 1)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}}, <256 x i1> [[SRC_MASK]], i32 0, i32 2)
+// CHECK: call <256 x i8> @llvm.hivm.vcvtii.u322u8.x({{.*}}, <256 x i1> [[SRC_MASK]], i32 0, i32 3)

--- a/test/vpto/cases/micro-op/conversion/vcvt-f16-special/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f16-special/kernel.pto
@@ -24,9 +24,10 @@ module attributes {pto.target_arch = "a5"} {
 
     pto.vecscope {
       %full_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %cvt_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
       scf.for %offset = %c0 to %c1024 step %c64 {
         %loaded = pto.vlds %ub_in[%offset] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
-        %out = pto.vcvt %loaded {part = "EVEN"} : !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %out = pto.vcvt %loaded, %cvt_mask {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
         pto.vsts %out, %ub_out[%offset], %full_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32-part-even/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32-part-even/kernel.pto
@@ -26,11 +26,12 @@ module attributes {pto.target_arch = "a5"} {
 
     pto.vecscope {
       %full_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %cvt_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
       // Use packed f16 load (no UNPK): PART_EVEN selects the lower 16-bit
       // element from each f16 pair inside a b32 lane.
       scf.for %offset = %c0 to %c512 step %c64 {
         %loaded = pto.vlds %ub_in[%offset] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
-        %out = pto.vcvt %loaded {part = "EVEN"} : !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %out = pto.vcvt %loaded, %cvt_mask {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
         pto.vsts %out, %ub_out[%offset], %full_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32-part-odd/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32-part-odd/kernel.pto
@@ -26,11 +26,12 @@ module attributes {pto.target_arch = "a5"} {
 
     pto.vecscope {
       %full_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %cvt_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
       // Use packed f16 load (no UNPK): PART_ODD then selects the upper 16-bit
       // element from each f16 pair inside a b32 lane.
       scf.for %offset = %c0 to %c512 step %c64 {
         %loaded = pto.vlds %ub_in[%offset] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
-        %out = pto.vcvt %loaded {part = "ODD"} : !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %out = pto.vcvt %loaded, %cvt_mask {part = "ODD"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
         pto.vsts %out, %ub_out[%offset], %full_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f16-to-f32/kernel.pto
@@ -24,9 +24,10 @@ module attributes {pto.target_arch = "a5"} {
 
     pto.vecscope {
       %full_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %cvt_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
       scf.for %offset = %c0 to %c1024 step %c64 {
         %loaded = pto.vlds %ub_in[%offset] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
-        %out = pto.vcvt %loaded {part = "EVEN"} : !pto.vreg<128xf16> -> !pto.vreg<64xf32>
+        %out = pto.vcvt %loaded, %cvt_mask {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
         pto.vsts %out, %ub_out[%offset], %full_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-f32-special/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f32-special/kernel.pto
@@ -28,11 +28,13 @@ module attributes {pto.target_arch = "a5"} {
     pto.vecscope {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c128 iter_args(%remaining = %c1024_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %lower_mask, %upper_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %upper_mask, %_next_b32 = pto.plt_b32 %upper_remaining : i32 -> !pto.mask<b32>, i32
         %upper_offset = arith.addi %offset, %c64 : index
         %lower = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %upper = pto.vlds %ub_in[%upper_offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %even = pto.vcvt %lower {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-        %odd = pto.vcvt %upper {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+        %even = pto.vcvt %lower, %lower_mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+        %odd = pto.vcvt %upper, %upper_mask {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
         %merged = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
         pto.vsts %merged, %ub_out[%offset], %mask : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
         scf.yield %next_remaining : i32

--- a/test/vpto/cases/micro-op/conversion/vcvt-f32-to-f16-pk-b32/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f32-to-f16-pk-b32/kernel.pto
@@ -32,7 +32,7 @@ module attributes {pto.target_arch = "a5"} {
       %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
       scf.for %offset = %c0 to %c1024 step %c64 {
         %loaded = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %converted = pto.vcvt %loaded {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+        %converted = pto.vcvt %loaded, %mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
         pto.vsts %converted, %ub_out[%offset], %mask {dist = "PK_B32"} : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-f32-to-f16/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f32-to-f16/kernel.pto
@@ -28,11 +28,13 @@ module attributes {pto.target_arch = "a5"} {
     pto.vecscope {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c128 iter_args(%remaining = %c1024_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %lower_mask, %upper_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %upper_mask, %_next_b32 = pto.plt_b32 %upper_remaining : i32 -> !pto.mask<b32>, i32
         %upper_offset = arith.addi %offset, %c64 : index
         %lower = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %upper = pto.vlds %ub_in[%upper_offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %even = pto.vcvt %lower {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-        %odd = pto.vcvt %upper {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+        %even = pto.vcvt %lower, %lower_mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+        %odd = pto.vcvt %upper, %upper_mask {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
         %merged = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
         pto.vsts %merged, %ub_out[%offset], %mask : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
         scf.yield %next_remaining : i32

--- a/test/vpto/cases/micro-op/conversion/vcvt-i32-to-i16-overflow/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-i32-to-i16-overflow/kernel.pto
@@ -33,11 +33,13 @@ module attributes {pto.target_arch = "a5"} {
     pto.vecscope {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c128 iter_args(%remaining = %c1024_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %lower_mask, %upper_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %upper_mask, %_next_b32 = pto.plt_b32 %upper_remaining : i32 -> !pto.mask<b32>, i32
         %upper_offset = arith.addi %offset, %c64 : index
         %lower = pto.vlds %ub_in[%offset] : !pto.ptr<i32, ub> -> !pto.vreg<64xi32>
         %upper = pto.vlds %ub_in[%upper_offset] : !pto.ptr<i32, ub> -> !pto.vreg<64xi32>
-        %even = pto.vcvt %lower {sat = "SAT", part = "EVEN"} : !pto.vreg<64xi32> -> !pto.vreg<128xi16>
-        %odd = pto.vcvt %upper {sat = "SAT", part = "ODD"} : !pto.vreg<64xi32> -> !pto.vreg<128xi16>
+        %even = pto.vcvt %lower, %lower_mask {sat = "SAT", part = "EVEN"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<128xi16>
+        %odd = pto.vcvt %upper, %upper_mask {sat = "SAT", part = "ODD"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<128xi16>
         %merged = pto.vor %even, %odd, %mask : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
         pto.vsts %merged, %ub_out[%offset], %mask : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
         scf.yield %next_remaining : i32

--- a/test/vpto/cases/micro-op/conversion/vcvt-i64-to-f32/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-i64-to-f32/kernel.pto
@@ -39,7 +39,7 @@ module attributes {pto.target_arch = "a5"} {
       scf.for %store_offset = %c0 to %c512 step %c16 {
         %input_offset = arith.muli %store_offset, %c2 : index
         %loaded = pto.vlds %ub_in[%input_offset] : !pto.ptr<si64, ub> -> !pto.vreg<32xsi64>
-        %converted = pto.vcvt %loaded {rnd = "R", part = "EVEN"} : !pto.vreg<32xsi64> -> !pto.vreg<64xf32>
+        %converted = pto.vcvt %loaded, %mask {rnd = "R", part = "EVEN"} : !pto.vreg<32xsi64>, !pto.mask<b32> -> !pto.vreg<64xf32>
         pto.vsts %converted, %ub_out[%store_offset], %mask {dist = "PK_B64"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto/cases/micro-op/conversion/vcvt-tail-special/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-tail-special/kernel.pto
@@ -28,11 +28,13 @@ module attributes {pto.target_arch = "a5"} {
     pto.vecscope {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c128 iter_args(%remaining = %c1000_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %lower_mask, %upper_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %upper_mask, %_next_b32 = pto.plt_b32 %upper_remaining : i32 -> !pto.mask<b32>, i32
         %upper_offset = arith.addi %offset, %c64 : index
         %lower = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %upper = pto.vlds %ub_in[%upper_offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %even = pto.vcvt %lower {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-        %odd = pto.vcvt %upper {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+        %even = pto.vcvt %lower, %lower_mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+        %odd = pto.vcvt %upper, %upper_mask {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
         %merged = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
         pto.vsts %merged, %ub_out[%offset], %mask : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
         scf.yield %next_remaining : i32

--- a/test/vpto/cases/micro-op/conversion/vcvt-tail/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-tail/kernel.pto
@@ -28,11 +28,13 @@ module attributes {pto.target_arch = "a5"} {
     pto.vecscope {
       %_:1 = scf.for %offset = %c0 to %c1024 step %c128 iter_args(%remaining = %c1000_i32) -> (i32) {
         %mask, %next_remaining = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %lower_mask, %upper_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %upper_mask, %_next_b32 = pto.plt_b32 %upper_remaining : i32 -> !pto.mask<b32>, i32
         %upper_offset = arith.addi %offset, %c64 : index
         %lower = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %upper = pto.vlds %ub_in[%upper_offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %even = pto.vcvt %lower {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
-        %odd = pto.vcvt %upper {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32> -> !pto.vreg<128xf16>
+        %even = pto.vcvt %lower, %lower_mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+        %odd = pto.vcvt %upper, %upper_mask {rnd = "R", sat = "SAT", part = "ODD"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
         %merged = pto.vor %even, %odd, %mask : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
         pto.vsts %merged, %ub_out[%offset], %mask : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
         scf.yield %next_remaining : i32

--- a/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/kernel.pto
+++ b/test/vpto/cases/micro-op/conversion/vcvt-u32-to-u8-part-p0123/kernel.pto
@@ -34,6 +34,7 @@ module attributes {pto.target_arch = "a5"} {
 
     pto.vecscope {
       %full_mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %cvt_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
       scf.for %offset = %c0 to %c1024 step %c256 {
         %offset_p1 = arith.addi %offset, %c64 : index
         %offset_p2 = arith.addi %offset, %c128 : index
@@ -42,10 +43,10 @@ module attributes {pto.target_arch = "a5"} {
         %src_p1 = pto.vlds %ub_in[%offset_p1] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
         %src_p2 = pto.vlds %ub_in[%offset_p2] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
         %src_p3 = pto.vlds %ub_in[%offset_p3] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
-        %part_p0 = pto.vcvt %src_p0 {sat = "SAT", part = "P0"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-        %part_p1 = pto.vcvt %src_p1 {sat = "SAT", part = "P1"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-        %part_p2 = pto.vcvt %src_p2 {sat = "SAT", part = "P2"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-        %part_p3 = pto.vcvt %src_p3 {sat = "SAT", part = "P3"} : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
+        %part_p0 = pto.vcvt %src_p0, %cvt_mask {sat = "SAT", part = "P0"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+        %part_p1 = pto.vcvt %src_p1, %cvt_mask {sat = "SAT", part = "P1"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+        %part_p2 = pto.vcvt %src_p2, %cvt_mask {sat = "SAT", part = "P2"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+        %part_p3 = pto.vcvt %src_p3, %cvt_mask {sat = "SAT", part = "P3"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<256xui8>
         %merged01 = pto.vor %part_p0, %part_p1, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
         %merged23 = pto.vor %part_p2, %part_p3, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>
         %merged = pto.vor %merged01, %merged23, %full_mask : !pto.vreg<256xui8>, !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<256xui8>

--- a/test/vpto/cases/micro-op/dsa-sfu/vaxpy-f32/kernel.pto
+++ b/test/vpto/cases/micro-op/dsa-sfu/vaxpy-f32/kernel.pto
@@ -41,7 +41,7 @@ module attributes {pto.target_arch = "a5"} {
       scf.for %offset = %c0 to %c1024 step %c64 {
         %vec = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         %addend = pto.vlds %ub_addend[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-        %sum = pto.vaxpy %vec, %addend, %alpha : !pto.vreg<64xf32>, !pto.vreg<64xf32>, f32 -> !pto.vreg<64xf32>
+        %sum = pto.vaxpy %vec, %addend, %alpha, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
         pto.vsts %sum, %ub_out[%offset], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
       }
     }

--- a/test/vpto_tilelang_inline_soft_divmod_fastpath.pto
+++ b/test/vpto_tilelang_inline_soft_divmod_fastpath.pto
@@ -54,14 +54,14 @@ module attributes {pto.target_arch = "a5"} {
     %active_mask_16 = pto.pnot %zero_mask_15, %arg2 : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>
     %zero_u16_17 = pto.vbr %zero_10 : ui16 -> !pto.vreg<128xui16>
     %vy_lower_u16_18, %vy_higher_u16_19 = pto.vintlv %arg1, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
-    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vy_lower_u32_20 = pto.vcvt %vy_lower_u16_18, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+    %vy_higher_u32_21 = pto.vcvt %vy_higher_u16_19, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
     %active_low_22 = pto.vcmps %vy_lower_u32_20, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
     %active_high_23 = pto.vcmps %vy_higher_u32_21, %c0_ui32, %full_mask_b32_14, "ne" : !pto.vreg<64xui32>, ui32, !pto.mask<b32> -> !pto.mask<b32>
     %tmp_2 = pto.vbitcast %vy_lower_u32_20 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
-    %vy_lower_f32_24 = pto.vcvt %tmp_2 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %vy_lower_f32_24 = pto.vcvt %tmp_2, %active_low_22 {rnd = "F"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_3 = pto.vbitcast %vy_higher_u32_21 : !pto.vreg<64xui32> -> !pto.vreg<64xi32>
-    %vy_higher_f32_25 = pto.vcvt %tmp_3 {rnd = "F"} : !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+    %vy_higher_f32_25 = pto.vcvt %tmp_3, %active_high_23 {rnd = "F"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_4 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
     %vy_rec_lower_26 = pto.vdiv %tmp_4, %vy_lower_f32_24, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_5 = pto.vbr %fp32_one_12 : f32 -> !pto.vreg<64xf32>
@@ -70,13 +70,13 @@ module attributes {pto.target_arch = "a5"} {
     %vy_scale_lower_28 = pto.vmul %vy_rec_lower_26, %tmp_6, %active_low_22 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
     %tmp_7 = pto.vbr %c65536_0_f32 : f32 -> !pto.vreg<64xf32>
     %vy_scale_higher_29 = pto.vmul %vy_rec_higher_27, %tmp_7, %active_high_23 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
-    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32> -> !pto.vreg<64xi32>
+    %v_lower_i32_30 = pto.vcvt %vy_scale_lower_28, %active_low_22 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+    %v_higher_i32_31 = pto.vcvt %vy_scale_higher_29, %active_high_23 {rnd = "F", sat = "NOSAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xi32>
     %v_lower_u32_32 = pto.vbitcast %v_lower_i32_30 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
     %v_higher_u32_33 = pto.vbitcast %v_higher_i32_31 : !pto.vreg<64xi32> -> !pto.vreg<64xui32>
     %vx_lower_u16_34, %vx_higher_u16_35 = pto.vintlv %arg0, %zero_u16_17 : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
-    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35 {part = "EVEN"} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+    %vx_lower_u32_36 = pto.vcvt %vx_lower_u16_34, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+    %vx_higher_u32_37 = pto.vcvt %vx_higher_u16_35, %active_mask_16 {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
     %q_tmp_lower_38 = pto.vmul %v_lower_u32_32, %vx_lower_u32_36, %active_low_22 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
     %q_tmp_higher_39 = pto.vmul %v_higher_u32_33, %vx_higher_u32_37, %active_high_23 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
     %tmp_8 = pto.vbitcast %q_tmp_lower_38 : !pto.vreg<64xui32> -> !pto.vreg<128xui16>

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-current.md
@@ -674,7 +674,7 @@ pto.vstsx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vre
 **Conversion (one vector in, different-typed vector out):**
 
 ```mlir
-%result = pto.vcvt %input {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0> -> !pto.vreg<MxT1>
+%result = pto.vcvt %input, %mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0>, !pto.mask<G> -> !pto.vreg<MxT1>
 ```
 
 **Predicate construction:**
@@ -4916,7 +4916,7 @@ for (int i = 0; i < N; i++)
 
 ##### `pto.vaxpy`
 
-- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha : !pto.vreg<NxT>, !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** AXPY — scalar-vector multiply-add.
 
@@ -4925,8 +4925,8 @@ for (int i = 0; i < N; i++)
     dst[i] = alpha * src0[i] + src1[i];
 ```
 
-- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector, and
-  `%alpha` is the scalar multiplier.
+- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector,
+  `%alpha` is the scalar multiplier, and `%mask` selects active lanes.
 - **outputs:** `%result` is the fused AXPY result.
 - **constraints and limitations:** Floating-point element types only on the
   current documented surface.

--- a/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
+++ b/tilelang-dsl/docs/vpto_spec/vpto-spec-v0.3.md
@@ -674,7 +674,7 @@ pto.vstsx2 %low, %high, %dest[%offset], "DIST", %mask : !pto.vreg<NxT>, !pto.vre
 **Conversion (one vector in, different-typed vector out):**
 
 ```mlir
-%result = pto.vcvt %input {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0> -> !pto.vreg<MxT1>
+%result = pto.vcvt %input, %mask {rnd = "R", sat = "SAT", part = "EVEN"} : !pto.vreg<NxT0>, !pto.mask<G> -> !pto.vreg<MxT1>
 ```
 
 **Predicate construction:**
@@ -4882,7 +4882,7 @@ for (int i = 0; i < N; i++)
 
 ##### `pto.vaxpy`
 
-- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha : !pto.vreg<NxT>, !pto.vreg<NxT>, T -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vaxpy %src0, %src1, %alpha, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, T, !pto.mask<G> -> !pto.vreg<NxT>`
 - **A5 types:** f16, f32
 - **semantics:** AXPY — scalar-vector multiply-add.
 
@@ -4891,8 +4891,8 @@ for (int i = 0; i < N; i++)
     dst[i] = alpha * src0[i] + src1[i];
 ```
 
-- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector, and
-  `%alpha` is the scalar multiplier.
+- **inputs:** `%src0` is the scaled vector, `%src1` is the addend vector,
+  `%alpha` is the scalar multiplier, and `%mask` selects active lanes.
 - **outputs:** `%result` is the fused AXPY result.
 - **constraints and limitations:** Floating-point element types only on the
   current documented surface.

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2960,6 +2960,7 @@ class _AuthoringRenderer:
 
         if expr.name == "vcvt":
             value = self._lower_expr(expr.args[0], env, indent=indent, into=into)
+            mask = self._lower_expr(expr.args[2], env, indent=indent, into=into)
             attr_parts: list[str] = []
             if self._has_optional_string_literal(expr.args[3]):
                 attr_parts.append(f"rnd = {self._render_string_literal(expr.args[3])}")
@@ -2970,8 +2971,8 @@ class _AuthoringRenderer:
             attr_suffix = f" {{{', '.join(attr_parts)}}}" if attr_parts else ""
             into.append(
                 self._indent(indent)
-                + f"{result_name} = pto.vcvt {value.name}{attr_suffix} : "
-                + f"{self._render_type(value.type)} -> {self._render_type(expr.type)}"
+                + f"{result_name} = pto.vcvt {value.name}, {mask.name}{attr_suffix} : "
+                + f"{self._render_type(value.type)}, {self._render_type(mask.type)} -> {self._render_type(expr.type)}"
             )
             return _RenderedValue(name=result_name, type=expr.type)
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3600,7 +3600,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn('part = "ODD"', text)
         self.assertRegex(
             text,
-            r"= pto\.vcvt %[^,\s]+(?: \{[^}]+\})? : !pto\.vreg<[^>]+> -> !pto\.vreg<[^>]+>",
+            r"= pto\.vcvt %[^,\s]+, %[^,\s]+(?: \{[^}]+\})? : !pto\.vreg<[^>]+>, !pto\.mask<b32> -> !pto\.vreg<[^>]+>",
         )
 
     def test_vcvt_supports_part_t_modes_with_enum(self) -> None:


### PR DESCRIPTION
## Summary
- add explicit mask operands to `pto.vcvt` and `pto.vaxpy`
- lower both ops with the user-provided mask instead of materializing an all-active mask
- update DSL lowering, VPTO tests, validation cases, and VPTO docs/specs for the new syntax

## Validation
- `cmake --build build --target ptoas -j$(nproc)`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TestTileLangDSL.test_vcvt_supports_keyword_attrs_with_enums`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TestTileLangDSL.test_vcvt_i32_to_i64_reuses_b32_mask_and_emits_i64_vreg`
- `PYTHONPATH=tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TestTileLangDSL.test_fused_vector_ops_surface_lowers`
- `PATH=build/tools/ptoas:$PATH lit -v test/basic/vcvt_part_modes_vpto_llvm.pto`
- `WORK_SPACE=/tmp/pto-vpto-conversion-validation ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" PTOAS_BIN=/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas CASE_PREFIX=micro-op/conversion JOBS=8 test/vpto/scripts/run_host_vpto_validation_parallel.sh` (`PASS=16 FAIL=0`)
- `WORK_SPACE=/tmp/pto-vpto-vaxpy-validation ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" PTOAS_BIN=/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas CASE_NAME=micro-op/dsa-sfu/vaxpy-f32 test/vpto/scripts/run_host_vpto_validation_parallel.sh` (`PASS=1 FAIL=0`)
- `WORK_SPACE=/mnt/data/home/zhangzhendong/pto-vpto-host-validation ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" PTOAS_BIN=/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas JOBS=8 test/vpto/scripts/run_host_vpto_validation_parallel.sh` (`PASS=256 FAIL=0`)

Note: an initial full `test/vpto` run under `/tmp` hit inode exhaustion (`No space left on device`), so it was rerun under `/mnt/data/home/zhangzhendong` and passed.

Close #289 