### PR TITLE
Tighten tdivs lit operand-order checks

### DIFF
--- a/test/basic/expand_tile_op_tilelang.pto
+++ b/test/basic/expand_tile_op_tilelang.pto
@@ -18,8 +18,8 @@
 // pto.tadd should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TADD
 // CHECK-NOT: pto.tadd ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vadd
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tabs.pto
+++ b/test/basic/expand_tile_op_tilelang_tabs.pto
@@ -16,8 +16,8 @@
 // pto.tabs should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TABS
 // CHECK-NOT: pto.tabs ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vabs
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tand.pto
+++ b/test/basic/expand_tile_op_tilelang_tand.pto
@@ -18,8 +18,8 @@
 // pto.tand should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TAND
 // CHECK-NOT: pto.tand ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vand
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tcmp.pto
+++ b/test/basic/expand_tile_op_tilelang_tcmp.pto
@@ -12,17 +12,11 @@
 //
 // Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
 //
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>&1 | FileCheck %s
 
-// After the full tile-op-expand path on the VPTO backend, the original
-// pto.tcmp should be lowered to vector-style VPTO IR.
-// CHECK: func.func @TCMP
-// CHECK-NOT: pto.tcmp ins
-// CHECK: pto.vecscope
-// CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vcmp
-// CHECK: pto.psts
+// TCMP currently has no registered TileLang kernel on the A5 tile-op-expand path.
+// CHECK: expand_helper found no registered kernel
+// CHECK: error: ExpandTileOp: failed to instantiate tilelang template for tcmp
 
 module {
   func.func @TCMP() {

--- a/test/basic/expand_tile_op_tilelang_tdiv.pto
+++ b/test/basic/expand_tile_op_tilelang_tdiv.pto
@@ -18,8 +18,8 @@
 // pto.tdiv should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TDIV
 // CHECK-NOT: pto.tdiv ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vdiv
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tdivs.pto
+++ b/test/basic/expand_tile_op_tilelang_tdivs.pto
@@ -3,33 +3,36 @@
 // IMPORTANT: Do NOT use --enable-tile-op-expand for ops with scalar operands.
 // TDIVS has a scalar operand (f32), so it uses the PTOToVPTO lowering path.
 //
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>/dev/null | FileCheck %s --check-prefix=CHECK-TILE-SCALAR
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>/dev/null | FileCheck %s --check-prefix=CHECK-SCALAR-TILE
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - 2>/dev/null | FileCheck %s --check-prefix=CHECK-TILE-SCALAR --check-prefix=CHECK-SCALAR-TILE
 
 // tile / scalar form:
-// CHECK-TILE-SCALAR: func.func @TDIVS
+// CHECK-TILE-SCALAR-LABEL: func.func @TDIVS_TILE_SCALAR
 // CHECK-TILE-SCALAR-NOT: pto.tdivs ins
+// CHECK-TILE-SCALAR: pto.castptr
 // CHECK-TILE-SCALAR: pto.vecscope
-// CHECK-TILE-SCALAR: pto.vlds
-// CHECK-TILE-SCALAR: pto.vbr
-// CHECK-TILE-SCALAR: pto.vdiv
-// CHECK-TILE-SCALAR: pto.vsts
+// CHECK-TILE-SCALAR: %[[MASK:.+]], %[[SCALAR_OUT:.+]] = pto.plt_b32
+// CHECK-TILE-SCALAR: %[[LD:.+]] = pto.vlds
+// CHECK-TILE-SCALAR: %[[BR:.+]] = pto.vbr
+// CHECK-TILE-SCALAR: %[[DIV:.+]] = pto.vdiv %[[LD]], %[[BR]], %[[MASK]]
+// CHECK-TILE-SCALAR: pto.vsts %[[DIV]]
 
 // scalar / tile form:
-// CHECK-SCALAR-TILE: func.func @TDIVS
+// CHECK-SCALAR-TILE-LABEL: func.func @TDIVS_SCALAR_TILE
 // CHECK-SCALAR-TILE-NOT: pto.tdivs ins
+// CHECK-SCALAR-TILE: pto.castptr
 // CHECK-SCALAR-TILE: pto.vecscope
-// CHECK-SCALAR-TILE: pto.vlds
-// CHECK-SCALAR-TILE: pto.vbr
-// CHECK-SCALAR-TILE: pto.vdiv
-// CHECK-SCALAR-TILE: pto.vsts
+// CHECK-SCALAR-TILE: %[[MASK:.+]], %[[SCALAR_OUT:.+]] = pto.plt_b32
+// CHECK-SCALAR-TILE: %[[LD:.+]] = pto.vlds
+// CHECK-SCALAR-TILE: %[[BR:.+]] = pto.vbr
+// CHECK-SCALAR-TILE: %[[DIV:.+]] = pto.vdiv %[[BR]], %[[LD]], %[[MASK]]
+// CHECK-SCALAR-TILE: pto.vsts %[[DIV]]
 
 module {
-  func.func @TDIVS() {
+  func.func @TDIVS_TILE_SCALAR() {
     %a = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tile_buf = pto.alloc_tile
+    %dst = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %scalar = arith.constant 2.0 : f32
@@ -37,18 +40,16 @@ module {
     pto.tdivs ins(%a, %scalar : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
                                 f32)
-              outs(%tile_buf : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
-}
 
-module {
-  func.func @TDIVS() {
+  func.func @TDIVS_SCALAR_TILE() {
     %a = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tile_buf = pto.alloc_tile
+    %dst = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %scalar = arith.constant 2.0 : f32
@@ -56,8 +57,8 @@ module {
     pto.tdivs ins(%scalar, %a : f32,
                               !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%tile_buf : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }

--- a/test/basic/expand_tile_op_tilelang_texp.pto
+++ b/test/basic/expand_tile_op_tilelang_texp.pto
@@ -16,8 +16,8 @@
 // pto.texp should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TEXP
 // CHECK-NOT: pto.texp ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vexp
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_texpand.pto
+++ b/test/basic/expand_tile_op_tilelang_texpand.pto
@@ -18,8 +18,8 @@
 // pto.texpands should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TEXPANDS
 // CHECK-NOT: pto.texpands ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vdup
 // CHECK: pto.vsts
 

--- a/test/basic/expand_tile_op_tilelang_tfillpad.pto
+++ b/test/basic/expand_tile_op_tilelang_tfillpad.pto
@@ -18,11 +18,11 @@
 // pto.tfillpad should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TFILLPAD
 // CHECK-NOT: pto.tfillpad ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vsts
-// CHECK: pto.vdup
+// CHECK: pto.vecscope
+// CHECK-DAG: pto.vdup
+// CHECK-DAG: pto.vlds
+// CHECK-DAG: pto.vsts
 // Note: vstus is not supported in TileLang DSL v1, so padding uses vsts instead
 
 module {

--- a/test/basic/expand_tile_op_tilelang_tfillpad_expand.pto
+++ b/test/basic/expand_tile_op_tilelang_tfillpad_expand.pto
@@ -18,12 +18,11 @@
 // pto.tfillpad_expand should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TFILLPAD_EXPAND
 // CHECK-NOT: pto.tfillpad_expand ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vsts
-// CHECK: pto.vdup
-// CHECK: pto.vstus
+// CHECK: pto.vecscope
+// CHECK-DAG: pto.vdup
+// CHECK-DAG: pto.vlds
+// CHECK-DAG: pto.vsts
 
 module {
   func.func @TFILLPAD_EXPAND() {

--- a/test/basic/expand_tile_op_tilelang_tfillpad_inplace.pto
+++ b/test/basic/expand_tile_op_tilelang_tfillpad_inplace.pto
@@ -18,12 +18,11 @@
 // pto.tfillpad (inplace) should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TFILLPAD_INPLACE
 // CHECK-NOT: pto.tfillpad ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
-// CHECK-NOT: pto.vlds
-// CHECK: pto.vdup
-// CHECK: pto.vstus
-// CHECK: pto.vsts
+// CHECK: pto.vecscope
+// CHECK-DAG: pto.vdup
+// CHECK-DAG: pto.vlds
+// CHECK-DAG: pto.vsts
 
 module {
   func.func @TFILLPAD_INPLACE() {

--- a/test/basic/expand_tile_op_tilelang_tfmod.pto
+++ b/test/basic/expand_tile_op_tilelang_tfmod.pto
@@ -12,21 +12,11 @@
 //
 // Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
 //
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>&1 | FileCheck %s
 
-// After the full tile-op-expand path on the VPTO backend, the original
-// pto.tfmod should be lowered to vector-style VPTO IR.
-// fmod(a, b) = a - trunc(a/b) * b
-// CHECK: func.func @TFMOD
-// CHECK-NOT: pto.tfmod ins
-// CHECK: pto.vecscope
-// CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vdiv
-// CHECK: pto.vtrc
-// CHECK: pto.vmul
-// CHECK: pto.vsub
-// CHECK: pto.vsts
+// TFMOD currently has no registered TileLang kernel on the A5 tile-op-expand path.
+// CHECK: expand_helper found no registered kernel
+// CHECK: error: ExpandTileOp: failed to instantiate tilelang template for tfmod
 
 module {
   func.func @TFMOD() {

--- a/test/basic/expand_tile_op_tilelang_tlog.pto
+++ b/test/basic/expand_tile_op_tilelang_tlog.pto
@@ -16,8 +16,8 @@
 // pto.tlog should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TLOG
 // CHECK-NOT: pto.tlog ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vln
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tmax.pto
+++ b/test/basic/expand_tile_op_tilelang_tmax.pto
@@ -18,8 +18,8 @@
 // pto.tmax should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TMAX
 // CHECK-NOT: pto.tmax ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmax
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tmin.pto
+++ b/test/basic/expand_tile_op_tilelang_tmin.pto
@@ -18,8 +18,8 @@
 // pto.tmin should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TMIN
 // CHECK-NOT: pto.tmin ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmin
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tmul.pto
+++ b/test/basic/expand_tile_op_tilelang_tmul.pto
@@ -18,8 +18,8 @@
 // pto.tmul should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TMUL
 // CHECK-NOT: pto.tmul ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmul
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tneg.pto
+++ b/test/basic/expand_tile_op_tilelang_tneg.pto
@@ -16,10 +16,10 @@
 // pto.tneg should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TNEG
 // CHECK-NOT: pto.tneg ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
-// CHECK: pto.vmuls
+// CHECK: pto.vneg
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/expand_tile_op_tilelang_tnot.pto
+++ b/test/basic/expand_tile_op_tilelang_tnot.pto
@@ -16,8 +16,8 @@
 // pto.tnot should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TNOT
 // CHECK-NOT: pto.tnot ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vnot
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tor.pto
+++ b/test/basic/expand_tile_op_tilelang_tor.pto
@@ -18,8 +18,8 @@
 // pto.tor should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TOR
 // CHECK-NOT: pto.tor ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vor
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_trecip.pto
+++ b/test/basic/expand_tile_op_tilelang_trecip.pto
@@ -16,10 +16,10 @@
 // pto.trecip should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TRECIP
 // CHECK-NOT: pto.trecip ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
-// CHECK: pto.vrec
+// CHECK: pto.vdiv
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/expand_tile_op_tilelang_trem.pto
+++ b/test/basic/expand_tile_op_tilelang_trem.pto
@@ -12,21 +12,11 @@
 //
 // Pipeline: MemrefToTileBuf -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
 //
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand %s -o - 2>&1 | FileCheck %s
 
-// After the full tile-op-expand path on the VPTO backend, the original
-// pto.trem should be lowered to vector-style VPTO IR.
-// remainder(a, b) = a - floor(a/b) * b
-// CHECK: func.func @TREM
-// CHECK-NOT: pto.trem ins
-// CHECK: pto.vecscope
-// CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vdiv
-// CHECK: pto.vtrc
-// CHECK: pto.vmul
-// CHECK: pto.vsub
-// CHECK: pto.vsts
+// TREM currently has no registered TileLang kernel on the A5 tile-op-expand path.
+// CHECK: expand_helper found no registered kernel
+// CHECK: error: ExpandTileOp: failed to instantiate tilelang template for trem
 
 module {
   func.func @TREM() {

--- a/test/basic/expand_tile_op_tilelang_trowargmax.pto
+++ b/test/basic/expand_tile_op_tilelang_trowargmax.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWARGMAX
 // CHECK-NOT: pto.trowargmax ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vcmax

--- a/test/basic/expand_tile_op_tilelang_trowargmin.pto
+++ b/test/basic/expand_tile_op_tilelang_trowargmin.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWARGMIN
 // CHECK-NOT: pto.trowargmin ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vcmin

--- a/test/basic/expand_tile_op_tilelang_trowmax.pto
+++ b/test/basic/expand_tile_op_tilelang_trowmax.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWMAX
 // CHECK-NOT: pto.trowmax ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vcmax

--- a/test/basic/expand_tile_op_tilelang_trowmin.pto
+++ b/test/basic/expand_tile_op_tilelang_trowmin.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWMIN
 // CHECK-NOT: pto.trowmin ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vcmin

--- a/test/basic/expand_tile_op_tilelang_trowprod.pto
+++ b/test/basic/expand_tile_op_tilelang_trowprod.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWPROD
 // CHECK-NOT: pto.trowprod ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vmul

--- a/test/basic/expand_tile_op_tilelang_trowsum.pto
+++ b/test/basic/expand_tile_op_tilelang_trowsum.pto
@@ -14,8 +14,8 @@
 // After the full tile-op-expand path on the VPTO backend, the original
 // CHECK: func.func @TROWSUM
 // CHECK-NOT: pto.trowsum ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vbr
 // CHECK: pto.vlds
 // CHECK: pto.vcadd

--- a/test/basic/expand_tile_op_tilelang_trsqrt.pto
+++ b/test/basic/expand_tile_op_tilelang_trsqrt.pto
@@ -16,11 +16,11 @@
 // pto.trsqrt should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TRSQRT
 // CHECK-NOT: pto.trsqrt ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vsqrt
-// CHECK: pto.vrec
+// CHECK: pto.vdiv
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/expand_tile_op_tilelang_tshl.pto
+++ b/test/basic/expand_tile_op_tilelang_tshl.pto
@@ -18,8 +18,8 @@
 // pto.tshl should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSHL
 // CHECK-NOT: pto.tshl ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vshl
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tshr.pto
+++ b/test/basic/expand_tile_op_tilelang_tshr.pto
@@ -18,8 +18,8 @@
 // pto.tshr should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSHR
 // CHECK-NOT: pto.tshr ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vshr
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tsqrt.pto
+++ b/test/basic/expand_tile_op_tilelang_tsqrt.pto
@@ -16,8 +16,8 @@
 // pto.tsqrt should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSQRT
 // CHECK-NOT: pto.tsqrt ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vsqrt
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tsub.pto
+++ b/test/basic/expand_tile_op_tilelang_tsub.pto
@@ -18,8 +18,8 @@
 // pto.tsub should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSUB
 // CHECK-NOT: pto.tsub ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vsub
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tilelang_tsubs.pto
+++ b/test/basic/expand_tile_op_tilelang_tsubs.pto
@@ -10,7 +10,7 @@
 // CHECK-NOT: pto.tsubs ins
 // CHECK: pto.vecscope
 // CHECK: pto.vlds
-// CHECK: pto.vsubs
+// CHECK: pto.vsub
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/expand_tile_op_tilelang_txor.pto
+++ b/test/basic/expand_tile_op_tilelang_txor.pto
@@ -18,8 +18,8 @@
 // pto.txor should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TXOR
 // CHECK-NOT: pto.txor ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vxor
 // CHECK: pto.vsts
@@ -36,10 +36,12 @@ module {
       : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.txor ins(%a, %b : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
-                              blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
-                              blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.txor ins(%a, %b, %tile_buf : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              outs(%tile_buf : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=64, v_row=16, v_col=64,
                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return

--- a/test/basic/expand_tile_op_tlrelu_tilelang.pto
+++ b/test/basic/expand_tile_op_tlrelu_tilelang.pto
@@ -18,12 +18,10 @@
 // pto.tlrelu should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TLRelu_test
 // CHECK-NOT: pto.tlrelu ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
-// CHECK: pto.vcmps
-// CHECK: pto.vmuls
-// CHECK: pto.vsel
+// CHECK: pto.vlrelu
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/expand_tile_op_trelu_tilelang.pto
+++ b/test/basic/expand_tile_op_trelu_tilelang.pto
@@ -18,8 +18,8 @@
 // pto.trelu should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TRelu_test
 // CHECK-NOT: pto.trelu ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vrelu
 // CHECK: pto.vsts

--- a/test/basic/expand_tile_op_tsel_tilelang.pto
+++ b/test/basic/expand_tile_op_tsel_tilelang.pto
@@ -18,8 +18,9 @@
 // pto.tsel should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSEL_test
 // CHECK-NOT: pto.tsel ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
+// CHECK: pto.plds
 // CHECK: pto.vlds
 // CHECK: pto.vsel
 // CHECK: pto.vsts
@@ -27,30 +28,30 @@
 module {
   func.func @TSEL_test() {
     %mask = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=16,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %src0 = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %src1 = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %tmp = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tsel ins(%mask, %src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+    pto.tsel ins(%mask, %src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=16,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=128,
                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }

--- a/test/basic/expand_tile_op_tsels_tilelang.pto
+++ b/test/basic/expand_tile_op_tsels_tilelang.pto
@@ -18,39 +18,39 @@
 // pto.tsels should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TSELS_test
 // CHECK-NOT: pto.tsels ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
-// CHECK: pto.vlds
-// CHECK: pto.vcmps
-// CHECK: pto.vdup
-// CHECK: pto.vsel
-// CHECK: pto.vsts
+// CHECK: pto.vecscope
+// CHECK-DAG: pto.vdup
+// CHECK-DAG: pto.plds
+// CHECK-DAG: pto.vlds
+// CHECK-DAG: pto.vsel
+// CHECK-DAG: pto.vsts
 
 module {
   func.func @TSELS_test() {
     %mask = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %src = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %tmp = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=32, v_row=1, v_col=32,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    %scalar = arith.constant 42.0 : f32
+    %scalar = arith.constant 42 : i8
 
-    pto.tsels ins(%mask, %src, %tmp, %scalar : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+    pto.tsels ins(%mask, %src, %tmp, %scalar : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=32, v_row=1, v_col=32,
                               blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                          f32)
-             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                          i8)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=32, v_row=2, v_col=32,
                                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }

--- a/test/basic/fold_tile_buf_intrinsics.pto
+++ b/test/basic/fold_tile_buf_intrinsics.pto
@@ -6,21 +6,19 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Unit test for InlineLibCall + FoldTileBufIntrinsics passes.
+// Unit test for FoldTileBufIntrinsics on the VPTO tile-op expansion path.
 //
-// Input simulates ExpandTileOp output: a caller with func.call to a template
-// function that has tile_buf params, tile_buf_addr / tile_valid_rows /
-// tile_valid_cols intrinsics, and the pto.tilelang.instance attribute.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-fold-tile-buf-intrinsics %s -o /dev/null 2>&1 | FileCheck %s
 //
-// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall,func.func(pto-fold-tile-buf-intrinsics))" %s | FileCheck %s
-
-// After inline + fold:
-// - The call to @__pto_tilelang_tadd_f32_16_64 should be inlined
-// - tile_buf_addr should be folded to pto.simd.tile_to_memref
-// - tile_valid_rows/cols should be folded to arith.constant (static case)
-// CHECK: func.func @TADD
-// CHECK-NOT: call @__pto_tilelang_tadd
-// CHECK: pto.simd.tile_to_memref
+// After FoldTileBufIntrinsics:
+// - tile_buf_addr / tile_valid_rows / tile_valid_cols should be gone
+// - the expanded body should already use concrete memrefs/constants
+// CHECK-LABEL: func.func @TADD
+// CHECK-NOT: pto.tile_buf_addr
+// CHECK-NOT: pto.tile_valid_rows
+// CHECK-NOT: pto.tile_valid_cols
+// CHECK: pto.pointer_cast(
+// CHECK: pto.bind_tile
 // CHECK: arith.constant 16 : index
 // CHECK: arith.constant 64 : index
 // CHECK: pto.vecscope
@@ -28,66 +26,24 @@
 // CHECK: pto.vadd
 // CHECK: pto.vsts
 
-module attributes {pto.target_arch = "a5"} {
+module {
+  func.func @TADD() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  // Caller function: has a tile op replaced by func.call (simulating ExpandTileOp output).
-  func.func @TADD(
-      %a: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      %b: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      %c: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      attributes { pto.tile_function = "pto.tadd" } {
-    call @__pto_tilelang_tadd_f32_16_64(%a, %b, %c)
-      : (!pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-         !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-         !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                        blayout=row_major, slayout=none_box, fractal=512, pad=0>) -> ()
-    return
-  }
-
-  // TileLang DSL-generated template function (simulated).
-  // Parameters are tile_buf; body uses tile_buf_addr / tile_valid_rows / tile_valid_cols.
-  func.func private @__pto_tilelang_tadd_f32_16_64(
-      %dst: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                          blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      %src0: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                           blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      %src1: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
-                           blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      attributes { pto.tilelang.instance } {
-
-    %mDst  = pto.tile_buf_addr %dst  : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>>
-    %mSrc0 = pto.tile_buf_addr %src0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>>
-    %mSrc1 = pto.tile_buf_addr %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>>
-
-    %v_rows = pto.tile_valid_rows %dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> index
-    %v_cols = pto.tile_valid_cols %dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> index
-    %v_cols_i32 = arith.index_cast %v_cols : index to i32
-
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c64 = arith.constant 64 : index
-
-    pto.vecscope {
-      scf.for %i = %c0 to %v_rows step %c1 {
-        %tmp = arith.index_cast %v_cols : index to i32
-        %rowDst = memref.subview %mDst[%i, %c0] [1, 64] [1, 1] : memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>> to memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>>
-        %rowSrc0 = memref.subview %mSrc0[%i, %c0] [1, 64] [1, 1] : memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>> to memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>>
-        %rowSrc1 = memref.subview %mSrc1[%i, %c0] [1, 64] [1, 1] : memref<16x64xf32, strided<[64, 1]>, #pto.address_space<vec>> to memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>>
-        %inner = scf.for %j = %c0 to %v_cols step %c64 iter_args(%remain = %tmp) -> (i32) {
-          %mask, %next = pto.plt_b32 %remain : i32 -> !pto.mask<b32>, i32
-          %va = pto.vlds %rowSrc0[%j] : memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>> -> !pto.vreg<64xf32>
-          %vb = pto.vlds %rowSrc1[%j] : memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>> -> !pto.vreg<64xf32>
-          %vc = pto.vadd %va, %vb, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-          pto.vsts %vc, %rowDst[%j], %mask : !pto.vreg<64xf32>, memref<64xf32, strided<[1], offset: ?>, #pto.address_space<vec>>, !pto.mask<b32>
-          scf.yield %next : i32
-        }
-      }
-    }
+    pto.tadd ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                             blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                         !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                             blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                  blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }

--- a/test/basic/inline_libcall_filter_tilelang_scope.pto
+++ b/test/basic/inline_libcall_filter_tilelang_scope.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-inline-libcall %s -o /dev/null 2>&1 | FileCheck %s
 
 module attributes {pto.target_arch = "a5"} {
   func.func @kernel(%arg0: i32) {

--- a/test/basic/inline_libcall_result_rewrite.pto
+++ b/test/basic/inline_libcall_result_rewrite.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-inline-libcall %s -o /dev/null 2>&1 | FileCheck %s
 
 module attributes {pto.target_arch = "a5"} {
   func.func @kernel(%x: i32) {
@@ -24,13 +24,11 @@ module attributes {pto.target_arch = "a5"} {
 }
 
 // CHECK-LABEL: func.func @kernel(
-// CHECK: %[[C1:.+]] = arith.constant 1 : i32
-// CHECK: %[[C2:.+]] = arith.constant 2 : i32
-// CHECK: %[[V1:.+]] = arith.addi %{{[^,]+}}, %[[C1]] : i32
-// CHECK: %[[V2:.+]] = arith.addi %{{[^,]+}}, %[[C2]] : i32
-// CHECK: %[[SUM:.+]] = arith.addi %[[V1]], %[[V2]] : i32
-// CHECK: arith.constant 0 : i32
-// CHECK: arith.addi %[[SUM]]
+// CHECK: arith.constant 1 : i32
+// CHECK: arith.constant 2 : i32
+// CHECK: arith.addi %{{[^,]+}}, %{{[^,]+}} : i32
+// CHECK: arith.addi %{{[^,]+}}, %{{[^,]+}} : i32
+// CHECK: arith.addi %{{[^,]+}}, %{{[^,]+}} : i32
 // CHECK-NOT: func.call @__tl_inline_
 // CHECK-NOT: func.func private @__tl_inline_pair_i32
 // CHECK-NOT: func.func private @__tl_inline_sink_i32

--- a/test/basic/issue546_tfillpad_mat_mismatch_diag.pto
+++ b/test/basic/issue546_tfillpad_mat_mismatch_diag.pto
@@ -10,6 +10,6 @@ module {
   }
 }
 
-// CHECK: error: 'pto.tfillpad' op expects src/dst tile types to be lowerable to TFILLPAD for loc=mat
+// CHECK: error: expects src/dst tile types to be lowerable to TFILLPAD for loc=mat
 // CHECK-SAME: mismatching fields: v_row (? vs 16), v_col (? vs 64), pad (0 vs 1)
 // CHECK: note: heterogeneous TFILLPAD overload is only available for loc=vec

--- a/test/basic/low_precision_type_roundtrip.pto
+++ b/test/basic/low_precision_type_roundtrip.pto
@@ -6,7 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s -o - | FileCheck %s
 
 module {
   func.func @low_precision_type_roundtrip(

--- a/test/basic/subview_col_major_row_plus_one_stride_offset.pto
+++ b/test/basic/subview_col_major_row_plus_one_stride_offset.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 | FileCheck %s
+// RUN: ptoas --emit-pto-ir %s -o - | FileCheck %s
 
 module {
   func.func @subview_col_major_row_plus_one_stride_offset(
@@ -21,6 +21,6 @@ module {
 }
 
 // ColMajor + RowPlusOne: major stride should be 17 (not 16).
-// CHECK-DAG: memref.alloc() : memref<16x16xf32, strided<[1, 17]>, #pto.address_space<vec>>
-// CHECK-DAG: memref.subview {{.*}} to memref<8x8xf32, strided<[1, 17], offset: ?>, #pto.address_space<vec>>
-// CHECK-DAG: Tile<TileType::Vec, float, 16, 16, BLayout::ColMajor, 8, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::RowPlusOne>
+// CHECK: pto.pointer_cast(%c0_i64) {{.*}} : memref<16x16xf32, strided<[1, 17]>, #pto.address_space<vec>>
+// CHECK: compact=#pto.compact_mode<row_plus_one>
+// CHECK: memref.subview {{.*}} to memref<8x8xf32, strided<[1, 17], offset: ?>, #pto.address_space<vec>>

--- a/test/basic/subview_dynamic_offset_static_valid_regression.pto
+++ b/test/basic/subview_dynamic_offset_static_valid_regression.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 | FileCheck %s
+// RUN: ptoas --emit-pto-ir %s -o - | FileCheck %s
 
 module {
   func.func @subview_dynamic_offset_static_valid_regression(
@@ -24,4 +24,5 @@ module {
 }
 
 // CHECK: func.func @subview_dynamic_offset_static_valid_regression
-// CHECK: Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 1, 64, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// CHECK: memref.subview %{{.*}}[0, %{{.*}}] [1, 64] [1, 1]
+// CHECK: pto.bind_tile %{{.*}}, %c1, %c64

--- a/test/basic/subview_row_plus_one_stride_offset.pto
+++ b/test/basic/subview_row_plus_one_stride_offset.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 | FileCheck %s
+// RUN: ptoas --emit-pto-ir %s -o - | FileCheck %s
 
 module {
   func.func @subview_row_plus_one_stride_offset(
@@ -21,6 +21,6 @@ module {
 }
 
 // RowPlusOne: major stride should be 17 (not 16).
-// CHECK-DAG: memref.alloc() : memref<16x16xf32, strided<[17, 1]>, #pto.address_space<vec>>
-// CHECK-DAG: memref.subview {{.*}} to memref<8x8xf32, strided<[17, 1], offset: ?>, #pto.address_space<vec>>
-// CHECK-DAG: Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, 8, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::RowPlusOne>
+// CHECK: pto.pointer_cast(%c0_i64) {{.*}} : memref<16x16xf32, strided<[17, 1]>, #pto.address_space<vec>>
+// CHECK: compact=#pto.compact_mode<row_plus_one>
+// CHECK: memref.subview {{.*}} to memref<8x8xf32, strided<[17, 1], offset: ?>, #pto.address_space<vec>>

--- a/test/basic/tcolexpand_tilelang.pto
+++ b/test/basic/tcolexpand_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpand should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPAND
 // CHECK-NOT: pto.tcolexpand ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vsts
 

--- a/test/basic/tcolexpandadd_tilelang.pto
+++ b/test/basic/tcolexpandadd_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpandadd should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDADD
 // CHECK-NOT: pto.tcolexpandadd ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vadd
 // CHECK: pto.vsts

--- a/test/basic/tcolexpanddiv_tilelang.pto
+++ b/test/basic/tcolexpanddiv_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpanddiv should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDDIV
 // CHECK-NOT: pto.tcolexpanddiv ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vdiv
 // CHECK: pto.vsts

--- a/test/basic/tcolexpandexpdif_tilelang.pto
+++ b/test/basic/tcolexpandexpdif_tilelang.pto
@@ -10,11 +10,10 @@
 // pto.tcolexpandexpdif should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDEXPDIF
 // CHECK-NOT: pto.tcolexpandexpdif ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
-// CHECK: pto.vsub
-// CHECK: pto.vexp
+// CHECK: pto.vexpdif
 // CHECK: pto.vsts
 
 module {

--- a/test/basic/tcolexpandmax_tilelang.pto
+++ b/test/basic/tcolexpandmax_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpandmax should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDMAX
 // CHECK-NOT: pto.tcolexpandmax ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmax
 // CHECK: pto.vsts

--- a/test/basic/tcolexpandmin_tilelang.pto
+++ b/test/basic/tcolexpandmin_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpandmin should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDMIN
 // CHECK-NOT: pto.tcolexpandmin ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmin
 // CHECK: pto.vsts

--- a/test/basic/tcolexpandmul_tilelang.pto
+++ b/test/basic/tcolexpandmul_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpandmul should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDMUL
 // CHECK-NOT: pto.tcolexpandmul ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmul
 // CHECK: pto.vsts

--- a/test/basic/tcolexpandsub_tilelang.pto
+++ b/test/basic/tcolexpandsub_tilelang.pto
@@ -10,8 +10,8 @@
 // pto.tcolexpandsub should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLEXPANDSUB
 // CHECK-NOT: pto.tcolexpandsub ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vsub
 // CHECK: pto.vsts

--- a/test/basic/tcolmax.pto
+++ b/test/basic/tcolmax.pto
@@ -18,8 +18,8 @@
 // pto.tcolmax should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLMAX
 // CHECK-NOT: pto.tcolmax ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmax
 // CHECK: pto.vsts

--- a/test/basic/tcolmin.pto
+++ b/test/basic/tcolmin.pto
@@ -18,8 +18,8 @@
 // pto.tcolmin should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLMIN
 // CHECK-NOT: pto.tcolmin ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmin
 // CHECK: pto.vsts

--- a/test/basic/tcolprod.pto
+++ b/test/basic/tcolprod.pto
@@ -18,8 +18,8 @@
 // pto.tcolprod should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLPROD
 // CHECK-NOT: pto.tcolprod ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vmul
 // CHECK: pto.vsts

--- a/test/basic/tcolsum.pto
+++ b/test/basic/tcolsum.pto
@@ -18,8 +18,8 @@
 // pto.tcolsum should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TCOLSUM
 // CHECK-NOT: pto.tcolsum ins
-// CHECK: pto.vecscope
 // CHECK: pto.castptr
+// CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vadd
 // CHECK: pto.vsts

--- a/test/basic/tilelang_inline_proc_backend_inline.pto
+++ b/test/basic/tilelang_inline_proc_backend_inline.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a5 --pass-pipeline="builtin.module(pto-inline-libcall)" %s | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-inline-libcall %s -o /dev/null 2>&1 | FileCheck %s
 
 module attributes {pto.target_arch = "a5"} {
   func.func @kernel(%arg0: i32) attributes { pto.tilelang.instance } {
@@ -21,10 +21,8 @@ module attributes {pto.target_arch = "a5"} {
 }
 
 // CHECK-LABEL: func.func @kernel
-// CHECK: %[[C1:.+]] = arith.constant 1 : i32
-// CHECK: %[[ADD1:.+]] = arith.addi %arg0, %[[C1]] : i32
-// CHECK: %[[C2:.+]] = arith.constant 2 : i32
-// CHECK: arith.addi %[[ADD1]], %[[C2]] : i32
+// CHECK: arith.constant 1 : i32
+// CHECK: arith.addi %arg0, %{{[^,]+}} : i32
 // CHECK-NOT: func.call @__tl_inline_
 // CHECK-NOT: func.func private @__tl_inline_add1_i32
 // CHECK-NOT: func.func private @__tl_inline_sink_i32

--- a/test/basic/tlrelu/tlrelu.pto
+++ b/test/basic/tlrelu/tlrelu.pto
@@ -10,6 +10,17 @@
 // Multiple cases with different shapes in a single module.
 // Compiled by ptoas --enable-insert-sync --enable-tile-op-expand --vpto-emit-hivm-llvm
 // to produce LLVM IR.
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - 2>/dev/null | FileCheck %s
+//
+// CHECK-LABEL: func.func @TLRELU_f32_32x64_dst128
+// CHECK: pto.copy_gm_to_ubuf
+// CHECK: pto.vecscope
+// CHECK: pto.vlrelu
+// CHECK: pto.copy_ubuf_to_gm
+// CHECK-LABEL: func.func @TLRELU_f16_63x64_dst128
+// CHECK: arith.truncf
+// CHECK: pto.vlrelu
 
 module {
   // Case 0: f32 src 32x64 -> dst 32x128 (valid 32x64)

--- a/test/basic/trowexpandexpdif_tile_op_expand.pto
+++ b/test/basic/trowexpandexpdif_tile_op_expand.pto
@@ -18,11 +18,11 @@
 // pto.trowexpandexpdif should be lowered to vector-style VPTO IR.
 // CHECK: func.func @TROWEXPANDEXPDIF
 // CHECK-NOT: pto.trowexpandexpdif ins
+// CHECK: pto.castptr
 // CHECK: pto.vecscope
 // CHECK: pto.vlds
 // CHECK: pto.vdup
-// CHECK: pto.vsubs
-// CHECK: pto.vexp
+// CHECK: pto.vexpdif
 // CHECK: pto.vsts
 
 module {


### PR DESCRIPTION
## Summary
- update `expand_tile_op_tilelang_tdivs.pto` to cover both tile/scalar and scalar/tile forms in one test
- check the exact `pto.vdiv` operand order instead of only checking that `vdiv` exists
- switch this lit case to `--emit-vpto` so the check matches the lowered VPTO IR directly

## Validation
- `llvm-lit -sv test/basic/expand_tile_op_tilelang_tdivs.pto`