### PR TITLE
fix(dsl): support builtin vector operand matching

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -77,7 +77,7 @@ namespace {
 // ============================================================================
 // OperandTypeInfo: describes one operand for template specialization.
 //
-// Three kinds of operands:
+// Four kinds of operands:
 //   Tile   — from TileBufType.  dtype + shape + memorySpace + config
 //            all participate in the specialization key (SpecKey).
 //   View   — from MemRefType (lowered PartitionTensorViewType). Only dtype
@@ -85,9 +85,13 @@ namespace {
 //            shape/strides/memorySpace don't affect code generation. They are
 //            carried here solely for JSON serialization to the Python DSL for
 //            constraint checking.
+//   Vector — from builtin VectorType. The element dtype and vector shape
+//            participate in SpecKey so helper-side schema filtering can
+//            distinguish auxiliary vector operands such as tmrgsort's
+//            `excuted : vector<4xi16>`.
 //   Scalar — from a scalar element type.  Only dtype participates in SpecKey.
 // ============================================================================
-enum class OperandKind { Tile, View, Scalar };
+enum class OperandKind { Tile, View, Vector, Scalar };
 
 struct OperandTypeInfo {
   OperandKind kind = OperandKind::Tile;
@@ -107,6 +111,9 @@ struct OperandTypeInfo {
   SmallVector<int64_t> viewStrides;
   std::string viewMemorySpace; // "gm" or "ub"
 
+  // --- Vector-only (builtin VectorType) ---
+  SmallVector<int64_t> vectorShape;
+
   /// Equality for SpecKey caching — only compares fields relevant to each kind.
   bool operator==(const OperandTypeInfo &rhs) const {
     if (kind != rhs.kind || dtype != rhs.dtype)
@@ -117,6 +124,8 @@ struct OperandTypeInfo {
              tileMemorySpace == rhs.tileMemorySpace &&
              blayout == rhs.blayout && slayout == rhs.slayout &&
              fractal == rhs.fractal && pad == rhs.pad;
+    if (kind == OperandKind::Vector)
+      return vectorShape == rhs.vectorShape;
     // View and Scalar: dtype alone is sufficient for template caching.
     return true;
   }
@@ -151,8 +160,11 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
           h = llvm::hash_combine(h, d);
         for (int64_t d : op.tileValidShape)
           h = llvm::hash_combine(h, d);
+      } else if (op.kind == OperandKind::Vector) {
+        for (int64_t d : op.vectorShape)
+          h = llvm::hash_combine(h, d);
       }
-      // View/Scalar: only kind + dtype contribute to hash.
+      // View/Vector/Scalar: only kind + dtype contribute to hash.
     }
     for (const auto &[attrName, attrValue] : key.contextAttrs)
       h = llvm::hash_combine(h, attrName, attrValue);
@@ -417,6 +429,17 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     return info;
   }
 
+  // Auxiliary vector operand — from builtin VectorType (e.g. vector<4xi16>).
+  if (auto vecTy = dyn_cast<VectorType>(ty)) {
+    OperandTypeInfo info;
+    info.kind = OperandKind::Vector;
+    info.dtype = getDtypeString(vecTy.getElementType());
+    if (info.dtype.empty())
+      return std::nullopt;
+    info.vectorShape.assign(vecTy.getShape().begin(), vecTy.getShape().end());
+    return info;
+  }
+
   // Scalar operand — from a scalar element type.
   OperandTypeInfo info;
   info.kind = OperandKind::Scalar;
@@ -543,6 +566,13 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
         json += "]";
       }
       json += ",\"memory_space\":\"" + op.viewMemorySpace + "\"}";
+      continue;
+    }
+
+    if (op.kind == OperandKind::Vector) {
+      json += "{\"kind\":\"vector\",\"dtype\":\"" + op.dtype + "\",\"shape\":";
+      appendJsonIntArray(json, op.vectorShape);
+      json += "}";
       continue;
     }
 
