### PR TITLE
fix(pto): port tmrgsort format2 tmp-shape verifier fix

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -6621,10 +6621,22 @@ mlir::LogicalResult mlir::pto::TMrgSortOp::verify() {
       return emitOpError() << "format2 expects dst/tmp element types to match";
     auto dstShape = getShapeVec(dstTy);
     auto tmpShape = getShapeVec(tmpTy);
-    if (dstShape != tmpShape)
-      return emitOpError() << "format2 expects dst/tmp shapes to match";
+    if (dstShape.size() != 2 || tmpShape.size() != 2)
+      return emitOpError() << "format2 expects dst/tmp to be rank-2 tile-shaped";
+    if ((dstShape[0] != mlir::ShapedType::kDynamic && dstShape[0] != 1) ||
+        (tmpShape[0] != mlir::ShapedType::kDynamic && tmpShape[0] != 1))
+      return emitOpError() << "format2 expects dst/tmp rows == 1";
+    if (dstShape[1] != mlir::ShapedType::kDynamic &&
+        tmpShape[1] != mlir::ShapedType::kDynamic &&
+        tmpShape[1] < dstShape[1])
+      return emitOpError() << "format2 expects tmp.cols >= dst.cols";
     for (Value src : getSrcs()) {
       Type srcTy = src.getType();
+      auto srcShape = getShapeVec(srcTy);
+      if (srcShape.size() != 2)
+        return emitOpError() << "format2 expects src to be rank-2 tile-shaped";
+      if (srcShape[0] != mlir::ShapedType::kDynamic && srcShape[0] != 1)
+        return emitOpError() << "format2 expects src rows == 1";
       if (getElemTy(srcTy) != elemTy)
         return emitOpError() << "format2 expects src/dst/tmp element types to match";
     }

--- a/test/lit/pto/tmrgsort_format2_tmp_larger_emitc.pto
+++ b/test/lit/pto/tmrgsort_format2_tmp_larger_emitc.pto
@@ -1,0 +1,14 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tmrgsort_format2_tmp_larger(%ex: vector<4xi16>) {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=512, v_row=1, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmrgsort ins(%src0, %src1, %tmp {exhausted = false} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=512, v_row=1, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %ex : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
+    return
+  }
+}
+
+// A3: TMRGSORT<[[DST:Tile<.*256.*>]], [[TMP:Tile<.*512.*>]], [[SRC0:Tile<.*256.*>]], [[SRC1:Tile<.*256.*>]], false>(

--- a/test/lit/pto/tmrgsort_format2_tmp_too_small_invalid.pto
+++ b/test/lit/pto/tmrgsort_format2_tmp_too_small_invalid.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @tmrgsort_format2_tmp_too_small(%ex: vector<4xi16>) {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmrgsort ins(%src0, %src1, %tmp {exhausted = false} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %ex : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tmrgsort' op format2 expects tmp.cols >= dst.cols


### PR DESCRIPTION
## Summary
- port the merged official fix for `pto.tmrgsort` format2 verifier to `mouliangyu/PTOAS:feature-vpto-backend`
- allow `tmp.cols > dst.cols` while still rejecting unsafe `tmp.cols < dst.cols`
- add positive and negative lit regressions for the format2 tmp/dst shape contract

## Upstream Source
This change ports the already merged official fix from:
- hw-native-sys/PTOAS PR #641
- merge commit: `664a9a1008acc1a29ec33bd0459603ad9ec4becc`

## Why
Issue #333 reports that format2 currently rejects valid TMrgSort cases with:
- `dst.cols = 256`
- `tmp.cols = 512`

The official fix relaxes the old `dst/tmp shapes to match` verifier, but still keeps necessary safety checks:
- operands stay rank-2 with `rows == 1`
- `tmp.cols >= dst.cols`

## Files
- `lib/PTO/IR/PTO.cpp`
- `test/lit/pto/tmrgsort_format2_tmp_larger_emitc.pto`
- `test/lit/pto/tmrgsort_format2_tmp_too_small_invalid.pto`

## Validation
- Ported exactly the merged official change set
- Local full rebuild/validation in this mly worktree was not completed because this clean worktree requires additional local LLVM/lit test-tool wiring (`FileCheck` / `not` CMake targets) before `check-pto` can be configured
- The source patch has already been validated on the official branch before merge, including:
  - `ninja -C build ptoas`
  - `build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tmrgsort_format2_tmp_larger_emitc.pto`
  - `build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tmrgsort_variants_emitc.pto`
  - `build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tmrgsort_executed_constant_emitc.pto`
  - negative verifier check for `tmp.cols < dst.cols`

Closes #333
