### PR TITLE
docs: NZ fractal layout definition for cube buffers (GM->L1->L0A/B->L0C)

### DIFF
--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -2,7 +2,7 @@
 
 > **Status:** DRAFT for review
 > **Base:** [vpto-spec.md](https://github.com/mouliangyu/PTOAS/blob/feature-vpto-backend/docs/vpto-spec.md) (2026-03-20)
-> **Updated:** 2026-03-27
+> **Updated:** 2026-04-30
 
 ---
 
@@ -20,7 +20,7 @@ The PTO micro Instruction operates as a very low-level intermediate representati
 
 Within the end-to-end PTO software stack, PTO instructions may appear in three closely related authoring or lowering modes:
 
-- **PTO Tile Instruction**: tile-oriented PTO code that serves as a nano-kernel encapsulation of Tile operations, primarily expressing computation and data movement in terms of tile buffers, tile shapes, and tile-local layout.
+- **PTO Tile Instruction**: tile-oriented PTO code that serves as a nano-kernel encapsulation of tile instructions, primarily expressing computation and data movement in terms of tile buffers, tile shapes, and tile-local layout.
 - **PTO micro Instruction**: vector-execution-oriented PTO code that makes DMA setup, vector registers, masks, synchronization, and `__VEC_SCOPE__` boundaries explicit. This document is centered on this mode.
 - **PTO Tile+micro Instruction**: a hybrid PTO form that keeps tile-level orchestration while embedding explicit micro-instruction regions where direct vector-pipeline control is required.
 
@@ -147,13 +147,14 @@ The PTO micro Instruction enforces a strict memory hierarchy. The Unified Buffer
 4. **vreg → UB**: Vector Store instructions (`pto.vsts`, `pto.vstsx2`, etc.)
 5. **UB → GM**: DMA transfer via MTE3 (`pto.dma_store`)
 
-The grouped DMA surface in this specification covers GM↔UB transfer only.
-Low-level raw copy families such as UB→UB copy use separate operand contracts
-and are outside this grouped DMA interface.
+The grouped DMA surface in this specification covers `pto.dma_load`
+(GM→UB), `pto.dma_store` (UB→GM), and `pto.dma_copy`
+(UB→UB or UB→CBUF). Low-level raw copy families remain available with
+separate operand contracts.
 
 **Load/Store Access Patterns**:
 
-For UB↔vreg data movement, besides contiguous load/store, the architecture provides rich access pattern support including strided access, pack/unpack, interleave/deinterleave, broadcast, upsample/downsample, channel split/merge, gather/scatter, and squeeze/expand operations. For detailed instruction syntax and distribution modes, refer to the [Vector Load/Store](isa/03-vector-load-store.md) group in the ISA specification.
+For UB↔vreg data movement, besides contiguous load/store, the architecture provides rich access pattern support including strided access, pack/unpack, interleave/deinterleave, broadcast, upsample/downsample, channel split/merge, gather/scatter, and squeeze/expand operations. For detailed instruction syntax and distribution modes, refer to the [Vector Load/Store](isa/micro-isa/03-vector-load-store.md) group in the ISA specification.
 
 #### Synchronization Model
 
@@ -566,6 +567,7 @@ Full pipeline summary
 ```
 
 
+
 #### Programming Model
 
 The common pattern for Cube–Vector co-programming is a **software pipeline**: the Cube and Vector
@@ -742,61 +744,7 @@ Typical examples:
 - `!pto.ptr<f32, ub>`
 - `!pto.ptr<bf16, gm>`
 
-### Tensor View Metadata Query Ops
-
-VPTO source programs may keep GM tensor operands in logical `!pto.tensor_view`
-form instead of exposing them as raw memrefs. Two metadata-query ops are used to
-read shape and stride information from that logical view:
-
-#### `pto.get_tensor_view_dim`
-
-- **syntax:** `%dim = pto.get_tensor_view_dim %tv, %idx : !pto.tensor_view<...> -> index`
-- **semantics:** Returns the runtime extent of dimension `%idx` from the logical tensor view.
-
-```c
-dim = tv.shape[idx];
-```
-
-Example:
-
-```mlir
-%d2 = pto.get_tensor_view_dim %src, %c2 : !pto.tensor_view<?x?x?x?x?xf32> -> index
-```
-
-#### `pto.get_tensor_view_stride`
-
-- **syntax:** `%stride = pto.get_tensor_view_stride %tv, %idx : !pto.tensor_view<...> -> index`
-- **semantics:** Returns the logical stride of dimension `%idx`, measured in elements rather than bytes.
-
-```c
-stride = tv.strides[idx];
-```
-
-Example:
-
-```mlir
-%s2 = pto.get_tensor_view_stride %src, %c2 : !pto.tensor_view<?x?x?x?x?xf32> -> index
-```
-
-Notes:
-
-- These ops are metadata queries only and do not trigger any hardware pipeline activity.
-- In authoring-form IR, they operate on `!pto.tensor_view`.
-- During compiler-internal lowering, they may be rewritten to equivalent memref metadata queries such as `memref.dim` and extracted strided metadata.
-
 ### Pointer Operations
-
-#### `pto.tensor_view_addr`
-
-- **syntax:** `%result = pto.tensor_view_addr %src : !pto.tensor_view<...> -> memref<...>`
-- **syntax:** `%result = pto.tensor_view_addr %src : !pto.tensor_view<...> -> !pto.ptr<T, gm>`
-- **semantics:** Extract the underlying address view from a `tensor_view` or `partition_tensor_view`.
-
-```c
-result = addr_of(src);
-```
-
-`pto.tensor_view_addr` is an address-extraction operation. It does not move data and does not by itself imply any hardware side effect. When the result type is a memref, it exposes the lowered view directly. When the result type is `!pto.ptr<..., gm>`, it exposes the same address in pointer form. After compiler-internal view lowering, the operand may already be a memref; in that case the op is folded away or rewritten to an equivalent memref-to-ptr cast.
 
 #### `pto.castptr`
 
@@ -1174,22 +1122,22 @@ This section provides a categorized overview of all PTO micro Instruction operat
 
 | # | Group | Description | Count | Details |
 |---|-------|-------------|-------|---------|
-| 1 | [Pipeline Sync](isa/01-pipeline-sync.md) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
-| 2 | [DMA Copy Programming](isa/02-dma-copy.md) | Public DMA transfer interface between GM↔UB and UB↔UB | 3 | `pto.dma_load`, `pto.dma_store`, `pto.dma_copy` |
-| 3 | [Vector Load/Store](isa/03-vector-load-store.md) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldsx2`, `pto.vgather2`, `pto.vsts`, `pto.vstsx2`, `pto.vscatter`, etc. |
-| 4 | [Predicate Load/Store](isa/04-predicate-load-store.md) | UB↔mask register movement | 5 | `pto.plds`, `pto.pldi`, `pto.psts`, `pto.psti`, `pto.pstu` |
-| 5 | [Materialization & Predicate Ops](isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
-| 6 | [Unary Vector Ops](isa/06-unary-vector-ops.md) | Single-input element-wise operations | 6 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrelu`, `pto.vnot` |
-| 7 | [Binary Vector Ops](isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
-| 8 | [Vec-Scalar Ops](isa/08-vec-scalar-ops.md) | Vector-scalar operations | 9 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
-| 9 | [Conversion Ops](isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 4 | `pto.vcvt`, `pto.vtrc`, `pto.vbitcast`, `pto.pbitcast` |
-| 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
-| 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
-| 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
-| 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
-| 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
-| 16 | [Cube Matrix Multiply (MAT)](isa/16-cube-matmul.md) | GM↔L1 cube staging, L0A/L0B loads, L0C matmul, and L0C/L1 side-buffer moves | 10+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.mad`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf` |
+| 1 | [Pipeline Sync](isa/micro-isa/01-pipeline-sync.md) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
+| 2 | [DMA Copy Programming](isa/micro-isa/02-dma-copy.md) | Public DMA transfer interface between GM↔UB and UB↔UB | 3 | `pto.dma_load`, `pto.dma_store`, `pto.dma_copy` |
+| 3 | [Vector Load/Store](isa/micro-isa/03-vector-load-store.md) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldsx2`, `pto.vgather2`, `pto.vsts`, `pto.vstsx2`, `pto.vscatter`, etc. |
+| 4 | [Predicate Load/Store](isa/micro-isa/04-predicate-load-store.md) | UB↔mask register movement | 5 | `pto.plds`, `pto.pldi`, `pto.psts`, `pto.psti`, `pto.pstu` |
+| 5 | [Materialization & Predicate Ops](isa/micro-isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
+| 6 | [Unary Vector Ops](isa/micro-isa/06-unary-vector-ops.md) | Single-input element-wise operations | 6 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrelu`, `pto.vnot` |
+| 7 | [Binary Vector Ops](isa/micro-isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
+| 8 | [Vec-Scalar Ops](isa/micro-isa/08-vec-scalar-ops.md) | Vector-scalar operations | 9 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
+| 9 | [Conversion Ops](isa/micro-isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 4 | `pto.vcvt`, `pto.vtrc`, `pto.vbitcast`, `pto.pbitcast` |
+| 10 | [Reduction Ops](isa/micro-isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
+| 11 | [Compare & Select](isa/micro-isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
+| 12 | [Data Rearrangement](isa/micro-isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
+| 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
+| 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
+| 16 | [Cube Matrix Multiply (MAT)](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`cbuf`) staging, L1 (`cbuf`)↔UB side moves, L1→L0A/L0B loads, L0C (`acc`) matmul, and wrapper bridge load/store ops | 16+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.load_cbuf_to_ca_mx`, `pto.load_cbuf_to_cb_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf`, `pto.cube_load`, `pto.cube_store`, `pto.cube_load_frac`, `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx`, `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |
 
 ---
 
@@ -1201,10 +1149,18 @@ This section provides a categorized overview of all PTO micro Instruction operat
 |-----------|-------|-------------|
 | GM→UB DMA | 2 | `pto.dma_load` |
 | UB→GM DMA | 2 | `pto.dma_store` |
-| GM→L1 (cube staging) | 16 | `pto.copy_gm_to_cbuf` |
-| GM→L1 (multi layout staging) | 16 | `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz` |
+| UB→UB / UB→CBUF copy | 2 | `pto.dma_copy` |
+| GM→L1 | 16 | `pto.copy_gm_to_cbuf` |
+| GM→L1 | 16 | `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz` |
+| GM→L1 | 16 | `pto.cube_load`, `pto.cube_load_frac` |
+| L1→UB bridge wrapper | 16 | `pto.cube_store` |
+| L1→BT (bridge wrapper) | 16 | `pto.bias_load` |
 | L1→L0A / L1→L0B | 16 | `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb` |
-| L0C→GM (cube writeback) | 16 | `pto.copy_matrix_cc_to_gm` |
+| L1→L0A / L1→L0B bridge wrapper | 16 | `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx` |
+| L0C→GM cube writeback | 16 | `pto.copy_matrix_cc_to_gm` |
+| L0C→L1 bridge wrapper | 16 | `pto.acc_store` |
+| L0C→GM bridge wrapper | 16 | `pto.acc_store_gm` |
+| L0C→UB bridge wrapper | 16 | `pto.acc_store_ub` |
 | L0C→L1 / L0C→UB | 16 | `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub` |
 | L1→BT / L1→FB | 16 | `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf` |
 | Contiguous Load | 3 | `pto.vlds` with `NORM` dist |
@@ -1221,7 +1177,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | Scalar Operations | 8 | `pto.vadds`, `pto.vmuls`, etc. |
 | Transcendental | 6 | `pto.vexp`, `pto.vln`, `pto.vsqrt`, etc. |
 | Reduction | 10 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin` |
-| Cube matmul (L0A×L0B→L0C) | 16 | `pto.mad` |
+| Cube matmul family (zero-init / accumulate / bias-init; shared attrs `unit_flag_ctrl` and `disable_gemv`) | 16 | `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias` |
 | Comparison | 11 | `pto.vcmp`, `pto.vcmps` |
 | Selection | 11 | `pto.vsel`, `pto.vselr` |
 
@@ -1271,9 +1227,16 @@ Group 14 covers the full scalar `arith` surface. The rows below list common PTO 
 ### Verified Op List (Current Batch)
 
 - `pto.copy_cbuf_to_bt`
+- `pto.bias_load`
 - `pto.copy_cbuf_to_fbuf`
 - `pto.copy_gm_to_cbuf_multi_dn2nz`
 - `pto.copy_gm_to_cbuf_multi_nd2nz`
+- `pto.mad`
+- `pto.mad_acc`
+- `pto.mad_bias`
+- `pto.mad_mx`
+- `pto.mad_mx_acc`
+- `pto.mad_mx_bias`
 - `pto.copy_matrix_cc_to_cbuf`
 - `pto.copy_matrix_cc_to_ub`
 - `pto.load_cbuf_to_ca_mx`
@@ -1357,6 +1320,23 @@ pto.vstsx2 %x, %y, %ub_xy[%offset], "INTLV_B32", %all_mask : !pto.vreg<64xf32>, 
 ---
 
 *For detailed semantics, C-style pseudocode, and CCE mappings, see the individual group documentation files.*
+
+---
+
+## Part IV: PTO Tile Instruction
+
+PTO Tile Instruction is a high-performance instruction surface built on top of PTO micro Instruction. Each tile instruction encapsulates a tile-granular pattern — DMA between GM and on-chip buffers, vector arithmetic over a whole tile, reductions, broadcast / expansion, selection, padding — and internally expands to a sequence of micro-instruction primitives (`pto.vlds`, `pto.vsts`, `pto.vadd`, mask ops, sync flags, …).
+
+The full PTO Tile Instruction reference starts from [Tile and PTO Tile Instruction overview](isa/tile-op/01-tile-overview.md). It covers:
+
+- [Tile and PTO Tile Instruction overview](isa/tile-op/01-tile-overview.md) — tile concept, on-chip placement, physical shape vs valid region, conventions
+- [Types & Attributes](isa/tile-op/02-types-and-attributes.md) — `!pto.tile_buf`, `!pto.tensor_view`, address spaces, layout, pad
+- [Pointer & View](isa/tile-op/03-pointer-and-view.md) — tensor views, partitions, tile allocation, valid-shape updates
+- [DMA Data Movement](isa/tile-op/04-dma-data-movement.md) — `pto.tload` / `pto.tstore`
+- [Vector Arithmetic](isa/tile-op/05-vector-arithmetic.md) — `pto.tadd / tsub / tmul / tdiv / tmax / tmin`, tile-scalar forms, unary math, activations
+- [Reductions](isa/tile-op/06-reduction-ops.md), [Partial Elementwise](isa/tile-op/07-partial-elementwise.md), [Bitwise & Shift](isa/tile-op/08-bitwise-shift-ops.md), [Type Conversion](isa/tile-op/09-type-conversion.md), [Broadcast & Expansion](isa/tile-op/10-broadcast-and-expansion-ops.md), [Selection](isa/tile-op/11-selection-ops.md), [Fill & Padding](isa/tile-op/12-fill-and-padding-ops.md)
+
+For the boundary between Tile Instruction and the micro instruction surface (when to drop into `pto.vecscope` and how `pto.tile_buf_addr` bridges the two), see [Tile and PTO Tile Instruction overview §1.10](isa/tile-op/01-tile-overview.md#110-mixing-pto-tile-instruction-and-pto-micro-instruction).
 
 ---
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -2,7 +2,7 @@
 
 > **Status:** DRAFT for review
 > **Base:** [vpto-spec.md](https://github.com/mouliangyu/PTOAS/blob/feature-vpto-backend/docs/vpto-spec.md) (2026-03-20)
-> **Updated:** 2026-04-30
+> **Updated:** 2026-03-27
 
 ---
 
@@ -20,7 +20,7 @@ The PTO micro Instruction operates as a very low-level intermediate representati
 
 Within the end-to-end PTO software stack, PTO instructions may appear in three closely related authoring or lowering modes:
 
-- **PTO Tile Instruction**: tile-oriented PTO code that serves as a nano-kernel encapsulation of tile instructions, primarily expressing computation and data movement in terms of tile buffers, tile shapes, and tile-local layout.
+- **PTO Tile Instruction**: tile-oriented PTO code that serves as a nano-kernel encapsulation of Tile operations, primarily expressing computation and data movement in terms of tile buffers, tile shapes, and tile-local layout.
 - **PTO micro Instruction**: vector-execution-oriented PTO code that makes DMA setup, vector registers, masks, synchronization, and `__VEC_SCOPE__` boundaries explicit. This document is centered on this mode.
 - **PTO Tile+micro Instruction**: a hybrid PTO form that keeps tile-level orchestration while embedding explicit micro-instruction regions where direct vector-pipeline control is required.
 
@@ -147,14 +147,13 @@ The PTO micro Instruction enforces a strict memory hierarchy. The Unified Buffer
 4. **vreg → UB**: Vector Store instructions (`pto.vsts`, `pto.vstsx2`, etc.)
 5. **UB → GM**: DMA transfer via MTE3 (`pto.dma_store`)
 
-The grouped DMA surface in this specification covers `pto.dma_load`
-(GM→UB), `pto.dma_store` (UB→GM), and `pto.dma_copy`
-(UB→UB or UB→CBUF). Low-level raw copy families remain available with
-separate operand contracts.
+The grouped DMA surface in this specification covers GM↔UB transfer only.
+Low-level raw copy families such as UB→UB copy use separate operand contracts
+and are outside this grouped DMA interface.
 
 **Load/Store Access Patterns**:
 
-For UB↔vreg data movement, besides contiguous load/store, the architecture provides rich access pattern support including strided access, pack/unpack, interleave/deinterleave, broadcast, upsample/downsample, channel split/merge, gather/scatter, and squeeze/expand operations. For detailed instruction syntax and distribution modes, refer to the [Vector Load/Store](isa/micro-isa/03-vector-load-store.md) group in the ISA specification.
+For UB↔vreg data movement, besides contiguous load/store, the architecture provides rich access pattern support including strided access, pack/unpack, interleave/deinterleave, broadcast, upsample/downsample, channel split/merge, gather/scatter, and squeeze/expand operations. For detailed instruction syntax and distribution modes, refer to the [Vector Load/Store](isa/03-vector-load-store.md) group in the ISA specification.
 
 #### Synchronization Model
 
@@ -428,6 +427,145 @@ When the local data path is not applicable, data can be exchanged via a **Global
 buffer**: the producer DMAs data to GM, and the consumer DMAs from GM. This path incurs off-chip
 bandwidth cost and higher latency, but serves as a general fallback.
 
+#### Cube Internal Buffer Layout: NZ Fractal Format
+
+All cube unit internal buffers (L1/cbuf, L0A, L0B, L0C) use a **fractal NZ layout** rather than
+row-major ND. Understanding this layout is essential when authoring cube data-movement ops.
+
+##### Definition
+
+Given hardware constant `C0 = 32 bytes`, for element type with byte width `E = sizeof(T)`:
+
+- Inner tile width: `K0 = N0 = C0 / E` (e.g. `K0 = 16` for fp16/bf16)
+- Inner tile height: `M0 = 16`
+
+NZ re-indexing for a logical `[M, K]` tensor:
+
+```
+NZ index: (k1, m1, m0, k0)
+  where  k1 = k / K0,  k0 = k % K0
+         m1 = m / M0,  m0 = m % M0
+Physical layout: K1 x M1 x M0 x K0  (last dimension contiguous)
+```
+
+##### Per-buffer NZ Layouts
+
+| Buffer | Logical shape | Physical NZ layout | Notes |
+|--------|--------------|-------------------|-------|
+| L1 (cbuf) - Tensor A | `[M, K]` | `K1 M1 M0 K0` | `pto.copy_gm_to_cbuf_multi_nd2nz` of row-major A |
+| L1 (cbuf) - Tensor B | `[K, N]` | `K1 N1 K0 N0` | `pto.copy_gm_to_cbuf_multi_nd2nz` of row-major B |
+| L0A (left operand)   | -        | `K1 M1 M0 K0` | FRACTAL_NZ (A5) / FRACTAL_ZZ (A3): same NZ order as L1 cbuf |
+| L0B (right operand)  | -        | `K1 N1 N0 K0` | FRACTAL_ZN: row-major outer, col-major inner (K0 innermost) |
+| L0C (accumulator)    | `[M, N]` | `N1 M1 M0 N0` | output of MMAD (FRACTAL_NZ: col-major outer, row-major inner) |
+
+##### Data Flow: GM -> L1 -> L0A/B -> L0C
+
+```
++------------------------------------------------------------------------------+
+|              GEMM Data Layout: GM -> L1 (NZ) -> L0A/B -> L0C               |
++------------------------------------------------------------------------------+
+
+STEP 1 - Global Memory (ND, row-major)
+--------------------------------------
+ Tensor A [M, K]                     Tensor B [K, N]
+ (K is the contiguous axis)          (N is the contiguous axis)
+
+  col->  k0  k1  ...  kK-1             col->  n0  n1  ...  nN-1
+row|   +--------------------+         row|   +--------------------+
+  m0  | a00 a01 ...        |           k0  | b00 b01 ...        |
+  m1  | a10 a11 ...        |           k1  | b10 b11 ...        |
+  ... |                    |           ... |                    |
+  mM-1|                    |          kK-1 |                    |
+      +--------------------+               +--------------------+
+  Physical: A[m*K + k]                 Physical: B[k*N + n]
+
+
+STEP 2 - GM -> L1 (cbuf): NDtoNZ fractal repack
+-------------------------------------------------
+ op: pto.copy_gm_to_cbuf_multi_nd2nz  (A and B; use pto.copy_gm_to_cbuf_multi_dn2nz only for pre-transposed B)
+
+ A in L1: K1 x M1 x M0 x K0          B in L1: K1 x N1 x K0 x N0
+ For each outer block (k1, m1):       For each outer block (k1, n1):
+ +----------------------------+       +----------------------------+
+ |  M0 rows x K0 cols         |       |  K0 rows x N0 cols         |
+ |  (16x16 elems contiguous)  |       |  (16x16 elems contiguous)  |
+ |  m0|  k0-> [0 .. K0-1]     |       |  k0|  n0-> [0 .. N0-1]     |
+ |   0   [a a a a ...]        |       |   0   [b b b b ...]        |
+ |   1   [a a a a ...]        |       |   1   [b b b b ...]        |
+ |  ...                       |       |  ...                       |
+ |  M0-1 [a a a a ...]        |       |  K0-1 [b b b b ...]        |
+ +----------------------------+       +----------------------------+
+ Physical: A_nz[k1][m1][m0][k0]       Physical: B_nz[k1][n1][k0][n0]
+
+
+
+ NOTE: For GEMM (row-major A/B), prefer pto.copy_gm_to_cbuf_multi_nd2nz for both A and B.
+   pto.copy_gm_to_cbuf_multi_dn2nz is intended for NCHW-layout inputs (e.g. convolution)
+   where the data is already transposed in GM. Using dn2nz for row-major B forces
+   non-contiguous GM access (striding across N to gather K), which hurts burst BW.
+   The B fractal transpose for cube compatibility is done at STEP 3 (L1->L0B).
+   Note: A2/A3 does not have dn2nz, so using nd2nz only is backward compatible
+   across all generations.
+
+
+STEP 3 - L1 -> L0A / L0B
+--------------------------
+ ops: pto.load_cbuf_to_ca  (no transpose)
+      pto.load_cbuf_to_cb  (transpose via load_2d_v2)
+
+ L0A: cbuf K1 M1 M0 K0 -(load_cbuf_to_ca)-> L0A K1 M1 M0 K0  (FRACTAL_NZ on A5)
+ L0B: cbuf K1 N1 K0 N0 --(TMOV/ZN)---> L0B K1 N1 N0 K0  (FRACTAL_ZN, K0 innermost)
+
+ Why transpose at L1->L0B and not at GM->L1?
+ --------------------------------------------
+ The cube reduction axis is K. L0B requires K innermost (N1 K1 K0 N0)
+ so the cube hardware reads all K0 elements per cycle without striding.
+ The inner-box transpose is performed on-the-fly by the MTE hardware
+ during the L1->L0B transfer itself — no extra pass required.
+ Each 512B fractal z-block is permuted as it moves from L1 to L0B.
+
+  L0A tile (cube LEFT port):           L0B tile (cube RIGHT port):
+  +---------------------+              +---------------------+
+  |  shape: [M0, K0]    |       x      |  shape: [K0, N0]    |
+  |  M0 rows, K0 cols   |              |  K0 rows, N0 cols   |
+  |  K innermost (fast) |              |  K innermost (fast) |
+  +---------------------+              +---------------------+
+          |                                      |
+          +-----------------+--------------------+
+                            |  pto.mad (MMAD)
+                            v
+
+STEP 4 - L0C output layout: N1 M1 M0 N0
+-----------------------------------------
+  For each outer block (n1, m1):
+  +------------------------------+
+  |  M0 rows x N0 cols           |
+  |  = result sub-tile of C[M,N] |
+  |  n0->  [0 .. N0-1]           |
+  |  m0|  [c c c c ...]          |
+  |       [c c c c ...]          |
+  +------------------------------+
+  Physical: C_nz[n1][m1][m0][n0]  ->  C_nd[m1*M0+m0][n1*N0+n0]
+
+  Writeback: pto.copy_matrix_cc_to_gm   (FRACTAL_NZ -> ND, normal output)
+             pto.copy_matrix_cc_to_cbuf  (stays FRACTAL_NZ, for fused ops)
+             pto.copy_matrix_cc_to_ub    (FRACTAL_NZ -> ND to UB, A5 only;
+                                          used in fixed-point (fixp) datapath)
+
+
+Full pipeline summary
+----------------------
+  GM (ND)          L1/cbuf (NZ)            L0A/B (NZ)          L0C (NZ)    GM (ND)
+
+  A[M,K] -nd2nz(copy_gm_to_cbuf_multi_nd2nz)-> K1 M1 M0 K0 --load_cbuf_to_ca-> K1 M1 M0 K0 -+
+                                                               +-MAD-> N1 M1 M0 N0 --> C[M,N]
+  B[K,N] -nd2nz(copy_gm_to_cbuf_multi_nd2nz)-> K1 N1 K0 N0 --load_cbuf_to_cb-> K1 N1 N0 K0 -+
+                                 ^
+                      transpose at L1->L0B (load_cbuf_to_cb, load_2d_v2)
+                      NOT at GM->L1
+```
+
+
 #### Programming Model
 
 The common pattern for Cube–Vector co-programming is a **software pipeline**: the Cube and Vector
@@ -604,7 +742,61 @@ Typical examples:
 - `!pto.ptr<f32, ub>`
 - `!pto.ptr<bf16, gm>`
 
+### Tensor View Metadata Query Ops
+
+VPTO source programs may keep GM tensor operands in logical `!pto.tensor_view`
+form instead of exposing them as raw memrefs. Two metadata-query ops are used to
+read shape and stride information from that logical view:
+
+#### `pto.get_tensor_view_dim`
+
+- **syntax:** `%dim = pto.get_tensor_view_dim %tv, %idx : !pto.tensor_view<...> -> index`
+- **semantics:** Returns the runtime extent of dimension `%idx` from the logical tensor view.
+
+```c
+dim = tv.shape[idx];
+```
+
+Example:
+
+```mlir
+%d2 = pto.get_tensor_view_dim %src, %c2 : !pto.tensor_view<?x?x?x?x?xf32> -> index
+```
+
+#### `pto.get_tensor_view_stride`
+
+- **syntax:** `%stride = pto.get_tensor_view_stride %tv, %idx : !pto.tensor_view<...> -> index`
+- **semantics:** Returns the logical stride of dimension `%idx`, measured in elements rather than bytes.
+
+```c
+stride = tv.strides[idx];
+```
+
+Example:
+
+```mlir
+%s2 = pto.get_tensor_view_stride %src, %c2 : !pto.tensor_view<?x?x?x?x?xf32> -> index
+```
+
+Notes:
+
+- These ops are metadata queries only and do not trigger any hardware pipeline activity.
+- In authoring-form IR, they operate on `!pto.tensor_view`.
+- During compiler-internal lowering, they may be rewritten to equivalent memref metadata queries such as `memref.dim` and extracted strided metadata.
+
 ### Pointer Operations
+
+#### `pto.tensor_view_addr`
+
+- **syntax:** `%result = pto.tensor_view_addr %src : !pto.tensor_view<...> -> memref<...>`
+- **syntax:** `%result = pto.tensor_view_addr %src : !pto.tensor_view<...> -> !pto.ptr<T, gm>`
+- **semantics:** Extract the underlying address view from a `tensor_view` or `partition_tensor_view`.
+
+```c
+result = addr_of(src);
+```
+
+`pto.tensor_view_addr` is an address-extraction operation. It does not move data and does not by itself imply any hardware side effect. When the result type is a memref, it exposes the lowered view directly. When the result type is `!pto.ptr<..., gm>`, it exposes the same address in pointer form. After compiler-internal view lowering, the operand may already be a memref; in that case the op is folded away or rewritten to an equivalent memref-to-ptr cast.
 
 #### `pto.castptr`
 
@@ -982,22 +1174,22 @@ This section provides a categorized overview of all PTO micro Instruction operat
 
 | # | Group | Description | Count | Details |
 |---|-------|-------------|-------|---------|
-| 1 | [Pipeline Sync](isa/micro-isa/01-pipeline-sync.md) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
-| 2 | [DMA Copy Programming](isa/micro-isa/02-dma-copy.md) | Public DMA transfer interface between GM↔UB and UB↔UB | 3 | `pto.dma_load`, `pto.dma_store`, `pto.dma_copy` |
-| 3 | [Vector Load/Store](isa/micro-isa/03-vector-load-store.md) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldsx2`, `pto.vgather2`, `pto.vsts`, `pto.vstsx2`, `pto.vscatter`, etc. |
-| 4 | [Predicate Load/Store](isa/micro-isa/04-predicate-load-store.md) | UB↔mask register movement | 5 | `pto.plds`, `pto.pldi`, `pto.psts`, `pto.psti`, `pto.pstu` |
-| 5 | [Materialization & Predicate Ops](isa/micro-isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
-| 6 | [Unary Vector Ops](isa/micro-isa/06-unary-vector-ops.md) | Single-input element-wise operations | 6 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrelu`, `pto.vnot` |
-| 7 | [Binary Vector Ops](isa/micro-isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
-| 8 | [Vec-Scalar Ops](isa/micro-isa/08-vec-scalar-ops.md) | Vector-scalar operations | 9 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
-| 9 | [Conversion Ops](isa/micro-isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 4 | `pto.vcvt`, `pto.vtrc`, `pto.vbitcast`, `pto.pbitcast` |
-| 10 | [Reduction Ops](isa/micro-isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
-| 11 | [Compare & Select](isa/micro-isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
-| 12 | [Data Rearrangement](isa/micro-isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
-| 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
-| 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
-| 16 | [Cube Matrix Multiply (MAT)](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`cbuf`) staging, L1 (`cbuf`)↔UB side moves, L1→L0A/L0B loads, L0C (`acc`) matmul, and wrapper bridge load/store ops | 16+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.load_cbuf_to_ca_mx`, `pto.load_cbuf_to_cb_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf`, `pto.cube_load`, `pto.cube_store`, `pto.cube_load_frac`, `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx`, `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |
+| 1 | [Pipeline Sync](isa/01-pipeline-sync.md) | Intra-core pipeline synchronization | 5 | `pto.set_flag`, `pto.wait_flag`, `pto.pipe_barrier`, `pto.get_buf`, `pto.rls_buf` |
+| 2 | [DMA Copy Programming](isa/02-dma-copy.md) | Public DMA transfer interface between GM↔UB and UB↔UB | 3 | `pto.dma_load`, `pto.dma_store`, `pto.dma_copy` |
+| 3 | [Vector Load/Store](isa/03-vector-load-store.md) | UB↔vreg data movement with various access patterns | ~20 | `pto.vlds`, `pto.vldsx2`, `pto.vgather2`, `pto.vsts`, `pto.vstsx2`, `pto.vscatter`, etc. |
+| 4 | [Predicate Load/Store](isa/04-predicate-load-store.md) | UB↔mask register movement | 5 | `pto.plds`, `pto.pldi`, `pto.psts`, `pto.psti`, `pto.pstu` |
+| 5 | [Materialization & Predicate Ops](isa/05-materialization-predicate.md) | Scalar broadcast, predicate generation and manipulation | ~17 | `pto.vbr`, `pto.vdup`, `pto.pset_b*`, `pto.pge_b*`, `pto.plt_b*`, `pto.ppack`, `pto.punpack`, `pto.pnot`, `pto.psel`, etc. |
+| 6 | [Unary Vector Ops](isa/06-unary-vector-ops.md) | Single-input element-wise operations | 6 | `pto.vabs`, `pto.vexp`, `pto.vln`, `pto.vsqrt`, `pto.vrelu`, `pto.vnot` |
+| 7 | [Binary Vector Ops](isa/07-binary-vector-ops.md) | Two-input element-wise operations | 13 | `pto.vadd`, `pto.vsub`, `pto.vmul`, `pto.vdiv`, `pto.vmax`, `pto.vmin`, `pto.vand`, `pto.vor`, `pto.vxor`, `pto.vshl`, `pto.vshr`, `pto.vaddc`, `pto.vsubc` |
+| 8 | [Vec-Scalar Ops](isa/08-vec-scalar-ops.md) | Vector-scalar operations | 9 | `pto.vadds`, `pto.vmuls`, `pto.vmaxs`, `pto.vmins`, `pto.vlrelu`, `pto.vshls`, `pto.vshrs`, `pto.vaddcs`, `pto.vsubcs` |
+| 9 | [Conversion Ops](isa/09-conversion-ops.md) | Type conversion with rounding/saturation control | 4 | `pto.vcvt`, `pto.vtrc`, `pto.vbitcast`, `pto.pbitcast` |
+| 10 | [Reduction Ops](isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
+| 11 | [Compare & Select](isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
+| 12 | [Data Rearrangement](isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
+| 13 | [DSA/SFU Ops](isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 14 | [Arith (Shared MLIR Dialect)](isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
+| 15 | [SCF (Shared MLIR Dialect)](isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
+| 16 | [Cube Matrix Multiply (MAT)](isa/16-cube-matmul.md) | GM↔L1 cube staging, L0A/L0B loads, L0C matmul, and L0C/L1 side-buffer moves | 10+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.mad`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf` |
 
 ---
 
@@ -1009,18 +1201,10 @@ This section provides a categorized overview of all PTO micro Instruction operat
 |-----------|-------|-------------|
 | GM→UB DMA | 2 | `pto.dma_load` |
 | UB→GM DMA | 2 | `pto.dma_store` |
-| UB→UB / UB→CBUF copy | 2 | `pto.dma_copy` |
-| GM→L1 | 16 | `pto.copy_gm_to_cbuf` |
-| GM→L1 | 16 | `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz` |
-| GM→L1 | 16 | `pto.cube_load`, `pto.cube_load_frac` |
-| L1→UB bridge wrapper | 16 | `pto.cube_store` |
-| L1→BT (bridge wrapper) | 16 | `pto.bias_load` |
+| GM→L1 (cube staging) | 16 | `pto.copy_gm_to_cbuf` |
+| GM→L1 (multi layout staging) | 16 | `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz` |
 | L1→L0A / L1→L0B | 16 | `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb` |
-| L1→L0A / L1→L0B bridge wrapper | 16 | `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx` |
-| L0C→GM cube writeback | 16 | `pto.copy_matrix_cc_to_gm` |
-| L0C→L1 bridge wrapper | 16 | `pto.acc_store` |
-| L0C→GM bridge wrapper | 16 | `pto.acc_store_gm` |
-| L0C→UB bridge wrapper | 16 | `pto.acc_store_ub` |
+| L0C→GM (cube writeback) | 16 | `pto.copy_matrix_cc_to_gm` |
 | L0C→L1 / L0C→UB | 16 | `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub` |
 | L1→BT / L1→FB | 16 | `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf` |
 | Contiguous Load | 3 | `pto.vlds` with `NORM` dist |
@@ -1037,7 +1221,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | Scalar Operations | 8 | `pto.vadds`, `pto.vmuls`, etc. |
 | Transcendental | 6 | `pto.vexp`, `pto.vln`, `pto.vsqrt`, etc. |
 | Reduction | 10 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin` |
-| Cube matmul family (zero-init / accumulate / bias-init; shared attrs `unit_flag_ctrl` and `disable_gemv`) | 16 | `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias` |
+| Cube matmul (L0A×L0B→L0C) | 16 | `pto.mad` |
 | Comparison | 11 | `pto.vcmp`, `pto.vcmps` |
 | Selection | 11 | `pto.vsel`, `pto.vselr` |
 
@@ -1087,16 +1271,9 @@ Group 14 covers the full scalar `arith` surface. The rows below list common PTO 
 ### Verified Op List (Current Batch)
 
 - `pto.copy_cbuf_to_bt`
-- `pto.bias_load`
 - `pto.copy_cbuf_to_fbuf`
 - `pto.copy_gm_to_cbuf_multi_dn2nz`
 - `pto.copy_gm_to_cbuf_multi_nd2nz`
-- `pto.mad`
-- `pto.mad_acc`
-- `pto.mad_bias`
-- `pto.mad_mx`
-- `pto.mad_mx_acc`
-- `pto.mad_mx_bias`
 - `pto.copy_matrix_cc_to_cbuf`
 - `pto.copy_matrix_cc_to_ub`
 - `pto.load_cbuf_to_ca_mx`
@@ -1180,23 +1357,6 @@ pto.vstsx2 %x, %y, %ub_xy[%offset], "INTLV_B32", %all_mask : !pto.vreg<64xf32>, 
 ---
 
 *For detailed semantics, C-style pseudocode, and CCE mappings, see the individual group documentation files.*
-
----
-
-## Part IV: PTO Tile Instruction
-
-PTO Tile Instruction is a high-performance instruction surface built on top of PTO micro Instruction. Each tile instruction encapsulates a tile-granular pattern — DMA between GM and on-chip buffers, vector arithmetic over a whole tile, reductions, broadcast / expansion, selection, padding — and internally expands to a sequence of micro-instruction primitives (`pto.vlds`, `pto.vsts`, `pto.vadd`, mask ops, sync flags, …).
-
-The full PTO Tile Instruction reference starts from [Tile and PTO Tile Instruction overview](isa/tile-op/01-tile-overview.md). It covers:
-
-- [Tile and PTO Tile Instruction overview](isa/tile-op/01-tile-overview.md) — tile concept, on-chip placement, physical shape vs valid region, conventions
-- [Types & Attributes](isa/tile-op/02-types-and-attributes.md) — `!pto.tile_buf`, `!pto.tensor_view`, address spaces, layout, pad
-- [Pointer & View](isa/tile-op/03-pointer-and-view.md) — tensor views, partitions, tile allocation, valid-shape updates
-- [DMA Data Movement](isa/tile-op/04-dma-data-movement.md) — `pto.tload` / `pto.tstore`
-- [Vector Arithmetic](isa/tile-op/05-vector-arithmetic.md) — `pto.tadd / tsub / tmul / tdiv / tmax / tmin`, tile-scalar forms, unary math, activations
-- [Reductions](isa/tile-op/06-reduction-ops.md), [Partial Elementwise](isa/tile-op/07-partial-elementwise.md), [Bitwise & Shift](isa/tile-op/08-bitwise-shift-ops.md), [Type Conversion](isa/tile-op/09-type-conversion.md), [Broadcast & Expansion](isa/tile-op/10-broadcast-and-expansion-ops.md), [Selection](isa/tile-op/11-selection-ops.md), [Fill & Padding](isa/tile-op/12-fill-and-padding-ops.md)
-
-For the boundary between Tile Instruction and the micro instruction surface (when to drop into `pto.vecscope` and how `pto.tile_buf_addr` bridges the two), see [Tile and PTO Tile Instruction overview §1.10](isa/tile-op/01-tile-overview.md#110-mixing-pto-tile-instruction-and-pto-micro-instruction).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds documentation for the NZ fractal memory layout used by all cube unit internal buffers, covering the full data path GM -> L1 -> L0A/B -> L0C.

## Changes

### `docs/vpto-spec.md`
New subsection **Cube Internal Buffer Layout: NZ Fractal Format** under Cluster Programming Model > Intra-Cluster Data Paths:
- Math definition of NZ re-indexing: `K1 M1 M0 K0` (A in L1/L0A), `K1 N1 N0 K0` (B in L1), `N1 K1 K0 N0` (L0B), `M1 N1 M0 N0` (L0C)
- Per-buffer layout table (L1 cbuf, L0A, L0B, L0C)
- Full ASCII step-by-step diagram: GM -> L1 -> L0A/B -> L0C with layout at each stage
- `load_2d` parameter mapping (`n_burst`, `len_burst`, `src_stride`, `dst_stride`) for A and B
- Design rule: B transpose at **L1->L0B** (`load_cbuf_to_cb`, load_2d_v2), NOT at GM->L1

### `docs/isa/16-cube-matmul.md`
New subsection **Load 2D Parameter Mapping to NZ Layout**:
- Parameter tables for Tensor A `[M,K] -> K1 M1 M0 K0` and B `[K,N] -> K1 N1 N0 K0`
- Outer loop stride config (`set_loop1/2_stride_outtol1`)
- Explicit design rule note on nd2nz vs dn2nz and B transpose placement

## Key Design Rule

> Always load B from GM->L1 in natural row-major layout using `nd2nz`.
> Transpose B (`K1 N1 N0 K0` -> `N1 K1 K0 N0`) at L1->L0B via `load_cbuf_to_cb` (load_2d_v2).
> Using `dn2nz` at GM->L1 forces non-contiguous GM access and hurts burst BW efficiency.

## Review Checklist
- [ ] M0/K0/N0 values correct for target dtype (fp16 assumed: K0=16)
- [ ] `src_stride` formula matches specific `load_2d_v2` encoding
- [ ] Section placement fits overall doc structure