@@ -719,7 +749,8 @@ func::FuncOp ExpandState::invokeTilelangDSL(const SpecKey &key,
   for (const auto &op : key.operands) {
     uniqueName += op.kind == OperandKind::Tile   ? "_tile"
                  : op.kind == OperandKind::View ? "_view"
-                                                : "_scalar";
+                 : op.kind == OperandKind::Vector ? "_vector"
+                                                  : "_scalar";
     uniqueName += "_" + op.dtype;
     if (op.kind == OperandKind::Tile) {
       for (int64_t d : op.tileShape)
@@ -730,6 +761,9 @@ func::FuncOp ExpandState::invokeTilelangDSL(const SpecKey &key,
       uniqueName += "_sl" + std::to_string(op.slayout);
       uniqueName += "_fr" + std::to_string(op.fractal);
       uniqueName += "_pd" + llvm::utohexstr(op.pad, /*LowerCase=*/false);
+    } else if (op.kind == OperandKind::Vector) {
+      for (int64_t d : op.vectorShape)
+        uniqueName += "_" + std::to_string(d);
     }
   }
   for (const auto &[attrName, attrValue] : key.contextAttrs)

--- a/tilelang-dsl/docs/user_guide/03-kernel-declaration.md
+++ b/tilelang-dsl/docs/user_guide/03-kernel-declaration.md
@@ -85,6 +85,11 @@ The `dtypes` parameter supports flexible type matching:
    - `pto.i64`, `pto.si64`, `pto.ui64`
    - `pto.mask_b8`, `pto.mask_b16`, `pto.mask_b32`
 
+   Builtin vector operands still use their element dtype in `dtypes=[...]`.
+   For example, a parameter annotated as `ex_vec: pto.vector(pto.i16, (4,))`
+   contributes `pto.i16` to the signature tuple, while the vector shape
+   contract stays in the parameter annotation.
+
 2. **Type Wildcards**: Generic type patterns:
    - `pto.AnyFloat`: Matches any floating-point type (`f16`, `bf16`, `f32`)
    - `pto.AnyInt`: Matches any integer type (`i*`, `si*`, `ui*`)
@@ -204,6 +209,36 @@ def template_tload(src: pto.TensorView, dst: pto.Tile):
 ```
 
 This is the recommended constraint style for current TileLang DSL head.
+
+##### Builtin Vector Parameters
+
+When a kernel needs to match a builtin MLIR vector operand, annotate that
+parameter with `pto.vector(element_dtype, shape)`.
+
+```python
+@pto.vkernel(
+    target="a5",
+    op="pto.tmrgsort ins(src0, src1, tmp) -> outs(dst, ex_vec)",
+    dtypes=[(pto.f32, pto.f32, pto.f32, pto.f32, pto.i16)],
+)
+def template(
+    src0: pto.Tile,
+    src1: pto.Tile,
+    tmp: pto.Tile,
+    dst: pto.Tile,
+    ex_vec: pto.vector(pto.i16, (4,)),
+):
+    return None
+```
+
+Rules:
+
+- Use `pto.vector(...)` for builtin vector operands, not Python `list`.
+- `shape` is a Python tuple. A 1-D vector of length 4 is written `(4,)`.
+- `dtypes=[...]` still records only the element dtype for that operand (`pto.i16`
+  in the example above).
+- `pto.vector(...)` is distinct from `pto.vreg(...)`: the former models builtin
+  `vector<...>`, the latter models fixed-width VPTO vector registers.
 
 #### Kernel Selection Mechanism
 

--- a/tilelang-dsl/docs/user_guide/05-type-system.md
+++ b/tilelang-dsl/docs/user_guide/05-type-system.md
@@ -152,6 +152,50 @@ lanes1 = pto.elements_per_vreg(pto.f32)  # 64
 Current TileLang DSL v1 vector lowering supports the 8/16/32-bit integer
 families (`i*`, `si*`, `ui*`) plus `f16`, `bf16`, and `f32` element types.
 
+### Builtin Vector Type
+
+TileLang DSL v1 also exposes builtin MLIR vector types through
+`pto.vector(element_dtype, shape)`.
+
+```python
+executed_ty = pto.vector(pto.i16, (4,))  # vector<4xi16>
+```
+
+This type is different from `pto.vreg(...)`:
+
+- `pto.vreg(dtype)` models a VPTO vector register with fixed 256-byte width.
+- `pto.vector(dtype, shape)` models a builtin MLIR `vector<...>` type with an
+  explicit static shape.
+
+Use `pto.vector(...)` when a kernel parameter or intermediate value must match
+an existing builtin vector operand in PTO IR, for example an auxiliary
+`vector<4xi16>` operand carried by a tile op template.
+
+```python
+@pto.vkernel(
+    target="a5",
+    op="pto.tmrgsort ins(src0, src1, tmp) -> outs(dst, ex_vec)",
+    dtypes=[(pto.f32, pto.f32, pto.f32, pto.f32, pto.i16)],
+)
+def template(
+    src0: pto.Tile,
+    src1: pto.Tile,
+    tmp: pto.Tile,
+    dst: pto.Tile,
+    ex_vec: pto.vector(pto.i16, (4,)),
+):
+    return None
+```
+
+Notes:
+
+- `shape` must be a Python tuple of integers. For a 1-D vector, write `(4,)`,
+  not `(4)`. The trailing comma is Python's single-element tuple syntax.
+- The current public surface is intended for static builtin vector types.
+- In descriptor `dtypes=[...]`, builtin vector operands are matched by their
+  element dtype (`pto.i16` in the example above). The vector shape contract is
+  carried by the parameter annotation `pto.vector(...)`.
+
 ### Vector Type Reinterpretation (vbitcast)
 
 Vector registers support bitwise type reinterpretation via `pto.vbitcast`:

--- a/tilelang-dsl/python/tilelang_dsl/__init__.py
+++ b/tilelang-dsl/python/tilelang_dsl/__init__.py
@@ -62,6 +62,7 @@ from .types import (
     TileSpecialization,
     TypeVar,
     TypeVariable,
+    VectorType,
     VRegType,
     WildcardType,
     bf16,
@@ -90,6 +91,7 @@ from .types import (
     mask_b32,
     ptr,
     align,
+    vector,
     vreg,
 )
 
@@ -113,10 +115,12 @@ __all__ = [
     "PartitionTensorView",
     "Tile",
     "PointerType",
+    "VectorType",
     "VRegType",
     "MaskType",
     "AlignType",
     "ptr",
+    "vector",
     "vreg",
     "align",
     "MemorySpace",

--- a/tilelang-dsl/python/tilelang_dsl/expand_helper.py
+++ b/tilelang-dsl/python/tilelang_dsl/expand_helper.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 from contextlib import contextmanager
+import importlib
 import importlib.util
 import json
 import sys
@@ -114,6 +115,7 @@ def _template_import_context(template_dir: Path):
 
 def _import_py_file(path: Path):
     """Import a .py file as a module and return it."""
+    importlib.invalidate_caches()
     module_name = f"_tl_template_{path.stem}"
     spec = importlib.util.spec_from_file_location(module_name, str(path))
     if spec is None or spec.loader is None:
@@ -123,6 +125,7 @@ def _import_py_file(path: Path):
     try:
         spec.loader.exec_module(mod)
     except Exception as exc:
+        sys.modules.pop(module_name, None)
         print(f"expand_helper: warning: failed to import {path}: {exc}", file=sys.stderr)
         return None
     return mod
@@ -266,6 +269,22 @@ def _parse_operand_specs(spec_text: str) -> list[dict]:
                 )
             specs.append(view_spec)
             continue
+        if kind == "vector":
+            shape = raw.get("shape")
+            if not isinstance(shape, list) or not shape:
+                raise ValueError(f"operand-specs[{index}] vector shape must be a non-empty list")
+            specs.append(
+                {
+                    "kind": "vector",
+                    "dtype": dtype,
+                    "shape": _parse_optional_int_sequence(
+                        shape,
+                        field_name="vector shape",
+                        index=index,
+                    ),
+                }
+            )
+            continue
         raise ValueError(f"operand-specs[{index}] has unknown kind {kind!r}")
     return specs
 
@@ -275,6 +294,11 @@ def _operand_spec_matches_param_kind(param_kind: str, operand_kind: str) -> bool
         return param_kind == "tile"
     if operand_kind == "view":
         return param_kind in ("tensorview", "partition_tensor_view")
+    if operand_kind == "vector":
+        # Prefer an explicit builtin vector annotation, but keep scalar fallback
+        # for older templates that still model the auxiliary vector slot as a
+        # scalar-ish placeholder.
+        return param_kind in ("vector", "scalar")
     if operand_kind == "scalar":
         return param_kind == "scalar"
     return False
@@ -315,6 +339,8 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, obje
         shape = tuple(operand_spec["shape"])
         attrs[f"{prefix}_shape"] = shape
         attrs[f"{prefix}_rank"] = len(shape)
+        if operand_spec["kind"] == "vector":
+            continue
         memory_space = operand_spec.get("memory_space")
         if isinstance(memory_space, MemorySpace):
             attrs[f"{prefix}_memory_space"] = memory_space.value
@@ -387,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--memory-space", default="ub", help="Memory space (ub or gm)")
     parser.add_argument(
         "--operand-specs",
-        help="JSON array describing each operand (tile/scalar schema)",
+        help="JSON array describing each operand (tile/scalar/vector schema)",
     )
     parser.add_argument(
         "--context-attrs",
@@ -486,7 +512,15 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 return 1
             continue
-        if param.kind == "scalar" and operand_spec["kind"] != "scalar":
+        if param.kind == "vector":
+            if operand_spec["kind"] != "vector":
+                print(
+                    "expand_helper: error: descriptor builtin vector parameter does not match operand-specs",
+                    file=sys.stderr,
+                )
+                return 1
+            continue
+        if param.kind == "scalar" and operand_spec["kind"] not in ("scalar", "vector"):
             print(
                 "expand_helper: error: descriptor scalar parameter does not match operand-specs",
                 file=sys.stderr,

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -35,6 +35,7 @@ from .types import (
     TileConfig,
     TileSpecialization,
     TypeVariable,
+    VectorType,
     WildcardType,
     is_integer_dtype,
 )
@@ -740,7 +741,7 @@ class BoundKernelParameter:
 
     @property
     def element_dtype(self) -> ScalarType | None:
-        if self.kind in ("tensorview", "partition_tensor_view", "tile", "ptr"):
+        if self.kind in ("tensorview", "partition_tensor_view", "tile", "ptr", "vector"):
             return self.dtype
         return None
 
@@ -2047,6 +2048,12 @@ def _validate_parameter_spec(param: inspect.Parameter) -> KernelParameterSpec:
             kind="tile",
             annotation=annotation,
         )
+    if isinstance(annotation, VectorType):
+        return KernelParameterSpec(
+            name=param.name,
+            kind="vector",
+            annotation=annotation,
+        )
     if isinstance(annotation, PointerType):
         return KernelParameterSpec(
             name=param.name,
@@ -2090,6 +2097,9 @@ def _default_dtype_signature(
         if param_spec.kind in {"tensorview", "partition_tensor_view", "tile"}:
             defaults.append(AnyType)
             continue
+        if param_spec.kind == "vector":
+            defaults.append(param_spec.annotation.element_dtype)
+            continue
         if param_spec.kind == "ptr":
             defaults.append(param_spec.annotation.element_dtype)
             continue
@@ -2127,6 +2137,18 @@ def _bind_parameter(
             dtype=bound_dtype,
         )
     if param_spec.kind == "tile":
+        return BoundKernelParameter(
+            name=param_spec.name,
+            kind=param_spec.kind,
+            annotation=param_spec.annotation,
+            dtype=bound_dtype,
+        )
+    if param_spec.kind == "vector":
+        if param_spec.annotation.element_dtype != bound_dtype:
+            raise TypeError(
+                f"vector parameter '{param_spec.name}' annotation {param_spec.annotation!r} "
+                f"does not match selected dtype {bound_dtype!r}"
+            )
         return BoundKernelParameter(
             name=param_spec.name,
             kind=param_spec.kind,

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -67,6 +67,7 @@ from .semantic import (
     SemanticTupleType,
     SemanticVScatterStmt,
     SemanticVRegType,
+    SemanticVectorType,
     SemanticVectorPairStoreStmt,
     SemanticVectorStoreStmt,
     SemanticWaitFlagDevStmt,
@@ -4120,6 +4121,9 @@ class _AuthoringRenderer:
             return f"!pto.mask<{ty.granularity}>"
         if isinstance(ty, SemanticVRegType):
             return f"!pto.vreg<{ty.lanes}x{ty.element_dtype.name}>"
+        if isinstance(ty, SemanticVectorType):
+            dims = "x".join(str(dim) for dim in ty.shape)
+            return f"vector<{dims}x{ty.element_dtype.name}>"
         raise NotImplementedError(f"unsupported semantic type {ty!r}")
 
     def _is_memref_like_type(self, ty: SemanticType) -> bool:

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -99,6 +99,7 @@ from .types import (
     ui16,
     ui32,
     ui64,
+    VectorType,
 )
 
 
@@ -400,6 +401,12 @@ class SemanticMaskType(SemanticType):
 class SemanticVRegType(SemanticType):
     element_dtype: ScalarType
     lanes: int
+
+
+@dataclass(frozen=True)
+class SemanticVectorType(SemanticType):
+    element_dtype: ScalarType
+    shape: tuple[int, ...]
 
 
 _I32_TYPE = SemanticScalarType(dtype=i32)
@@ -900,6 +907,12 @@ class _SemanticAnalyzer:
                 valid_shape=valid_shape,
                 memory_space=memory_space,
                 config=None if spec is None else (spec.config or TileConfig()),
+            )
+        if param.kind == "vector":
+            vector_type = param.annotation
+            return SemanticVectorType(
+                element_dtype=param.dtype,
+                shape=vector_type.shape,
             )
         if param.kind == "ptr":
             memory_space = param.annotation.memory_space.value
@@ -2399,6 +2412,17 @@ class _SemanticAnalyzer:
                         f"annotated vector type `{vreg_type!r}` does not match inferred !pto.vreg<{inferred_type.lanes}x{inferred_type.element_dtype.name}>"
                     )
                 return inferred_type
+            if annotation_expr.type.kind == "vector_type" and isinstance(inferred_type, SemanticVectorType):
+                vector_type = self._require_vector_type_expr(annotation_expr, "annotated builtin vector type")
+                if (
+                    inferred_type.element_dtype != vector_type.element_dtype
+                    or inferred_type.shape != vector_type.shape
+                ):
+                    shape_text = "x".join(str(dim) for dim in inferred_type.shape)
+                    raise TypeError(
+                        f"annotated builtin vector type `{vector_type!r}` does not match inferred !pto.vector<{shape_text}x{inferred_type.element_dtype.name}>"
+                    )
+                return inferred_type
             if annotation_expr.type.kind == "mask_type" and isinstance(inferred_type, SemanticMaskType):
                 mask_type = self._require_mask_type_expr(annotation_expr, "annotated mask type")
                 if inferred_type.granularity != mask_type.granularity:
@@ -3685,6 +3709,8 @@ class _SemanticAnalyzer:
             return self._analyze_ptr_type(args)
         if name == "vreg":
             return self._analyze_vreg_type(args)
+        if name == "vector":
+            return self._analyze_vector_type(args)
         if name == "castptr":
             return self._analyze_castptr(args)
         if name == "addptr":
@@ -4111,6 +4137,16 @@ class _SemanticAnalyzer:
         return SemanticLiteralExpr(
             value=VRegType(element_dtype=dtype, lanes=vreg_type.lanes),
             type=SemanticMetaType(kind="vreg_type"),
+        )
+
+    def _analyze_vector_type(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
+        if len(args) != 2:
+            raise TypeError("pto.vector expects exactly 2 positional arguments in TileLang DSL v1")
+        dtype = self._require_dtype_symbol(args[0], "pto.vector element type")
+        shape = self._require_vector_shape_expr(args[1], "pto.vector shape")
+        return SemanticLiteralExpr(
+            value=VectorType(element_dtype=dtype, shape=shape),
+            type=SemanticMetaType(kind="vector_type"),
         )
 
     def _analyze_castptr(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
@@ -5142,6 +5178,45 @@ class _SemanticAnalyzer:
         ):
             return expr.binding.value
         raise TypeError(f"{context} must be a vector type constructed with pto.vreg(...)")
+
+    def _require_vector_type_expr(self, expr: SemanticExpr, context: str) -> VectorType:
+        if (
+            isinstance(expr, SemanticLiteralExpr)
+            and isinstance(expr.type, SemanticMetaType)
+            and expr.type.kind == "vector_type"
+            and isinstance(expr.value, VectorType)
+        ):
+            return expr.value
+        if (
+            isinstance(expr, SemanticBindingRef)
+            and isinstance(expr.type, SemanticMetaType)
+            and expr.type.kind == "vector_type"
+            and isinstance(expr.binding.value, VectorType)
+        ):
+            return expr.binding.value
+        raise TypeError(f"{context} must be a builtin vector type constructed with pto.vector(...)")
+
+    def _require_vector_shape_expr(self, expr: SemanticExpr, context: str) -> tuple[int, ...]:
+        if not isinstance(expr, SemanticTupleExpr):
+            dim = self._static_index_value(expr, default=None)
+            if dim is None:
+                raise TypeError(f"{context} must be a static integer or tuple of static integers")
+            if dim <= 0:
+                raise TypeError(f"{context} shape entries must be positive")
+            return (dim,)
+        if isinstance(expr, SemanticTupleExpr):
+            shape: list[int] = []
+            for element in expr.elements:
+                dim = self._static_index_value(element, default=None)
+                if dim is None:
+                    raise TypeError(f"{context} tuple entries must be static integers")
+                if dim <= 0:
+                    raise TypeError(f"{context} shape entries must be positive")
+                shape.append(dim)
+            if not shape:
+                raise TypeError(f"{context} must be a non-empty shape")
+            return tuple(shape)
+        raise TypeError(f"{context} must be a static integer or tuple of static integers")
 
     def _require_mask_type_expr(self, expr: SemanticExpr, context: str) -> MaskType:
         if (
@@ -6446,6 +6521,7 @@ __all__ = [
     "SemanticTupleExpr",
     "SemanticTupleType",
     "SemanticType",
+    "SemanticVectorType",
     "SemanticVRegType",
     "SemanticVScatterStmt",
     "SemanticVectorPairStoreStmt",

--- a/tilelang-dsl/python/tilelang_dsl/types.py
+++ b/tilelang-dsl/python/tilelang_dsl/types.py
@@ -97,6 +97,15 @@ class VRegType:
 
 
 @dataclass(frozen=True)
+class VectorType:
+    element_dtype: ScalarType
+    shape: tuple[int, ...]
+
+    def __repr__(self) -> str:
+        return f"vector({self.element_dtype!r}, {self.shape!r})"
+
+
+@dataclass(frozen=True)
 class MaskType:
     granularity: str
 
@@ -680,6 +689,25 @@ def vreg(dtype: ScalarType) -> VRegType:
     return VRegType(element_dtype=dtype, lanes=get_lanes(dtype))
 
 
+def vector(dtype: ScalarType, shape: tuple[int, ...] | list[int] | int) -> VectorType:
+    if not isinstance(dtype, ScalarType):
+        raise TypeError("vector() expects a TileLang scalar dtype")
+    if isinstance(shape, int) and not isinstance(shape, bool):
+        normalized_shape = (shape,)
+    elif isinstance(shape, (list, tuple)):
+        normalized_shape = tuple(shape)
+    else:
+        raise TypeError("vector() expects a shape integer or a non-empty sequence of integers")
+    if not normalized_shape:
+        raise TypeError("vector() expects a non-empty shape")
+    for dim in normalized_shape:
+        if not isinstance(dim, int) or isinstance(dim, bool):
+            raise TypeError("vector() shape entries must be integers")
+        if dim <= 0:
+            raise TypeError("vector() shape entries must be positive")
+    return VectorType(element_dtype=dtype, shape=normalized_shape)
+
+
 def integer_bitwidth(dtype: ScalarType) -> int | None:
     if not isinstance(dtype, ScalarType):
         return None
@@ -737,9 +765,11 @@ __all__ = [
     "Tile",
     "PointerType",
     "VRegType",
+    "VectorType",
     "MaskType",
     "ptr",
     "vreg",
+    "vector",
     "MemorySpace",
     "Pipe",
     "Event",

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -161,10 +161,12 @@ class TileLangDSLPackageTests(unittest.TestCase):
         self.assertTrue(hasattr(pto, "Tile"))
         self.assertTrue(hasattr(pto, "TileSpecialization"))
         self.assertTrue(hasattr(pto, "PointerType"))
+        self.assertTrue(hasattr(pto, "VectorType"))
         self.assertTrue(hasattr(pto, "VRegType"))
         self.assertTrue(hasattr(pto, "MaskType"))
         self.assertTrue(hasattr(pto, "AlignType"))
         self.assertTrue(hasattr(pto, "ptr"))
+        self.assertTrue(hasattr(pto, "vector"))
         self.assertTrue(hasattr(pto, "vreg"))
         self.assertTrue(hasattr(pto, "align"))
         self.assertTrue(hasattr(pto, "mask_b8"))
@@ -769,6 +771,92 @@ def template_dn(inp: pto.TensorView, out: pto.Tile):
             )
 
         self.assertEqual(selected.name, "template_nd")
+
+    def test_select_descriptor_accepts_aux_vector_operand_for_vector_annotation(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="pto.expand_helper_vector_operand_unique",
+    dtypes=[(pto.f32, pto.i16, pto.f32)],
+)
+def template(src: pto.Tile, ex_vec: pto.vector(pto.i16, (4,)), dst: pto.Tile):
+    return None
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "expand_helper_vector_operand_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+
+            mod = expand_helper._import_py_file(module_path)
+            self.assertIsNotNone(mod)
+            descriptors = expand_helper._find_descriptors(mod)
+            self.assertTrue(descriptors)
+
+            operand_specs = expand_helper._parse_operand_specs(
+                """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 256],
+    "valid_shape": [1, 256],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "vector",
+    "dtype": "i16",
+    "shape": [4]
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 256],
+    "valid_shape": [1, 256],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  }
+]
+"""
+            )
+
+            selected = expand_helper._select_descriptor(
+                descriptors,
+                target="a5",
+                op_name="pto.expand_helper_vector_operand_unique",
+                operand_specs=operand_specs,
+            )
+            tile_specs = {}
+            for param, operand_spec in zip(selected.parameters, operand_specs):
+                if param.kind != "tile":
+                    continue
+                tile_specs[param.name] = pto.TileSpecialization(
+                    shape=operand_spec["shape"],
+                    memory_space=operand_spec["memory_space"],
+                    config=operand_spec["config"],
+                    valid_shape=operand_spec["valid_shape"],
+                )
+            mlir_text = selected.specialize(**tile_specs).mlir_text()
+
+        self.assertEqual(selected.name, "template")
+        self.assertEqual(selected.parameters[1].kind, "vector")
+        self.assertEqual(selected.parameters[1].annotation, pto.vector(pto.i16, (4,)))
+        self.assertIn("vector<4xi16>", mlir_text)
+        context_attrs = expand_helper._build_positional_context_attrs(operand_specs)
+        self.assertEqual(context_attrs["arg1_kind"], "vector")
+        self.assertEqual(context_attrs["arg1_shape"], (4,))
+        self.assertEqual(context_attrs["arg1_rank"], 1)
 
 
 class TileLangDSLSupportMatrixTests(unittest.TestCase):
@@ -1870,6 +1958,23 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertEqual(vec_type.element_dtype, pto.f32)
         self.assertEqual(vec_type.lanes, 64)
         self.assertEqual(repr(vec_type), "vreg(f32)")
+
+    def test_vector_type_constructor_exposes_shape(self) -> None:
+        vec_type = pto.vector(pto.i16, (4,))
+        self.assertIsInstance(vec_type, pto.VectorType)
+        self.assertEqual(vec_type.element_dtype, pto.i16)
+        self.assertEqual(vec_type.shape, (4,))
+        self.assertEqual(repr(vec_type), "vector(i16, (4,))")
+
+    def test_vector_parameter_annotation_binds_as_vector_kind(self) -> None:
+        @pto.vkernel(op="vector_surface_unique", dtypes=[(pto.f32, pto.i16, pto.f32)], advanced=True)
+        def kernel(src: pto.Tile, ex_vec: pto.vector(pto.i16, (4,)), dst: pto.Tile):
+            return None
+
+        self.assertEqual(kernel.parameters[1].kind, "vector")
+        self.assertEqual(kernel.parameters[1].dtype, pto.i16)
+        self.assertEqual(kernel.parameters[1].annotation, pto.vector(pto.i16, (4,)))
+        self.assertEqual(kernel.parameters[1].element_dtype, pto.i16)
 
     def test_mask_type_constants_expose_granularity(self) -> None:
         self.assertIsInstance(pto.mask_b8, pto.MaskType)


### PR DESCRIPTION
## Summary
- add TileLang DSL builtin `pto.vector(dtype, shape)` type support for kernel parameter binding and semantic/lowering paths
- extend `ExpandTileOp` operand schema handling so builtin MLIR vector operands participate in descriptor matching
- document builtin vector parameters in the DSL user guide and add regression coverage

## Validation
- `PYTHONPATH=tilelang-dsl/python python3 -m pytest tilelang-dsl/tests/test_tilelang_dsl_v1.py -q`

## Notes
- dropped the temporary local-only `tmrgsort` template and `.pto` repro files before publishing this PR

Closes #334
