### PR TITLE
Add get_vms4_sr four-result support

### DIFF
--- a/docs/isa/micro-isa/13-dsa-sfu-ops.md
+++ b/docs/isa/micro-isa/13-dsa-sfu-ops.md
@@ -209,6 +209,16 @@ for (int i = 0; i < N; i++)
 
 ---
 
+### `pto.get_vms4_sr`
+
+- **syntax:** `%list0, %list1, %list2, %list3 = pto.get_vms4_sr : i16, i16, i16, i16`
+- **semantics:** Read `VMS4_SR` and return the finished counts for source
+  lists 0, 1, 2, and 3. After exhausted `pto.vmrgsort4`, the four results map
+  to `VMS4_SR[15:0]`, `VMS4_SR[31:16]`, `VMS4_SR[47:32]`, and
+  `VMS4_SR[63:48]`.
+
+---
+
 ## Current Implementation Surface Summary
 
 - `pto.vmull %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>, !pto.vreg<NxT>`
@@ -216,6 +226,7 @@ for (int i = 0; i < N; i++)
 - `pto.vci %index {order = "ASC|DESC"} : T -> !pto.vreg<NxT>`
 - `pto.vbitsort %dest, %src, %indices, %repeat_times : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, index`
 - `pto.vmrgsort4 %dest, %src0, %src1, %src2, %src3, %count, %config : !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, !pto.ptr<...>, i64, i64`
