### PR TITLE
fix(vpto): force V300 ctrl mode for sat-sensitive vcvt

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -2513,6 +2513,22 @@ static FailureOr<VcvtContract> buildVcvtContract(pto::VcvtOp op) {
   return *contract;
 }
 
+static bool needsV300CtrlModeForVPTOFunc(func::FuncOp funcOp) {
+  if (!pto::isPTOEntryFunction(funcOp) || funcOp.getBlocks().empty())
+    return false;
+
+  bool needsCtrlSetup = false;
+  funcOp.walk([&](pto::VcvtOp vcvtOp) {
+    FailureOr<VcvtContract> contract = buildVcvtContract(vcvtOp);
+    if (succeeded(contract) && (*contract).requiresSat) {
+      needsCtrlSetup = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return needsCtrlSetup;
+}
+
 template <typename LoopOp>
 static StringRef buildSetLoopCallee(MLIRContext *context);
 
@@ -7067,6 +7083,28 @@ static void normalizeFuncSignaturesForOfficialLLVMLowering(ModuleOp module) {
   }
 }
 
+static void forceV300CtrlModeForVPTOFuncs(ModuleOp module) {
+  OpBuilder builder(module.getContext());
+
+  for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
+    if (!needsV300CtrlModeForVPTOFunc(funcOp))
+      continue;
+
+    Block &entry = funcOp.getBody().front();
+    builder.setInsertionPointToStart(&entry);
+    auto i64Type = builder.getI64Type();
+    auto bit60 = builder.create<arith::ConstantOp>(
+        funcOp.getLoc(), i64Type, builder.getI64IntegerAttr(60));
+    Value ctrl =
+        builder.create<pto::GetCtrlOp>(funcOp.getLoc(), i64Type).getResult();
+    Value ctrlV300 = builder
+                         .create<pto::Sbitset0Op>(funcOp.getLoc(), i64Type,
+                                                  ctrl, bit60.getResult())
+                         .getResult();
+    builder.create<pto::SetCtrlOp>(funcOp.getLoc(), ctrlV300);
+  }
+}
+
 template <typename EmitFn>
 static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
                                  const VPTOEmissionOptions &options,
@@ -7074,7 +7112,9 @@ static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
   OwningOpRef<Operation *> clonedOp(module->clone());
   ModuleOp clonedModule = cast<ModuleOp>(*clonedOp);
 
+  pto::annotatePTOEntryFunctions(clonedModule);
   materializeVecScopeCarrierLoops(clonedModule);
+  forceV300CtrlModeForVPTOFuncs(clonedModule);
 
   if (failed(lowerVPTOOps(clonedModule, diagOS))) {
     diagOS << "VPTO LLVM emission failed: lowerVPTOOps failed\n";

--- a/test/basic/vpto_kernel_entry_force_v300_ctrl.pto
+++ b/test/basic/vpto_kernel_entry_force_v300_ctrl.pto
@@ -1,0 +1,20 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%value: f16, %dst: !pto.ptr<ui8, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %vec = pto.vdup %value, %mask : f16, !pto.mask<b16> -> !pto.vreg<128xf16>
+      %out = pto.vcvt %vec, %mask {rnd = "R", sat = "NOSAT", part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xui8>
+      pto.vsts %out, %dst[%c0], %mask {dist = "PK_B16"} : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @kernel(
+// CHECK: call i64 @llvm.hivm.GET.CTRL()
+// CHECK: call i64 @llvm.hivm.SBITSET0(i64 {{.*}}, i64 60)
+// CHECK: call void @llvm.hivm.SET.CTRL(i64
+// CHECK: call <256 x i8> @llvm.hivm.vcvtfi.f162u8.x(

--- a/test/basic/vpto_kernel_entry_skip_v300_ctrl_for_nonsat_insensitive_vcvt.pto
+++ b/test/basic/vpto_kernel_entry_skip_v300_ctrl_for_nonsat_insensitive_vcvt.pto
@@ -1,0 +1,21 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --vpto-emit-hivm-llvm %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%value: f16, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %load_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %store_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %vec = pto.vdup %value, %load_mask : f16, !pto.mask<b16> -> !pto.vreg<128xf16>
+      %out = pto.vcvt %vec, %load_mask {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+      pto.vsts %out, %dst[%c0], %store_mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @kernel(
+// CHECK-NOT: @llvm.hivm.GET.CTRL
+// CHECK-NOT: @llvm.hivm.SBITSET0
+// CHECK-NOT: @llvm.hivm.SET.CTRL
+// CHECK: call <64 x float> @llvm.hivm.vcvtff.f162f32.x(

--- a/test/vpto/cases/micro-op/conversion/vcvt-f32-special/golden.py
+++ b/test/vpto/cases/micro-op/conversion/vcvt-f32-special/golden.py
@@ -23,6 +23,13 @@ import numpy as np
 ROWS = 32
 COLS = 32
 SEED = 19
+F16_MAX_FINITE = np.float32(65504.0)
+
+
+def sat_cast_f32_to_f16(values: np.ndarray) -> np.ndarray:
+    values = np.where(np.isnan(values), np.float32(0.0), values)
+    values = np.clip(values, -F16_MAX_FINITE, F16_MAX_FINITE)
+    return values.astype(np.float16)
 
 
 def generate(output_dir: Path, seed: int) -> None:
@@ -54,8 +61,8 @@ def generate(output_dir: Path, seed: int) -> None:
     golden_flat = np.zeros(ROWS * COLS, dtype=np.float16)
 
     for offset in range(0, ROWS * COLS, 128):
-        lower = flat[offset : offset + 64].astype(np.float16)
-        upper = flat[offset + 64 : offset + 128].astype(np.float16)
+        lower = sat_cast_f32_to_f16(flat[offset : offset + 64])
+        upper = sat_cast_f32_to_f16(flat[offset + 64 : offset + 128])
         merged = np.empty(128, dtype=np.float16)
         merged[0::2] = lower
         merged[1::2] = upper

--- a/test/vpto/cases/micro-op/conversion/vcvt-tail-special/golden.py
+++ b/test/vpto/cases/micro-op/conversion/vcvt-tail-special/golden.py
@@ -24,6 +24,13 @@ ROWS = 32
 COLS = 32
 SEED = 19
 LOGICAL_ELEMS = 1000
+F16_MAX_FINITE = np.float32(65504.0)
+
+
+def sat_cast_f32_to_f16(values: np.ndarray) -> np.ndarray:
+    values = np.where(np.isnan(values), np.float32(0.0), values)
+    values = np.clip(values, -F16_MAX_FINITE, F16_MAX_FINITE)
+    return values.astype(np.float16)
 
 
 def generate(output_dir: Path, seed: int) -> None:
@@ -57,8 +64,8 @@ def generate(output_dir: Path, seed: int) -> None:
 
     remaining = LOGICAL_ELEMS
     for offset in range(0, ROWS * COLS, 128):
-        lower = flat[offset : offset + 64].astype(np.float16)
-        upper = flat[offset + 64 : offset + 128].astype(np.float16)
+        lower = sat_cast_f32_to_f16(flat[offset : offset + 64])
+        upper = sat_cast_f32_to_f16(flat[offset + 64 : offset + 128])
         merged = np.empty(128, dtype=np.float16)
         merged[0::2] = lower
         merged[1::2] = upper


### PR DESCRIPTION
This PR fixes a VPTO backend issue where kernels may inherit the V220-compatible CTRL mode, causing hardware saturation behavior to ignore the `#sat` / `#nosat` intent encoded by the instruction.

The change makes VPTO emission clear `CTRL[60]` at kernel entry, but only for entry functions that actually contain saturation-sensitive `pto.vcvt` operations. This keeps the behavior transparent for PTOAS users while avoiding unnecessary prologue overhead for unrelated kernels.

It also adds two regression tests:
- one test that verifies `GET.CTRL -> SBITSET0(bit 60) -> SET.CTRL` is emitted for a sat-sensitive `f16 -> ui8` vcvt kernel
- one test that verifies no ctrl setup is emitted for a non-sat-sensitive `f16 -> f32` vcvt kernel

Closes #305
Refs #314
