### PR TITLE
fix(vpto): support merged align state across scf.if

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -184,6 +184,18 @@ static bool isLoadAlignProducer(Operation *op) {
   return isa<VldasOp, VldusOp>(op);
 }
 
+static scf::IfOp getEnclosingBranchIf(Operation *op) {
+  for (Operation *cursor = op; cursor; cursor = cursor->getParentOp()) {
+    auto ifOp = dyn_cast<scf::IfOp>(cursor);
+    if (!ifOp)
+      continue;
+    Region *parentRegion = op->getParentRegion();
+    if (parentRegion == &ifOp.getThenRegion() || parentRegion == &ifOp.getElseRegion())
+      return ifOp;
+  }
+  return nullptr;
+}
+
 static bool isValueOwnedByRegion(Value value, Region *region) {
   if (auto blockArg = dyn_cast<BlockArgument>(value))
     return blockArg.getParentRegion() == region;
@@ -192,9 +204,11 @@ static bool isValueOwnedByRegion(Value value, Region *region) {
   return false;
 }
 
-static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user) {
-  llvm::SmallPtrSet<void *, 8> visited;
-  Value current = value;
+static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user);
+static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user);
+
+static FailureOr<Value> resolveStoreAlignRootImpl(
+    Value current, llvm::SmallPtrSet<void *, 8> visited) {
 
   while (true) {
     if (!visited.insert(current.getAsOpaquePointer()).second) {
@@ -218,8 +232,20 @@ static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user) {
     }
 
     if (Operation *def = current.getDefiningOp()) {
-      if (isStoreAlignProducer(def))
+      if (isa<InitAlignOp>(def))
         return current;
+      if (auto stateOp = dyn_cast<PstuOp>(def)) {
+        current = stateOp.getAlignIn();
+        continue;
+      }
+      if (auto stateOp = dyn_cast<VstusOp>(def)) {
+        current = stateOp.getAlignIn();
+        continue;
+      }
+      if (auto stateOp = dyn_cast<VsturOp>(def)) {
+        current = stateOp.getAlignIn();
+        continue;
+      }
       if (auto forOp = dyn_cast<scf::ForOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
         if (!result)
@@ -230,10 +256,34 @@ static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user) {
         current = forOp.getYieldedValues()[resultIdx];
         continue;
       }
+      if (auto ifOp = dyn_cast<scf::IfOp>(def)) {
+        auto result = dyn_cast<OpResult>(current);
+        if (!result || !ifOp.elseBlock())
+          return failure();
+        unsigned resultIdx = result.getResultNumber();
+        auto thenYield = dyn_cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
+        auto elseYield = dyn_cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
+        if (!thenYield || !elseYield || resultIdx >= thenYield.getNumOperands() ||
+            resultIdx >= elseYield.getNumOperands()) {
+          return failure();
+        }
+        FailureOr<Value> thenRoot =
+            resolveStoreAlignRootImpl(thenYield.getOperand(resultIdx), visited);
+        FailureOr<Value> elseRoot =
+            resolveStoreAlignRootImpl(elseYield.getOperand(resultIdx), visited);
+        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot)
+          return failure();
+        return *thenRoot;
+      }
     }
 
     return failure();
   }
