### PR TITLE
Fix TileLang soft-math helper lookup in installed layout

### DIFF
--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -221,14 +221,27 @@ def _load_module_from_path(module_name: str, path: Path) -> Any:
     return module
 
 
+def _find_internal_soft_math_path() -> Path | None:
+    module_path = Path(__file__).resolve()
+    candidate_suffixes = (
+        ("lib", "TileOps", "math.py"),
+        ("share", "ptoas", "TileOps", "math.py"),
+    )
+    for root in (module_path.parent, *module_path.parents):
+        for suffix in candidate_suffixes:
+            candidate = root.joinpath(*suffix)
+            if candidate.exists():
+                return candidate
+    return None
+
+
 def _collect_internal_inline_procs() -> tuple[tuple[str, InlineProcDescriptor], ...]:
     global _INTERNAL_INLINE_PROC_CACHE
     if _INTERNAL_INLINE_PROC_CACHE is not None:
         return _INTERNAL_INLINE_PROC_CACHE
 
-    repo_root = Path(__file__).resolve().parents[3]
-    soft_math_path = repo_root / "lib" / "TileOps" / "math.py"
-    if not soft_math_path.exists():
+    soft_math_path = _find_internal_soft_math_path()
+    if soft_math_path is None:
         _INTERNAL_INLINE_PROC_CACHE = ()
         return _INTERNAL_INLINE_PROC_CACHE
 


### PR DESCRIPTION
## Summary
- make TileLang internal soft-math helper lookup work in both source-tree and installed layouts
- search upward for either lib/TileOps/math.py or share/ptoas/TileOps/math.py instead of assuming a fixed repo-root depth
- unblock integer tcolexpanddiv/trowexpanddiv style paths that lower integer vdiv/vmod through _tl_soft_vdiv/_tl_soft_vmod

## Validation
- python3 -m py_compile tilelang-dsl/python/tilelang_dsl/kernel.py
- python3 -c 'import sys; sys.path.insert(0, "/home/zhangzhendong/ptoas-workspace/PTOAS/tilelang-dsl/python"); from tilelang_dsl.kernel import _collect_internal_inline_procs; items = _collect_internal_inline_procs(); print(len(items), any(name == "_tl_soft_vdiv" for name, _ in items))'
- python3 ../ptoas-workspace/PTOAS/test/tilelang_st/script/run_all_st.py -r sim -v a5 -t tcolexpanddiv