+- `pto.get_vms4_sr : i16, i16, i16, i16`
 
 ---
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -681,6 +681,31 @@ Typical usage:
 %subblock_num = pto.get_subblock_num
 ```
 
+### VMS4 Status Query
+
+#### `pto.get_vms4_sr`
+
+- **syntax:** `%list0, %list1, %list2, %list3 = pto.get_vms4_sr : i16, i16, i16, i16`
+- **results:** four `i16` values
+- **semantics:** Read `VMS4_SR` and return the finished element counts for
+  source lists 0, 1, 2, and 3. After an exhausted `pto.vmrgsort4`, these are
+  the per-source-list executed counts.
+
+| Bits | Meaning |
+|------|---------|
+| `[15:0]` | finished count for source list 0 |
+| `[31:16]` | finished count for source list 1 |
+| `[47:32]` | finished count for source list 2 |
+| `[63:48]` | finished count for source list 3 |
+
+```c
+status = VMS4_SR;
+list0 = (uint16_t)(status & 0xffff);
+list1 = (uint16_t)((status >> 16) & 0xffff);
+list2 = (uint16_t)((status >> 32) & 0xffff);
+list3 = (uint16_t)((status >> 48) & 0xffff);
+```
+
 ### Core Types
 
 ### Element Types
@@ -1134,7 +1159,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 10 | [Reduction Ops](isa/micro-isa/10-reduction-ops.md) | Vector reductions | 7 | `pto.vcadd`, `pto.vcmax`, `pto.vcmin`, `pto.vcgadd`, `pto.vcgmax`, `pto.vcgmin`, `pto.vcpadd` |
 | 11 | [Compare & Select](isa/micro-isa/11-compare-select.md) | Comparison and conditional selection | 4 (+1 not A5) | `pto.vcmp`, `pto.vcmps`, `pto.vsel`, `pto.vselr` (`pto.vselrv2` removed: not A5) |
 | 12 | [Data Rearrangement](isa/micro-isa/12-data-rearrangement.md) | In-register data movement and permutation | 2 (+2 not A5) | `pto.vintlv`, `pto.vdintlv` (`pto.vintlvv2`, `pto.vdintlvv2` removed: not A5) |
-| 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 9 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4` |
+| 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 10 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4`, `pto.get_vms4_sr` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 | 16 | [Cube Matrix Multiply (MAT)](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`cbuf`) staging, L1 (`cbuf`)↔UB side moves, L1→L0A/L0B loads, L0C (`acc`) matmul, and wrapper bridge load/store ops | 16+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.load_cbuf_to_ca_mx`, `pto.load_cbuf_to_cb_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf`, `pto.cube_load`, `pto.cube_store`, `pto.cube_load_frac`, `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx`, `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -219,6 +219,14 @@ def PTO_SetChannelParaOp : PTO_BinaryI64ConfigOp<"set_channel_para">;
 def PTO_SetMte2NzParaOp : PTO_UnaryI64ConfigOp<"set_mte2_nz_para">;
 def PTO_SetPadValOutToL1Op : PTO_UnaryI64ConfigOp<"set_pad_val_outtol1">;
 def PTO_GetCtrlOp : PTO_NullaryI64PureOp<"get_ctrl">;
+def PTO_GetVms4SrOp : PTO_Op<"get_vms4_sr", [Pure]> {
+  let arguments = (ins);
+  let results = (outs I16:$list0, I16:$list1, I16:$list2, I16:$list3);
+
+  let assemblyFormat = [{
+    attr-dict `:` type($list0) `,` type($list1) `,` type($list2) `,` type($list3)
+  }];
+}
 def PTO_SetCtrlOp : PTO_UnaryI64ConfigOp<"set_ctrl">;
 def PTO_Sbitset0Op : PTO_BinaryI64PureOp<"sbitset0">;
 def PTO_Sbitset1Op : PTO_BinaryI64PureOp<"sbitset1">;

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1878,6 +1878,11 @@ StringRef buildRuntimeQueryCallee<pto::GetCtrlOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.GET.CTRL").getValue();
 }
 
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetVms4SrOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.GET.VMS4.SR").getValue();
+}
+
 static StringRef buildSprclrCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.sprclr").getValue();
 }
@@ -7008,6 +7013,54 @@ private:
   LoweringState &state;
 };
 
+class LowerGetVms4SrOpPattern final
+    : public OpConversionPattern<pto::GetVms4SrOp> {
+public:
+  explicit LowerGetVms4SrOpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context,
+                                   LoweringState &state)
+      : OpConversionPattern<pto::GetVms4SrOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::GetVms4SrOp op, pto::GetVms4SrOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes)) ||
+        resultTypes.size() != 4)
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert get_vms4_sr result types");
+
+    StringRef calleeName = buildRuntimeQueryCallee<pto::GetVms4SrOp>(
+        op.getContext());
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{}, TypeRange{rewriter.getI64Type()});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), calleeName, TypeRange{rewriter.getI64Type()},
+        ValueRange{});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+
+    SmallVector<Value> counts;
+    counts.reserve(4);
+    Value raw = call.getResult(0);
+    for (unsigned i = 0; i < 4; ++i) {
+      Value shifted = raw;
+      if (i != 0)
+        shifted = rewriter.create<arith::ShRUIOp>(
+            op.getLoc(), raw, getI64Constant(rewriter, op.getLoc(), i * 16));
+      counts.push_back(rewriter.create<arith::TruncIOp>(
+          op.getLoc(), resultTypes[i], shifted));
+    }
+    rewriter.replaceOp(op, counts);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename BinaryOp>
 class LowerBinaryI64PureOpPattern final : public OpConversionPattern<BinaryOp> {
 public:
@@ -7334,6 +7387,7 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPgeOpPattern<pto::PgeB16Op>,
                LowerPgeOpPattern<pto::PgeB32Op>,
                LowerRuntimeQueryOpPattern<pto::GetCtrlOp>,
+               LowerGetVms4SrOpPattern,
                LowerBinaryI64PureOpPattern<pto::Sbitset0Op>,
                LowerBinaryI64PureOpPattern<pto::Sbitset1Op>,
                LowerSetLoopConfigOpPattern<pto::SetLoop2StrideOutToUbOp>,
@@ -7420,7 +7474,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::GetBufOp, pto::RlsBufOp>();
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,
-                      pto::GetCtrlOp>();
+                      pto::GetCtrlOp, pto::GetVms4SrOp>();
   target.addIllegalOp<pto::SetLoop2StrideOutToUbOp, pto::SetLoop1StrideOutToUbOp,
                       pto::SetLoopSizeOutToUbOp, pto::SetLoop2StrideUbToOutOp,
                       pto::SetLoop1StrideUbToOutOp, pto::SetLoopSizeUbToOutOp,

--- a/test/basic/get_vms4_sr_vpto.pto
+++ b/test/basic/get_vms4_sr_vpto.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    func.func @get_vms4_sr_kernel(%arg0: !pto.ptr<i16, gm>) attributes {pto.aicore} {
+      %c0 = arith.constant 0 : index
+      %list0, %list1, %list2, %list3 = pto.get_vms4_sr : i16, i16, i16, i16
+      pto.store_scalar %list1, %arg0[%c0] : !pto.ptr<i16, gm>, i16
+      return
+    }
+  }
+}
+
+// CHECK: %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} = pto.get_vms4_sr : i16, i16, i16, i16
+// CHECK: pto.store_scalar

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/compare.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/compare.py
@@ -33,15 +33,24 @@ def read_pairs(path: str):
     return np.array(values, dtype=np.float32), np.array(indices, dtype=np.uint32)
 
 
+def read_counts(path: str):
+    with open(path, "rb") as f:
+        data = f.read(8)
+    return np.array(struct.unpack("4h", data), dtype=np.int16)
+
+
 def main() -> None:
     strict = os.getenv("COMPARE_STRICT", "1") != "0"
     golden_values, golden_indices = read_pairs("golden_v2.bin")
     output_values, output_indices = read_pairs("v2.bin")
+    golden_counts = read_counts("golden_v3.bin")
+    output_counts = read_counts("v3.bin")
     ok = (
         golden_values.shape == output_values.shape
         and golden_indices.shape == output_indices.shape
         and np.allclose(golden_values, output_values)
         and np.array_equal(golden_indices, output_indices)
+        and np.array_equal(golden_counts, output_counts)
     )
     if not ok:
         if strict:

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/golden.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/golden.py
@@ -30,11 +30,13 @@ def main() -> None:
     out.mkdir(parents=True, exist_ok=True)
 
     src = [(9.0, 90), (7.0, 70), (8.0, 80), (6.0, 60)]
-    golden = [(9.0, 90), (8.0, 80), (7.0, 70), (6.0, 60)]
+    golden = [(9.0, 90), (0.0, 0), (0.0, 0), (0.0, 0)]
 
     write_pairs(out / "v1.bin", src)
     write_pairs(out / "v2.bin", [(0.0, 0)] * 4)
     write_pairs(out / "golden_v2.bin", golden)
+    (out / "v3.bin").write_bytes(struct.pack("4h", 0, 0, 0, 0))
+    (out / "golden_v3.bin").write_bytes(struct.pack("4h", 1, 0, 0, 0))
 
 
 if __name__ == "__main__":

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/kernel.pto
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/kernel.pto
@@ -1,14 +1,18 @@
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @vmrgsort4_kernel_f32(%arg0: !pto.ptr<f32, gm>,
-                                  %arg1: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+                                  %arg1: !pto.ptr<f32, gm>,
+                                  %arg2: !pto.ptr<i16, gm>) attributes {pto.aicore} {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
     %c4 = arith.constant 4 : index
     %c6 = arith.constant 6 : index
     %c32_i64 = arith.constant 32 : i64
     %c_count = arith.constant 281479271743489 : i64
-    %c_config = arith.constant 3841 : i64
+    %c_config = arith.constant 7937 : i64
 
     %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
     %ub_out = pto.castptr %c32_i64 : i64 -> !pto.ptr<f32, ub>
@@ -26,6 +30,14 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.vmrgsort4 %ub_out, %ub_in, %src1, %src2, %src3, %c_count, %c_config
       : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>,
         !pto.ptr<f32, ub>, i64, i64
+
+    pto.set_flag["PIPE_V", "PIPE_S", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_S", "EVENT_ID0"]
+    %list0, %list1, %list2, %list3 = pto.get_vms4_sr : i16, i16, i16, i16
+    pto.store_scalar %list0, %arg2[%c0] : !pto.ptr<i16, gm>, i16
+    pto.store_scalar %list1, %arg2[%c1] : !pto.ptr<i16, gm>, i16
+    pto.store_scalar %list2, %arg2[%c2] : !pto.ptr<i16, gm>, i16
+    pto.store_scalar %list3, %arg2[%c3] : !pto.ptr<i16, gm>, i16
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/launch.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/launch.cpp
@@ -17,9 +17,12 @@
 #endif
 
 extern "C" __global__ [aicore] void vmrgsort4_kernel_f32(__gm__ float *src,
-                                                         __gm__ float *dst);
+                                                         __gm__ float *dst,
+                                                         __gm__ int16_t *counts);
 
-void LaunchVmrgsort4_kernel_f32(float *src, float *dst, void *stream) {
+void LaunchVmrgsort4_kernel_f32(float *src, float *dst, int16_t *counts,
+                                void *stream) {
   vmrgsort4_kernel_f32<<<1, nullptr, stream>>>((__gm__ float *)src,
-                                               (__gm__ float *)dst);
+                                               (__gm__ float *)dst,
+                                               (__gm__ int16_t *)counts);
 }

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/main.cpp
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/main.cpp
@@ -24,15 +24,19 @@ using namespace PtoTestCommon;
     }                                                                            \
   } while (0)
 
-void LaunchVmrgsort4_kernel_f32(float *src, float *dst, void *stream);
+void LaunchVmrgsort4_kernel_f32(float *src, float *dst, int16_t *counts,
+                                void *stream);
 
 int main() {
   size_t inputBytes = 32;
   size_t outputBytes = 32;
+  size_t countsBytes = 8;
   float *srcHost = nullptr;
   float *srcDevice = nullptr;
   float *dstHost = nullptr;
   float *dstDevice = nullptr;
+  int16_t *countsHost = nullptr;
+  int16_t *countsDevice = nullptr;
   int rc = 0;
   bool aclInited = false;
   bool deviceSet = false;
@@ -48,8 +52,10 @@ int main() {
   ACL_CHECK(aclrtCreateStream(&stream));
   ACL_CHECK(aclrtMallocHost((void **)(&srcHost), inputBytes));
   ACL_CHECK(aclrtMallocHost((void **)(&dstHost), outputBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&countsHost), countsBytes));
   ACL_CHECK(aclrtMalloc((void **)&srcDevice, inputBytes, ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void **)&dstDevice, outputBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&countsDevice, countsBytes, ACL_MEM_MALLOC_HUGE_FIRST));
 
   if (!ReadFile("./v1.bin", inputBytes, srcHost, inputBytes)) {
     std::fprintf(stderr, "[ERROR] failed to read v1.bin\n");
@@ -61,19 +67,29 @@ int main() {
     rc = 1;
     goto cleanup;
   }
+  if (!ReadFile("./v3.bin", countsBytes, countsHost, countsBytes)) {
+    std::fprintf(stderr, "[ERROR] failed to read v3.bin\n");
+    rc = 1;
+    goto cleanup;
+  }
 
   ACL_CHECK(aclrtMemcpy(srcDevice, inputBytes, srcHost, inputBytes, ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(dstDevice, outputBytes, dstHost, outputBytes, ACL_MEMCPY_HOST_TO_DEVICE));
-  LaunchVmrgsort4_kernel_f32(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtMemcpy(countsDevice, countsBytes, countsHost, countsBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmrgsort4_kernel_f32(srcDevice, dstDevice, countsDevice, stream);
   ACL_CHECK(aclrtSynchronizeStream(stream));
   ACL_CHECK(aclrtMemcpy(dstHost, outputBytes, dstDevice, outputBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(countsHost, countsBytes, countsDevice, countsBytes, ACL_MEMCPY_DEVICE_TO_HOST));
   WriteFile("./v2.bin", dstHost, outputBytes);
+  WriteFile("./v3.bin", countsHost, countsBytes);
 
 cleanup:
   aclrtFree(srcDevice);
   aclrtFree(dstDevice);
+  aclrtFree(countsDevice);
   aclrtFreeHost(srcHost);
   aclrtFreeHost(dstHost);
+  aclrtFreeHost(countsHost);
   if (stream != nullptr)
     aclrtDestroyStream(stream);
   if (deviceSet)

--- a/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
+++ b/tilelang-dsl/docs/user_guide/11-vector-arithmetic-operations.md
@@ -1558,6 +1558,24 @@ None. The op writes UB memory directly.
 - `dest` and `src0` through `src3` must be UB-backed pointers
 - Inputs must already be sorted according to the order encoded by `config`
 
+#### `pto.get_vms4_sr() -> (pto.i16, pto.i16, pto.i16, pto.i16)`  [Advanced Tier]
+
+**Description**: Read `VMS4_SR` after exhausted `pto.vmrgsort4` and return the
+finished element counts for source lists 0 through 3.
+
+**Returns**:
+| Return Value | Type | Description |
+|--------------|------|-------------|
+| `list0` | `pto.i16` | Finished count from `VMS4_SR[15:0]` |
+| `list1` | `pto.i16` | Finished count from `VMS4_SR[31:16]` |
+| `list2` | `pto.i16` | Finished count from `VMS4_SR[47:32]` |
+| `list3` | `pto.i16` | Finished count from `VMS4_SR[63:48]` |
+
+**Example**:
+```python
+list0, list1, list2, list3 = pto.get_vms4_sr()
+```
+
 **Order Mode Enum**: The `OrderMode` enum provides type-safe order selection for `pto.vci` operations. `ASC` and `DESC` are supported.
 
 #### `pto.vci(index: ScalarType, order: OrderMode = OrderMode.ASC) -> VRegType`

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -727,12 +727,14 @@ class _AuthoringRenderer:
             raise NotImplementedError(
                 f"multi-result assignment for `pto.{stmt.value.name}` is not supported in TileLang DSL v1"
             )
-        if len(stmt.targets) != 2:
-            raise NotImplementedError("multi-result lowering expects exactly two assignment targets")
-        if not isinstance(stmt.value.type, SemanticTupleType) or len(stmt.value.type.elements) != 2:
-            raise NotImplementedError("multi-result lowering expects a two-result tuple type")
+        if not isinstance(stmt.value.type, SemanticTupleType):
+            raise NotImplementedError("multi-result lowering expects a tuple result type")
+        if len(stmt.targets) != len(stmt.value.type.elements):
+            raise NotImplementedError("multi-result lowering expects assignment arity to match result arity")
 
         if stmt.value.name in {"make_mask", "plt_b8", "plt_b16", "plt_b32"}:
+            if len(stmt.targets) != 2 or len(stmt.value.type.elements) != 2:
+                raise NotImplementedError("mask multi-result lowering expects exactly two results")
             lines: list[str] = []
             if stmt.value.name == "make_mask":
                 dtype_expr, remaining_expr = stmt.value.args
@@ -932,6 +934,18 @@ class _AuthoringRenderer:
             )
             env[align_target.name] = _RenderedValue(name=align_target.ssa_name, type=align_type)
             env[base_target.name] = _RenderedValue(name=base_target.ssa_name, type=base_type)
+            return lines
+
+        if stmt.value.name == "get_vms4_sr":
+            lines = []
+            result_names = ", ".join(target.ssa_name for target in stmt.targets)
+            result_types = ", ".join(self._render_type(result_type) for result_type in stmt.value.type.elements)
+            lines.append(
+                self._indent(indent)
+                + f"{result_names} = pto.get_vms4_sr : {result_types}"
+            )
+            for target, result_type in zip(stmt.targets, stmt.value.type.elements):
+                env[target.name] = _RenderedValue(name=target.ssa_name, type=result_type)
             return lines
 
         raise NotImplementedError(

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3924,6 +3924,8 @@ class _SemanticAnalyzer:
             return self._analyze_vbitsort(args)
         if name == "vmrgsort4":
             return self._analyze_vmrgsort4(args)
+        if name == "get_vms4_sr":
+            return self._analyze_get_vms4_sr(args)
         if name in _BROADCAST_VECTOR_OPS:
             return self._analyze_broadcast_vector_op(name, args)
         if name in _MULTI_RESULT_VECTOR_OPS:
@@ -5973,6 +5975,17 @@ class _SemanticAnalyzer:
             name="vmrgsort4",
             args=(destination, source0, source1, source2, source3, args[5], args[6]),
             type=None,
+        )
+
+    def _analyze_get_vms4_sr(self, args: tuple[SemanticExpr, ...]) -> SemanticExpr:
+        if args:
+            raise TypeError("pto.get_vms4_sr does not accept positional arguments in TileLang DSL v1")
+        count_type = SemanticScalarType(dtype=i16)
+        return SemanticCallExpr(
+            namespace="pto",
+            name="get_vms4_sr",
+            args=(),
+            type=SemanticTupleType(elements=(count_type, count_type, count_type, count_type)),
         )
 
     def _require_dtype_symbol(self, expr: SemanticExpr, context: str) -> ScalarType:

--- a/tilelang-dsl/python/tilelang_dsl/support_matrix.py
+++ b/tilelang-dsl/python/tilelang_dsl/support_matrix.py
@@ -202,6 +202,7 @@ ADVANCED_VECSCOPE_PTO_CALLS = frozenset(
         "vdintlvv2",
         "vbitsort",
         "vmrgsort4",
+        "get_vms4_sr",
     }
 )
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -923,6 +923,7 @@ class TileLangDSLSupportMatrixTests(unittest.TestCase):
         self.assertEqual(get_feature_tier("pto.vscatter"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.vbitsort"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("pto.vmrgsort4"), ADVANCED_TIER)
+        self.assertEqual(get_feature_tier("pto.get_vms4_sr"), ADVANCED_TIER)
         self.assertEqual(get_feature_tier("PadMode"), BASIC_TIER)
         self.assertEqual(get_feature_tier("VRegType"), BASIC_TIER)
         self.assertEqual(get_feature_tier("MaskType"), BASIC_TIER)
@@ -1965,6 +1966,33 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertEqual(kernel.parameters[0].dtype, pto.f32)
         self.assertEqual(kernel.parameters[0].annotation, pto.ptr(pto.f32, pto.MemorySpace.UB))
         self.assertEqual(kernel.parameters[0].element_dtype, pto.f32)
+
+    def test_get_vms4_sr_lowers_to_four_i16_results(self) -> None:
+        @pto.vkernel(op="get_vms4_sr_surface", dtypes=[(pto.i16,)], advanced=True)
+        def kernel(dst: pto.ptr(pto.i16, pto.MemorySpace.GM)):
+            list0, list1, list2, list3 = pto.get_vms4_sr()
+            pto.store_scalar(dst, 0, list2)
+            return None
+
+        specialized = kernel.specialize()
+        semantic_kernel = analyze_frontend_kernel(build_frontend_kernel_node(specialized))
+        status_assign = next(
+            stmt
+            for stmt in semantic_kernel.body
+            if isinstance(stmt, SemanticAssignStmt)
+            and isinstance(stmt.value, SemanticCallExpr)
+            and stmt.value.name == "get_vms4_sr"
+        )
+        self.assertEqual(len(status_assign.targets), 4)
+        self.assertTrue(all(isinstance(target.type, SemanticScalarType) for target in status_assign.targets))
+        self.assertTrue(all(target.type.dtype == pto.i16 for target in status_assign.targets))
+
+        text = specialized.mlir_text()
+        self.assertRegex(
+            text,
+            r"%list0_\d+, %list1_\d+, %list2_\d+, %list3_\d+ = pto\.get_vms4_sr : i16, i16, i16, i16",
+        )
+        self.assertIn("pto.store_scalar", text)
 
     def test_vreg_type_constructor_exposes_inferred_lane_count(self) -> None:
         vec_type = pto.vreg(pto.f32)


### PR DESCRIPTION
This PR adds four-result support for `pto.get_vms4_sr` and wires it through the VPTO and TileLang DSL paths.

Changes:
- add `pto.get_vms4_sr` with four `i16` results in VPTO
- lower it to `llvm.hivm.GET.VMS4.SR()` and split the packed result
- expose the DSL API and corresponding lowering/test coverage
- add a VPTO SIM case for `vmrgsort4` that validates the returned status values

Example:
```pto
%a, %b, %c, %d = pto.get_vms4_sr : i16, i16, i16, i16
```