+}
+
+static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user) {
+  (void)user;
+  return resolveStoreAlignRootImpl(value, {});
 }
 
 static LogicalResult verifyStoreAlignLoopThreading(Value align, Operation *user,
@@ -241,6 +291,8 @@ static LogicalResult verifyStoreAlignLoopThreading(Value align, Operation *user,
   Operation *cursor = user;
   while (auto forOp = cursor->getParentOfType<scf::ForOp>()) {
     Region *body = &forOp.getRegion();
+    if (isValueOwnedByRegion(align, body))
+      return success();
     if (!isValueOwnedByRegion(align, body)) {
       return user->emitOpError()
              << roleDescription
@@ -252,6 +304,17 @@ static LogicalResult verifyStoreAlignLoopThreading(Value align, Operation *user,
   return success();
 }
 
+static FailureOr<Value> resolveSingleAlignIfResult(scf::IfOp ifOp) {
+  SmallVector<unsigned> alignResultIndices;
+  for (auto [index, type] : llvm::enumerate(ifOp.getResultTypes())) {
+    if (isa<AlignType>(type))
+      alignResultIndices.push_back(index);
+  }
+  if (alignResultIndices.size() != 1)
+    return failure();
+  return ifOp.getResult(alignResultIndices.front());
+}
+
 static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
   llvm::SmallPtrSet<void *, 16> visited;
   Value current = value;
@@ -259,23 +322,28 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
   while (visited.insert(current.getAsOpaquePointer()).second) {
     SmallVector<Value> nextValues;
     SmallVector<Operation *> terminalUsers;
+    SmallVector<Operation *> branchUsers;
 
     for (OpOperand &use : current.getUses()) {
       Operation *owner = use.getOwner();
       if (isStoreAlignSink(owner)) {
         terminalUsers.push_back(owner);
+        branchUsers.push_back(owner);
         continue;
       }
       if (auto stateOp = dyn_cast<PstuOp>(owner)) {
         nextValues.push_back(stateOp.getAlignOut());
+        branchUsers.push_back(owner);
         continue;
       }
       if (auto stateOp = dyn_cast<VstusOp>(owner)) {
         nextValues.push_back(stateOp.getAlignOut());
+        branchUsers.push_back(owner);
         continue;
       }
       if (auto stateOp = dyn_cast<VsturOp>(owner)) {
         nextValues.push_back(stateOp.getAlignOut());
+        branchUsers.push_back(owner);
         continue;
       }
       if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
@@ -307,6 +375,27 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
     }
 
     if (nextValues.size() + terminalUsers.size() > 1) {
+      scf::IfOp commonIf;
+      for (Operation *branchUser : branchUsers) {
+        scf::IfOp enclosingIf = getEnclosingBranchIf(branchUser);
+        if (!enclosingIf) {
+          commonIf = nullptr;
+          break;
+        }
+        if (!commonIf)
+          commonIf = enclosingIf;
+        else if (commonIf != enclosingIf) {
+          commonIf = nullptr;
+          break;
+        }
+      }
+      if (commonIf) {
+        FailureOr<Value> mergedValue = resolveSingleAlignIfResult(commonIf);
+        if (succeeded(mergedValue)) {
+          current = *mergedValue;
+          continue;
+        }
+      }
       return user->emitOpError()
              << "!pto.align value must form a single linear store-state chain";
     }
@@ -355,9 +444,8 @@ static LogicalResult verifyStoreAlignChain(Value align, Operation *user,
   return verifyStoreAlignLinearUses(*root, user);
 }
 
-static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user) {
-  llvm::SmallPtrSet<void *, 8> visited;
-  Value current = value;
+static FailureOr<Value> resolveLoadAlignRootImpl(
+    Value current, llvm::SmallPtrSet<void *, 8> visited) {
 
   while (true) {
     if (!visited.insert(current.getAsOpaquePointer()).second)
@@ -380,8 +468,12 @@ static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user) {
     }
 
     if (Operation *def = current.getDefiningOp()) {
-      if (isLoadAlignProducer(def))
+      if (isa<VldasOp>(def))
         return current;
+      if (auto stateOp = dyn_cast<VldusOp>(def)) {
+        current = stateOp.getAlign();
+        continue;
+      }
       if (auto forOp = dyn_cast<scf::ForOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
         if (!result)
@@ -392,10 +484,34 @@ static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user) {
         current = forOp.getYieldedValues()[resultIdx];
         continue;
       }
+      if (auto ifOp = dyn_cast<scf::IfOp>(def)) {
+        auto result = dyn_cast<OpResult>(current);
+        if (!result || !ifOp.elseBlock())
+          return failure();
+        unsigned resultIdx = result.getResultNumber();
+        auto thenYield = dyn_cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
+        auto elseYield = dyn_cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
+        if (!thenYield || !elseYield || resultIdx >= thenYield.getNumOperands() ||
+            resultIdx >= elseYield.getNumOperands()) {
+          return failure();
+        }
+        FailureOr<Value> thenRoot =
+            resolveLoadAlignRootImpl(thenYield.getOperand(resultIdx), visited);
+        FailureOr<Value> elseRoot =
+            resolveLoadAlignRootImpl(elseYield.getOperand(resultIdx), visited);
+        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot)
+          return failure();
+        return *thenRoot;
+      }
     }
 
     return failure();
   }
+}
+
+static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user) {
+  (void)user;
+  return resolveLoadAlignRootImpl(value, {});
 }
 
 static LogicalResult verifyLoadAlignLoopThreading(Value align, Operation *user,
@@ -403,6 +519,8 @@ static LogicalResult verifyLoadAlignLoopThreading(Value align, Operation *user,
   Operation *cursor = user;
   while (auto forOp = cursor->getParentOfType<scf::ForOp>()) {
     Region *body = &forOp.getRegion();
+    if (isValueOwnedByRegion(align, body))
+      return success();
     if (!isValueOwnedByRegion(align, body)) {
       return user->emitOpError()
              << roleDescription
@@ -420,11 +538,13 @@ static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
 
   while (visited.insert(current.getAsOpaquePointer()).second) {
     SmallVector<Value> nextValues;
+    SmallVector<Operation *> branchUsers;
 
     for (OpOperand &use : current.getUses()) {
       Operation *owner = use.getOwner();
       if (auto stateOp = dyn_cast<VldusOp>(owner)) {
         nextValues.push_back(stateOp.getUpdatedAlign());
+        branchUsers.push_back(owner);
         continue;
       }
       if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
@@ -460,6 +580,27 @@ static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
     }
 
     if (nextValues.size() > 1) {
+      scf::IfOp commonIf;
+      for (Operation *branchUser : branchUsers) {
+        scf::IfOp enclosingIf = getEnclosingBranchIf(branchUser);
+        if (!enclosingIf) {
+          commonIf = nullptr;
+          break;
+        }
+        if (!commonIf)
+          commonIf = enclosingIf;
+        else if (commonIf != enclosingIf) {
+          commonIf = nullptr;
+          break;
+        }
+      }
+      if (commonIf) {
+        FailureOr<Value> mergedValue = resolveSingleAlignIfResult(commonIf);
+        if (succeeded(mergedValue)) {
+          current = *mergedValue;
+          continue;
+        }
+      }
       return user->emitOpError()
              << "!pto.align value must form a single linear load-state chain";
     }

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2431,40 +2431,56 @@ class _AuthoringRenderer:
             lines.append(self._indent(indent) + "}")
             return lines
 
-        if len(stmt.results) != 1:
-            raise NotImplementedError(
-                "TileLang DSL v1 lowering currently supports at most one merged if/else binding"
-            )
-
-        result = stmt.results[0]
         lines = list(cond_lines)
+        result_names = ", ".join(result.result_binding.ssa_name for result in stmt.results)
+        result_types = ", ".join(
+            self._render_type(result.result_binding.type) for result in stmt.results
+        )
         lines.append(
             self._indent(indent)
-            + f"{result.result_binding.ssa_name} = scf.if {condition.name} -> "
-            + f"({self._render_type(result.result_binding.type)}) {{"
+            + f"{result_names} = scf.if {condition.name} -> ({result_types}) {{"
         )
         lines.extend(self._render_block(stmt.then_body, then_env, indent=indent + 2))
-        then_value = then_env.get(result.result_binding.name, then_env.get(result.then_binding.name))
-        if then_value is None:
-            then_value = _RenderedValue(result.then_binding.ssa_name, result.then_binding.type)
+        then_values = []
+        for result in stmt.results:
+            then_value = then_env.get(
+                result.result_binding.name,
+                then_env.get(result.then_binding.name),
+            )
+            if then_value is None:
+                then_value = _RenderedValue(result.then_binding.ssa_name, result.then_binding.type)
+            then_values.append(then_value)
         lines.append(
             self._indent(indent + 2)
-            + f"scf.yield {then_value.name} : {self._render_type(then_value.type)}"
+            + "scf.yield "
+            + ", ".join(value.name for value in then_values)
+            + " : "
+            + ", ".join(self._render_type(value.type) for value in then_values)
         )
         lines.append(self._indent(indent) + "} else {")
         lines.extend(self._render_block(stmt.else_body, else_env, indent=indent + 2))
-        else_value = else_env.get(result.result_binding.name, else_env.get(result.else_binding.name))
-        if else_value is None:
-            else_value = _RenderedValue(result.else_binding.ssa_name, result.else_binding.type)
+        else_values = []
+        for result in stmt.results:
+            else_value = else_env.get(
+                result.result_binding.name,
+                else_env.get(result.else_binding.name),
+            )
+            if else_value is None:
+                else_value = _RenderedValue(result.else_binding.ssa_name, result.else_binding.type)
+            else_values.append(else_value)
         lines.append(
             self._indent(indent + 2)
-            + f"scf.yield {else_value.name} : {self._render_type(else_value.type)}"
+            + "scf.yield "
+            + ", ".join(value.name for value in else_values)
+            + " : "
+            + ", ".join(self._render_type(value.type) for value in else_values)
         )
         lines.append(self._indent(indent) + "}")
-        env[result.result_binding.name] = _RenderedValue(
-            name=result.result_binding.ssa_name,
-            type=result.result_binding.type,
-        )
+        for result in stmt.results:
+            env[result.result_binding.name] = _RenderedValue(
+                name=result.result_binding.ssa_name,
+                type=result.result_binding.type,
+            )
         return lines
 
     def _lower_condition(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -6565,6 +6565,50 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("scf.for %lane_", text)
         self.assertIn("pto.barrier #pto.pipe<PIPE_ALL>", text)
 
+    def test_if_else_with_two_merged_bindings_lowers_to_multi_result_scf_if(self) -> None:
+        @pto.vkernel(op="eltwise", dtypes=[(pto.f32, pto.i32)], advanced=True)
+        def kernel(tile: pto.Tile, flag: pto.i32):
+            step = 64
+            upper = 256
+            if flag:
+                step = 32
+                upper = upper - step
+            else:
+                step = 64
+                upper = 128
+            with pto.strict_vecscope(tile, tile, 0, upper, step) as (src, dst, lb, ub, vec_step):
+                for lane in range(lb, ub, vec_step):
+                    mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+                    vec = pto.vlds(src, lane)
+                    pto.vsts(vec, dst, lane, mask)
+            return None
+
+        specialized = kernel.specialize(
+            tile=pto.TileSpecialization(
+                shape=(16, 16),
+                memory_space=pto.MemorySpace.UB,
+            )
+        )
+
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        if_stmt = next(stmt for stmt in semantic_kernel.body if isinstance(stmt, SemanticIfStmt))
+        self.assertIsInstance(if_stmt, SemanticIfStmt)
+        self.assertEqual([result.result_binding.name for result in if_stmt.results], ["step", "upper"])
+
+        text = specialized.mlir_text()
+        self.assertRegex(
+            text,
+            r"%step_\d+, %upper_\d+ = scf\.if %tmp_\d+ -> \(index, index\) \{",
+        )
+        self.assertRegex(
+            text,
+            r"scf\.yield %step_\d+, %upper_\d+ : index, index",
+        )
+        self.assertRegex(
+            text,
+            r"pto\.strict_vecscope\(%tmp_\d+, %tmp_\d+, %c0, %upper_\d+, %step_\d+\)",
+        )
+
     def test_extended_sync_buffer_ops_lower_to_authoring_surface(self) -> None:
         Pipe = pto.Pipe
         Event = pto.Event


### PR DESCRIPTION
## Summary
- support multi-result `scf.if` lowering in TileLang DSL v1 so branch-local state updates can merge structurally
- teach VPTO `!pto.align` verification to follow `scf.if` merge results and continue tracing through prior state ops to the real root producer
- add a DSL regression covering two merged if-results and verify the `tfillpad_inplace` issue path no longer fails in `ExpandTileOp`

## Scope
- This PR intentionally excludes the template changes in `lib/TileOps/`
- This PR intentionally excludes the separate vecscope-infer backend commit

## Issue Chain
Issue #300 hit three layers in sequence:
1. `fillpad_inplace.py` updates both `ureg` (`!pto.align`) and `remaining` inside a runtime `if` nested in a loop.
2. TileLang DSL lowering previously rejected that shape because `_render_if(...)` only supported one merged result.
3. After enabling multi-result `scf.if`, VPTO verification still rejected the emitted IR because `!pto.align` chain analysis only understood straight-line state flow and did not recognize structured `scf.if` merge points.

This patch fixes the implementation gap in layers 2 and 3 without relying on template-side rewrites.

## Validation
- `PYTHONPATH=$PWD/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_if_else_and_sync_ops_lower_to_scf_if_and_authoring_sync_ops tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_if_else_with_two_merged_bindings_lowers_to_multi_result_scf_if`
- `build/tools/ptoas/ptoas --pto-level=level3 --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand test/tilelang_st/npu/a5/src/st/testcase/tfillpad_inplace/tfillpad_inplace.pto -o -`

Fixes #300