### PR TITLE
cleanup(ptoas): drop duplicate pass registration

### DIFF
--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1393,13 +1393,7 @@ int main(int argc, char **argv) {
       cliArchSpecified = true;
   }
 
-  // Register all passes so that --mlir-print-ir-after/before can resolve
-  // pass names like 'cse' at option-parse time.
-  mlir::registerAllPasses();
-  registerPTOPasses();
-
   // Parse command line options
-  mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv, "PTO Assembler (ptoas)\n");
 
   PTOBackend effectiveBackend = PTOBackend::EmitC;


### PR DESCRIPTION
## Summary
- remove duplicate `registerAllPasses()` / `registerPTOPasses()` calls that already run earlier in `main`
- remove the redundant second `registerPassManagerCLOptions()` before CLI parsing
- keep `ptoas` CLI behavior unchanged while simplifying startup registration flow

## Validation
- `cmake --build /home/zhangzhendong/ptoas-workspace/PTOAS/build --target ptoas -j4`
- `build/tools/ptoas/ptoas --help`
