### PR TITLE
Finalize cube semantic docs and ops

### DIFF
--- a/.codex/skills/ptoas-manual-authoring/SKILL.md
+++ b/.codex/skills/ptoas-manual-authoring/SKILL.md
@@ -17,6 +17,8 @@ details unless the user explicitly asks for an implementation design document.
 Do not mention:
 
 - raw op layers, bridge ops, or wrapper-to-raw expansion
+- legacy or low-level operation names in high-level manuals or in
+  `docs/vpto-spec.md` high-level summaries, inventories, and navigation tables
 - hardware registers, control-bit numbers, packed instruction fields, or
   intrinsic names
 - pass names, lowering helper names, emitter internals, or source file paths
@@ -25,6 +27,10 @@ Do not mention:
 
 Implementation details may live in `docs/designs/` or implementation plans, but
 not in the stable user manual.
+
+Legacy and low-level operation references may remain only in explicitly legacy
+release snapshots or dedicated low-level reference material. Do not promote them
+into current high-level op manuals, examples, or `docs/vpto-spec.md` indexes.
 
 ## Required Content
 
@@ -58,6 +64,9 @@ For each op or op family, document these items when applicable:
   examples.
 - Keep the manual canonical. Remove obsolete plans and superseded forms instead
   of preserving them for history.
+- When updating `docs/vpto-spec.md`, keep high-level summaries, inventories,
+  and chapter op lists aligned with the current semantic surface. Do not list
+  legacy implementation ops just because they exist in ODS or old manuals.
 - Avoid vague phrases such as "sets parameters", "configures the pipeline", or
   "does the conversion" unless followed by the concrete values, organization,
   and observable effect.
@@ -93,6 +102,8 @@ Before finishing a manual edit:
   register implementation.
 - No removed syntax, old方案, TODO design fragments, or dead alternatives remain
   in the stable manual.
+- No legacy or low-level op names are introduced into high-level manuals or
+  `docs/vpto-spec.md` high-level summaries/inventories.
 - Examples are meaningful and consistent with verifier/lowering behavior.
 - Related generated or bundled docs are refreshed when this repo expects them
   to be kept in sync.

--- a/docs/designs/acc-store-structured-interface.md
+++ b/docs/designs/acc-store-structured-interface.md
@@ -11,7 +11,7 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
               pre_relu(%alpha_or_fb_addr, mode = ..., clip = %clip_value ?)?,
               nz2nd? | nz2dn(%loop0_src_stride)? | nz2nz(%split)?,
               loop3(%count, %src_stride, %dst_stride)?,
-              sat?
+              (sat | nosat)?
 ```
 
 其中：
@@ -61,9 +61,12 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
 - `loop3(%count, %src_stride, %dst_stride)?`
   - 这三个参数都必填
   - 无额外可选子参数
-- `sat?`
+- `(sat | nosat)?`
   - 可选 flag
-  - 不写表示不显式配置饱和控制；写 `sat` 表示选择饱和行为
+  - 不写表示不显式配置饱和控制，沿用进入 op 前的状态
+  - 写 `sat` 表示本 op 内选择饱和行为
+  - 写 `nosat` 表示本 op 内选择非饱和行为
+  - `sat` 和 `nosat` 互斥
 - `atomic(type = ..., op = ...)?`
   - 仅 `acc_store_gm` 支持
   - `type` 必填，可选值：`f32`、`f16`、`s16`、`s32`、`s8`、`bf16`
@@ -81,7 +84,7 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
 - `nz2dn(%loop0_src_stride)`
 - `nz2nz(%split)?`
 - `loop3(...)`
-- `sat`
+- `sat` / `nosat`
 - `atomic(...)`（仅 `acc_store_gm`）
 
 其中：
@@ -93,7 +96,7 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
 - `pre_relu(..., clip = %clip_value)` 的 `clip` 子句走 `SPR.FIX_CLIP_RELU`
 - `unit_flag` 不走 FB1
 - `split` 不走 FB1
-- `sat` 走 `SPR.CTRL`
+- `sat` / `nosat` 走 `SPR.CTRL`
 - `atomic` 仅在 `acc_store_gm` 上走 `SPR.CTRL`
 - `post-stage`、`element-wise`、`LoopEnhance` 相关扩展不纳入本版接口
 
@@ -114,7 +117,7 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
 - `nz2nz(%split)?` 映射到 `X_t[42] / SPLIT_EN`
 - `nz2dn(%loop0_src_stride)` 映射到 `CHANNEL_PARA[63:48]`
 - `loop3(...)` 映射到 `SPR.LOOP3_PARA`
-- `sat?` 映射到 `SPR.CTRL[48] / ctrl_sat_ctrl`
+- `sat` / `nosat` 映射到 `SPR.CTRL[48] / ctrl_sat_ctrl`
 - `atomic(type = ..., op = ...)?` 仅对 `acc_store_gm` 有效，映射到 `SPR.CTRL[8:6] / ctrl_atomic_en` 和 `SPR.CTRL[10:9] / ctrl_atomic_op`
 
 ## 5. Keyword
@@ -187,9 +190,10 @@ pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride,
   - `add` -> `2'b00`
   - `max` -> `2'b01`
   - `min` -> `2'b10`
-- `sat`
+- `sat` / `nosat`
   - absent -> no explicit `CTRL[48]` override
-  - present -> `CTRL[48] = 1'b0`
+  - `sat` -> `CTRL[48] = 1'b0`
+  - `nosat` -> `CTRL[48] = 1'b1`
 
 ## 6. 说明
 

--- a/docs/isa/micro-isa/02-dma-copy.md
+++ b/docs/isa/micro-isa/02-dma-copy.md
@@ -11,11 +11,6 @@ This document describes the public grouped DMA interfaces:
 - `pto.dma_store`
 - `pto.dma_copy`
 
-This chapter covers the public grouped DMA interfaces. The legacy raw copy
-family remains documented separately; in particular, `pto.copy_ubuf_to_ubuf`
-shares the same UB→UB copy contract as `pto.dma_copy` but remains a legacy
-surface op.
-
 ---
 
 ## DMA Transfer Execution
@@ -124,7 +119,7 @@ pto.dma_copy %ub_src, %dst, %len_burst
   nburst(%n_burst, %src_gap, %dst_gap)
   : !pto.ptr<T, ub>, !pto.ptr<T, ub|mat>, i64, i64, i64, i64
 ```
-- **semantics:** Grouped UB→destination raw copy. When `%dst` is in UB, the transfer is UB→UB. When `%dst` is in MAT/CBUF, the transfer is UB→CBUF.
+- **semantics:** Grouped UB→destination copy. When `%dst` is in UB, the transfer is UB→UB. When `%dst` is in MAT/CBUF, the transfer is UB→CBUF.
 
 **Parameter Table:**
 

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -1,48 +1,112 @@
 # 16. Cube Matrix Multiply (MAT)
 
-> **Category:** Cube unit ops — staged load/store and matrix multiply
+> **Category:** Cube unit ops — staged load/store, matrix multiply, and
+> FIXPIPE MTE writeback
+
+This chapter documents the high-level Cube VPTO surface. It describes logical
+data objects, operand units, layout contracts, numeric behavior, and writeback
+effects from the user's point of view.
 
 ---
 
-## Wrapper-Layer Compute Ops
+## Common Cube Operand Model
 
-The `pto.mad*` family describes a logical matrix multiply over already prepared
-cube tiles:
+Cube ops use typed PTO pointers to name logical storage domains:
 
-- `%lhs` is the logical `M x K` left matrix tile in `left`.
-- `%rhs` is the logical `K x N` right matrix tile in `right`.
-- `%dst` is the logical `M x N` accumulator tile in `acc`.
-- `%m`, `%n`, and `%k` are element counts in the logical M/N/K dimensions, not
-  byte sizes.
-- The matrix data type is inferred from the pointer element types. Do not pass
-  a separate type selector. Invalid target-profile type combinations are not
-  valid programs.
+| Address space | Logical role |
+|---------------|--------------|
+| `gm` | Global memory |
+| `mat` | L1 matrix staging buffer |
+| `left` | Left matrix operand tile for Cube compute |
+| `right` | Right matrix operand tile for Cube compute |
+| `acc` | Accumulator/result tile produced by Cube compute |
+| `bias` | Bias vector payload consumed by bias matmul forms |
+| `scaling` | FIXPIPE parameter payloads consumed by vector quant/ReLU clauses |
+| `ub` | Unified Buffer destination/source for vector-side use |
 
-Common optional clauses:
+Unless an op says otherwise:
 
-| Clause | Values | Semantic effect |
-|--------|--------|-----------------|
-| `unit_flag(...)` | `check_only`, `check_and_set` | Enables producer-side unit-flag participation for this result tile. `check_only` only performs the producer-side availability check; `check_and_set` also publishes the produced tile for downstream consumers. Omit it when the schedule does not use unit-flag synchronization. |
-| `disable_gemv` | flag | Selects the normal matmul `%lhs` consumption contract for `M = 1` GEMV operations. When `M = 1`, omitting this flag selects the GEMV `%lhs` consumption contract: `%lhs` must point to an L0A tile organized in the target GEMV A-vector format. On the current A5 contract, the logical `A[1, K]` values must be provided as a sequential K-element vector. Supplying a normal matmul L0A organization while GEMV mode is selected is invalid. Adding `disable_gemv` makes `%lhs` use the normal matmul consumption contract instead. For `M != 1`, the op uses the normal matmul `%lhs` consumption contract. The mathematical result is unchanged: all modes compute `A @ B`; only the required L0A organization for `%lhs` changes in the `M = 1` GEMV case. |
-| `sat` / `nosat` | flags | Optional CUBE floating exceptional-value mode. With `sat`, exceptional input values participating in the multiply are normalized before arithmetic (`+/-INF -> +/-finite type max`, `NaN -> 0`), and finite arithmetic overflow saturates to the finite type range instead of producing INF. With `nosat`, INF/NaN inputs are preserved and overflow can produce INF/NaN through the multiply-accumulate. Omit both to use the surrounding execution mode. These flags are valid only for floating/MX MAD forms, not integer MAD. |
-| `tf32_mode(...)` | `round_even`, `round_away` | Valid only for non-MX `f32 x f32 -> f32`. FP32 inputs are rounded to TF32 precision before multiplication; accumulation/output remain FP32. `round_even` uses nearest-even tie handling; `round_away` uses nearest-away tie handling. |
-| `n_dir` | flag | Requests N-direction result production. This does not change the mathematical matrix value; it changes the producer ordering expected by schedules that combine unit flags with later layout movement. Omit it for the default M-direction production order. |
+- Shape operands such as `%m`, `%n`, `%k`, `shape(%n, %d)` are logical element
+  counts, not byte counts.
+- Length operands named `%len_burst` in byte-copy surfaces are byte counts
+  unless the op explicitly states a different unit.
+- Strides named `src_stride` or `dst_stride` are start-to-start distances in
+  the unit stated by the op. Do not infer byte units from the name alone.
+- Pointer operands select the base address of the logical object. Sub-tile
+  selection is expressed by computing a different base pointer before calling
+  the op, unless the op exposes an explicit start or group operand.
+- Cache/session hint operands may affect the memory path but do not change the
+  mathematical value written or read.
 
-`pto.mad_mx*` additionally applies microscaling. The scale operands are not
-explicit operands of the matmul op: they are associated with the `%lhs` and
-`%rhs` tiles by the MX load/layout contract. Logically, each group of 32
-K-direction values shares one scale value. In the current target profile, the
-supported MX data tile type is `f8E4M3FN`:
+---
+
+## Cube Compute Ops
+
+The `pto.mad*` family computes logical matrix multiplication over tiles already
+prepared in `left` and `right`:
 
 ```text
-mx_matmul(lhs, rhs)[m, n] =
-  sum_k (lhs[m, k] * scale_lhs[m, floor(k / 32)]) *
-        (rhs[k, n] * scale_rhs[floor(k / 32), n])
+lhs: M x K
+rhs: K x N
+dst: M x N
 ```
 
-The corresponding scale data must have been loaded into the matching MX side
-buffers before the `pto.mad_mx*` op executes, and it must be aligned with the
-data tile selected by `%lhs` / `%rhs`.
+The matrix element types are inferred from `%lhs`, `%rhs`, and `%dst` pointer
+element types. There is no separate type selector. Unsupported type
+combinations are invalid programs.
+
+The current VPTO surface enforces the Cube storage roles through pointer
+address spaces: `%lhs` is `left`, `%rhs` is `right`, and `%dst` is `acc`.
+Bias forms additionally require `%bias` in the `bias` address space with the
+same element type as `%dst`. MX forms require MX element types on both `%lhs`
+and `%rhs`; the current target-profile MX data type is `f8E4M3FN`.
+
+### MAD Common Clauses
+
+| Clause | Values | Effect |
+|--------|--------|--------|
+| `unit_flag(...)` | `check_only`, `check_and_set` | Participates in producer-side tile synchronization. `check_only` checks that the producer slot can be used. `check_and_set` also publishes the produced `%dst` tile for later consumers. Omit the clause when the schedule does not use unit flags for this tile. |
+| `disable_gemv` | flag | Applies only when `%m = 1`. Omitted means GEMV A-vector consumption: `%lhs` must contain the logical `1 x K` row in the target GEMV left-tile organization. Present means normal matmul left-tile organization. The mathematical result is still `lhs @ rhs`; only the required `%lhs` organization changes. For `%m != 1`, normal matmul organization is used. |
+| `sat` / `nosat` | flags | Floating exceptional-value mode for floating and MX MAD forms. With `sat`, exceptional multiply inputs are normalized before arithmetic (`+/-inf` to finite type extrema, `nan` to 0) and finite overflow saturates to the finite type range. With `nosat`, exceptional inputs are preserved and overflow may produce exceptional outputs. Omit both to use the execution mode selected outside this op. Integer MAD forms do not accept these flags. |
+| `tf32_mode(...)` | `round_even`, `round_away` | Valid only for non-MX `f32 x f32 -> f32`. FP32 inputs are rounded to TF32 precision before multiplication; accumulation and output remain FP32. |
+| `n_dir` | flag | Requests N-direction result production order for schedules that combine compute with unit flags and later layout movement. It does not change `dst[m, n]`. |
+
+Reference semantics for non-MX forms:
+
+```text
+product[m, n] = sum k in 0 .. K-1:
+                  numeric_lhs(lhs[m, k]) * numeric_rhs(rhs[k, n])
+
+pto.mad:      dst[m, n] = product[m, n]
+pto.mad_acc:  dst[m, n] = dst[m, n] + product[m, n]
+pto.mad_bias: dst[m, n] = product[m, n] + bias[n]
+```
+
+For integer forms, the op multiplies the typed values already present in
+`left` and `right`. Per-input offset correction for quantized integer
+algorithms is not an operand of `pto.mad*`; apply such correction before
+loading the Cube operands when the algorithm needs it.
+
+### MX Matmul Model
+
+`pto.mad_mx*` additionally applies microscaling. The scale payloads are loaded
+with `pto.left_load_mx` / `pto.right_load_mx` and are associated with the
+selected `%lhs` / `%rhs` tiles; they are not direct operands of `pto.mad_mx*`.
+
+The K dimension is partitioned into 32-element groups:
+
+```text
+k_group = floor(k / 32)
+
+mx_product[m, n] =
+  sum k in 0 .. K-1:
+    (lhs[m, k] * lhs_scale[m, k_group]) *
+    (rhs[k, n] * rhs_scale[k_group, n])
+```
+
+Current target-profile MX data tiles use `f8E4M3FN`. `%k` must be compatible
+with MX grouping. On the current target profile, MX matmul consumes K in
+64-element multiples, which contain two 32-element scale groups.
 
 ### `pto.mad`
 
@@ -56,35 +120,34 @@ pto.mad %lhs, %rhs, %dst, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, i64, i64, i64
 ```
-- **semantics:** Zero-init cube matmul, `dst = lhs * rhs`.
+- **semantics:** Zero-init matrix multiply, `dst[m, n] = sum_k(lhs[m, k] * rhs[k, n])`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%lhs` | ptr | L0A input (`left`) |
-| `%rhs` | ptr | L0B input (`right`) |
-| `%dst` | ptr | L0C accumulator (`acc`) |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%k` | i64 | K size |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `tf32_mode` | clause | Optional TF32 input rounding; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
+| `%lhs` | ptr | Left operand tile in `left`, interpreted as logical `M x K` |
+| `%rhs` | ptr | Right operand tile in `right`, interpreted as logical `K x N` |
+| `%dst` | ptr | Accumulator destination tile in `acc`, interpreted as logical `M x N` |
+| `%m` | i64 | Logical M element count |
+| `%n` | i64 | Logical N element count |
+| `%k` | i64 | Logical K element count |
+| optional clauses | - | See [MAD Common Clauses](#mad-common-clauses) |
 
 **Constraints:**
 
-- Address spaces must be `left`, `right`, `acc`.
-- `unit_flag(check_only)` and `unit_flag(check_and_set)` are the supported forms.
+- `%lhs`, `%rhs`, and `%dst` must be in `left`, `right`, and `acc`.
+- `%m`, `%n`, and `%k` must be positive and satisfy the target shape limits
+  for the selected element-type combination.
 - `tf32_mode(...)` requires `f32` lhs, rhs, and dst element types.
-- `sat` / `nosat` requires floating or MX lhs/rhs/dst element types; integer `s8 -> s32` MAD does not accept this clause.
+- `sat` / `nosat` requires a floating element-type combination.
+- Packed 4-bit integer data requires `%k` to select an even number of K
+  elements.
 
 **Example:**
 
 ```mlir
-pto.mad %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c16_i64
+pto.mad %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c32_i64
   : !pto.ptr<f16, left>, !pto.ptr<f16, right>, !pto.ptr<f32, acc>, i64, i64, i64
 ```
 
@@ -102,34 +165,17 @@ pto.mad_acc %lhs, %rhs, %dst, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, i64, i64, i64
 ```
-- **semantics:** Accumulating cube matmul, `dst += lhs * rhs`.
+- **semantics:** Accumulating matrix multiply,
+  `dst[m, n] = dst[m, n] + sum_k(lhs[m, k] * rhs[k, n])`.
 
-**Parameter Table:**
+**Parameter Table:** same as `pto.mad`.
 
-| Parameter | Width | Description |
-|-----------|-------|-------------|
-| `%lhs` | ptr | L0A input (`left`) |
-| `%rhs` | ptr | L0B input (`right`) |
-| `%dst` | ptr | L0C accumulator (`acc`) |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%k` | i64 | K size |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `tf32_mode` | clause | Optional TF32 input rounding; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
-
-**Constraints:**
-
-- Same address space/type family requirements as `pto.mad`.
-- `tf32_mode(...)` requires `f32` lhs, rhs, and dst element types.
-- `sat` / `nosat` requires floating or MX lhs/rhs/dst element types.
+**Constraints:** same as `pto.mad`.
 
 **Example:**
 
 ```mlir
-pto.mad_acc %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c16_i64 unit_flag(check_only)
+pto.mad_acc %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c32_i64 unit_flag(check_only)
   : !pto.ptr<f16, left>, !pto.ptr<f16, right>, !pto.ptr<f32, acc>, i64, i64, i64
 ```
 
@@ -147,38 +193,28 @@ pto.mad_bias %lhs, %rhs, %dst, %bias, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, !pto.ptr<C, bias>, i64, i64, i64
 ```
-- **semantics:** Bias-init cube matmul, `dst[m, n] = lhs[m, k] * rhs[k, n] + bias[n]`.
-  The bias operand is not an `M x N` matrix. It points to an `N`-element
-  per-output-channel bias vector in the bias buffer, and that vector is
-  broadcast across the M dimension.
+- **semantics:** Bias-init matrix multiply,
+  `dst[m, n] = sum_k(lhs[m, k] * rhs[k, n]) + bias[n]`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%lhs` / `%rhs` / `%dst` / `%m` / `%n` / `%k` | - | Same meaning as `pto.mad` |
-| `%bias` | ptr | Bias-buffer pointer (`!pto.ptr<C, bias>`) for the `N`-element bias vector. |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `tf32_mode` | clause | Optional TF32 input rounding; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
+| `%lhs`, `%rhs`, `%dst`, `%m`, `%n`, `%k` | - | Same as `pto.mad` |
+| `%bias` | ptr | Bias vector in `bias`, interpreted as `N` values and broadcast across M |
+| optional clauses | - | See [MAD Common Clauses](#mad-common-clauses) |
 
 **Constraints:**
 
 - `%bias` must be in `bias` address space.
 - `%bias` element type must match `%dst` element type.
-- `%bias` must satisfy the target alignment requirement for the bias buffer.
-- Only `N` bias values are consumed. To model a logical `M x N` result, use
-  `bias[None, :]` in the reference calculation, not an independent `M x N`
-  bias matrix.
-- `tf32_mode(...)` requires `f32` lhs, rhs, and dst element types.
-- `sat` / `nosat` requires floating or MX lhs/rhs/dst element types.
+- Only `N` bias values are consumed; `%bias` is not an `M x N` matrix.
+- Other constraints match `pto.mad`.
 
 **Example:**
 
 ```mlir
-pto.mad_bias %l0a, %l0b, %l0c, %bt, %c16_i64, %c16_i64, %c16_i64
+pto.mad_bias %l0a, %l0b, %l0c, %bt, %c16_i64, %c16_i64, %c32_i64
   : !pto.ptr<f16, left>, !pto.ptr<f16, right>, !pto.ptr<f32, acc>, !pto.ptr<f32, bias>, i64, i64, i64
 ```
 
@@ -195,28 +231,17 @@ pto.mad_mx %lhs, %rhs, %dst, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, i64, i64, i64
 ```
-- **semantics:** Zero-init MX cube matmul, `dst = mx_matmul(lhs, rhs)`.
+- **semantics:** Zero-init MX matrix multiply, `dst[m, n] = mx_product[m, n]`.
 
-**Parameter Table:**
-
-| Parameter | Width | Description |
-|-----------|-------|-------------|
-| `%lhs` | ptr | MX L0A input (`left`) |
-| `%rhs` | ptr | MX L0B input (`right`) |
-| `%dst` | ptr | L0C accumulator (`acc`) |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%k` | i64 | K size; MX scaling groups values in K-direction chunks of 32 |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
+**Parameter Table:** same as `pto.mad`; `%lhs` and `%rhs` must have matching
+MX scale payloads prepared by the MX load ops.
 
 **Constraints:**
 
 - Operands must use a target-supported MX dtype combination.
-- The corresponding MX scale data for `%lhs` and `%rhs` must already be
-  prepared and aligned with the data tiles selected by those pointers.
+- Matching left and right MX scale payloads must be loaded before this op.
+- `%k` must satisfy the MX grouping rule described in [MX Matmul Model](#mx-matmul-model).
+- `tf32_mode(...)` is not a clause of MX MAD.
 
 **Example:**
 
@@ -238,24 +263,12 @@ pto.mad_mx_acc %lhs, %rhs, %dst, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, i64, i64, i64
 ```
-- **semantics:** Accumulating MX cube matmul, `dst += mx_matmul(lhs, rhs)`.
+- **semantics:** Accumulating MX matrix multiply,
+  `dst[m, n] = dst[m, n] + mx_product[m, n]`.
 
-**Parameter Table:**
+**Parameter Table:** same as `pto.mad_mx`.
 
-| Parameter | Width | Description |
-|-----------|-------|-------------|
-| `%lhs` | ptr | MX L0A input (`left`) |
-| `%rhs` | ptr | MX L0B input (`right`) |
-| `%dst` | ptr | L0C accumulator (`acc`) |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%k` | i64 | K size; MX scaling groups values in K-direction chunks of 32 |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
-
-**Constraints:** same as `pto.mad_mx`; `sat` / `nosat` is valid because MX is a floating exceptional-value mode.
+**Constraints:** same as `pto.mad_mx`.
 
 **Example:**
 
@@ -277,29 +290,13 @@ pto.mad_mx_bias %lhs, %rhs, %dst, %bias, %m, %n, %k
   n_dir?
   : !pto.ptr<A, left>, !pto.ptr<B, right>, !pto.ptr<C, acc>, !pto.ptr<C, bias>, i64, i64, i64
 ```
-- **semantics:** Bias-init MX cube matmul. Like `pto.mad_bias`, the bias is an
-  `N`-element per-output-channel vector in the bias buffer and is broadcast
-  across M:
-  `dst[m, n] = mx_matmul(lhs, rhs)[m, n] + bias[n]`.
+- **semantics:** Bias-init MX matrix multiply,
+  `dst[m, n] = mx_product[m, n] + bias[n]`.
 
-**Parameter Table:**
+**Parameter Table:** same as `pto.mad_bias`, with MX `%lhs` / `%rhs` scale
+payload requirements from `pto.mad_mx`.
 
-| Parameter | Width | Description |
-|-----------|-------|-------------|
-| `%lhs` | ptr | MX L0A input (`left`) |
-| `%rhs` | ptr | MX L0B input (`right`) |
-| `%dst` | ptr | L0C accumulator (`acc`) |
-| `%bias` | ptr | Bias-buffer pointer (`bias`) for the `N`-element bias vector |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%k` | i64 | K size; MX scaling groups values in K-direction chunks of 32 |
-| `unit_flag` | clause | Optional unit-flag producer control; see common clauses |
-| `disable_gemv` | flag | Optional GEMV disable; see common clauses |
-| `sat` / `nosat` | flag | Optional floating exceptional-value mode override; see common clauses |
-| `n_dir` | flag | Optional N-direction producer order; see common clauses |
-
-**Constraints:** same as `pto.mad_mx` plus the `pto.mad_bias` bias-buffer/broadcast
-constraints; `sat` / `nosat` is valid because MX is a floating exceptional-value mode.
+**Constraints:** same as `pto.mad_mx` plus `pto.mad_bias` bias constraints.
 
 **Example:**
 
@@ -310,7 +307,23 @@ pto.mad_mx_bias %l0a, %l0b, %l0c, %bt, %c16_i64, %c16_i64, %c64_i64
 
 ---
 
-## Cube Bridge Wrapper Ops
+## Cube Data Movement Ops
+
+### Cube Burst / Loop Addressing Model
+
+`pto.cube_load` and `pto.cube_store` use the same grouped transfer model:
+
+```text
+burst(row) = len_burst contiguous bytes
+nburst     = innermost repeated burst group
+loop       = optional outer repetition group
+```
+
+For each `nburst` row, the source and destination start addresses advance by
+`src_stride` and `dst_stride` after a burst row. Optional `loop(...)` groups
+wrap the full inner transfer pattern and advance by their own source and
+destination strides between repetitions. All lengths and strides in this model
+are bytes.
 
 ### `pto.cube_load`
 
@@ -321,34 +334,30 @@ pto.cube_load %src, %dst, %len_burst
   [loop(%count_i, %src_stride_i, %dst_stride_i)]*
   : !pto.ptr<T, gm>, !pto.ptr<T, mat>, i64, i64, i64, i64
 ```
-- **semantics:** Structured GM-to-L1 (`cbuf`) wrapper.
-  The op copies one or more contiguous byte ranges from GM to L1. Each inner
-  burst copies `%len_burst` bytes. `nburst` repeats that burst, and each
-  optional `loop(...)` wraps the inner transfer pattern in an outer repeated
-  pattern.
+- **semantics:** Structured GM-to-L1 copy. The op copies grouped byte ranges
+  from `%src` in `gm` to `%dst` in `mat`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | GM source pointer |
-| `%dst` | ptr | L1 destination pointer (`mat`) |
-| `%len_burst` | i64 | Contiguous transfer length in bytes |
-| `nburst(%count, %src_stride, %dst_stride)` | i64 triple | Inner burst count and source/destination gaps between bursts. The gap is applied after each `%len_burst` byte burst. |
-| `loop(%count_i, %src_stride_i, %dst_stride_i)` | i64 triple | Optional outer loop triplet. Strides are byte offsets applied between repetitions of the enclosed transfer pattern. |
+| `%src` | ptr | GM source base pointer |
+| `%dst` | ptr | L1 matrix destination base pointer in `mat` |
+| `%len_burst` | i64 | Bytes copied per burst row |
+| `nburst(%count, %src_stride, %dst_stride)` | i64 triple | Innermost burst count and byte strides between row starts |
+| `loop(%count_i, %src_stride_i, %dst_stride_i)` | i64 triple | Optional outer repetition; strides are byte advances between enclosed patterns |
 
 **Constraints:**
 
-- For a contiguous 16-element f16 vector, use `%len_burst = 32`, not `16`.
-- `%count = 1` with zero gaps describes one contiguous copy of `%len_burst`
-  bytes. Increase `%count` for multiple same-sized bursts; use `loop(...)` for
-  higher-dimensional tiling around the inner burst pattern.
+- `nburst(...)` is required.
+- Each `loop(...)` group must provide all three operands.
+- For a contiguous 16-element f16 vector, use `%len_burst = 32`.
 
 **Example:**
 
 ```mlir
 pto.cube_load %bias_gm, %l1_bias, %c32_i64
-  nburst(%c1_i64, %c0_i64, %c0_i64)
+  nburst(%c4_i64, %c64_i64, %c32_i64)
   : !pto.ptr<f16, gm>, !pto.ptr<f16, mat>, i64, i64, i64, i64
 ```
 
@@ -363,29 +372,23 @@ pto.cube_store %src, %dst, %len_burst
   [loop(%count_i, %src_stride_i, %dst_stride_i)]*
   : !pto.ptr<T, mat>, !pto.ptr<T, ub>, i64, i64, i64, i64
 ```
-- **semantics:** Structured L1 (`cbuf`) to UB wrapper. The transfer shape uses
-  the same burst/repeat model as `pto.cube_load`, but the source is L1 and the
-  destination is UB.
+- **semantics:** Structured L1-to-UB copy. The grouped byte ranges are read
+  from `%src` in `mat` and written to `%dst` in `ub`.
 
-**Parameter Table:**
-
-| Parameter | Width | Description |
-|-----------|-------|-------------|
-| `%src` | ptr | L1 source pointer (`mat`) |
-| `%dst` | ptr | UB destination pointer |
-| `%len_burst` | i64 | Contiguous transfer length in bytes |
-| `nburst(%count, %src_stride, %dst_stride)` | i64 triple | Inner burst count and source/destination gaps between bursts |
-| `loop(%count_i, %src_stride_i, %dst_stride_i)` | i64 triple | Optional outer loop triplet. Strides are byte offsets between repetitions of the enclosed transfer pattern. |
+**Parameter Table:** same grouped byte model as `pto.cube_load`, with source
+and destination address spaces reversed to `mat -> ub`.
 
 **Constraints:**
 
-- The source and destination address spaces must match the L1-to-UB dataflow.
+- `%src` must be in `mat`, `%dst` must be in `ub`.
+- `nburst(...)` is required.
+- Each `loop(...)` group must provide all three operands.
 
 **Example:**
 
 ```mlir
-pto.cube_store %l1_src, %ub_dst, %c16_i64
-  nburst(%c1_i64, %c0_i64, %c0_i64)
+pto.cube_store %l1_src, %ub_dst, %c64_i64
+  nburst(%c2_i64, %c128_i64, %c64_i64)
   : !pto.ptr<f16, mat>, !pto.ptr<f16, ub>, i64, i64, i64, i64
 ```
 
@@ -395,46 +398,89 @@ pto.cube_store %l1_src, %ub_dst, %c16_i64
 
 - **syntax:**
 ```mlir
-pto.cube_load_frac %src, %dst, nd2nz|dn2nz, shape(%n_value, %d_value), src_layout(%src_inner_stride[, %src_outer_stride]), dst_group(%group_count, %dst_loop2_stride, %dst_loop3_stride, %dst_loop4_stride), ctrl(%l2_cache_ctrl, %smallc0_en)
+pto.cube_load_frac %src, %dst, nd2nz|dn2nz,
+  shape(%n_value, %d_value),
+  src_layout(%src_inner_stride[, %src_outer_stride]),
+  dst_group(%group_count, %dst_loop2_stride, %dst_loop3_stride, %dst_loop4_stride),
+  ctrl(%l2_cache_ctrl, %smallc0_en)
   : !pto.ptr<T, gm>, !pto.ptr<T, mat>, ...
 ```
-- **semantics:** Structured fractal-load wrapper for `nd2nz` / `dn2nz`.
-  It copies a logical 2-D source region into L1 using the target fractal
-  layout expected by subsequent cube loads. `nd2nz` treats the source as
-  logical N-major rows with D as the inner dimension; `dn2nz` treats the same
-  logical region with D/N interpretation swapped before writing NZ layout.
+- **semantics:** Load a logical 2-D GM region and write one or more L1 NZ
+  matrix groups. `nd2nz` reads a logical `src[n, d]` matrix. `dn2nz` reads a
+  logical `src[d, n]` matrix and writes the same logical `N x D` result into
+  NZ layout.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | GM source pointer |
-| `%dst` | ptr | L1 destination pointer (`mat`) |
-| `nd2nz` / `dn2nz` | enum token | Fractal load mode |
-| `shape(%n_value, %d_value)` | i64 pair | Logical N and D shape of the source region being transformed |
-| `src_layout(%src_inner_stride[, %src_outer_stride])` | i64 / i64 pair | Source address strides in bytes. For row-major f16 `[N, D]`, `%src_inner_stride = D * 2`. |
-| `dst_group(%group_count, %dst_loop2_stride, %dst_loop3_stride, %dst_loop4_stride)` | i64 tuple | Destination fractal grouping and nested destination strides in C0-size units. These values organize where generated NZ fractals land in L1; they do not select a separate destination memory block. |
-| `ctrl(%l2_cache_ctrl, %smallc0_en)` | i64, i1 | L2 cache policy hint and small-C0 mode enable |
+| `%src` | ptr | GM source base pointer |
+| `%dst` | ptr | L1 NZ destination base pointer in `mat` |
+| `nd2nz` / `dn2nz` | keyword | Source logical layout mode |
+| `shape(%n_value, %d_value)` | i64 pair | Logical output shape before NZ packing |
+| `src_layout(%src_inner_stride[, %src_outer_stride])` | i64 / optional i64 | Source row/matrix byte strides |
+| `dst_group(...)` | i64 tuple | Destination group count and placement strides in C0-size units |
+| `ctrl(%l2_cache_ctrl, %smallc0_en)` | i64, i1 | Cache hint and small-C0 packing enable |
+
+`src_layout(%src_inner_stride)` describes one logical source matrix. For
+`nd2nz`, `%src_inner_stride` is the byte distance from `src[n, 0]` to
+`src[n + 1, 0]`. For `dn2nz`, it is the byte distance from `src[d, 0]` to
+`src[d + 1, 0]`. When `%src_outer_stride` is present, it is the byte distance
+between adjacent source matrices. When omitted, the outer source stride is 0.
+
+`dst_group(%group_count, %dst_loop2_stride, %dst_loop3_stride,
+%dst_loop4_stride)` writes `%group_count` logical matrices. Destination strides
+are measured in C0-size units; one C0-size unit is 32 bytes. These strides
+place generated NZ blocks relative to `%dst`. They do not select a separate
+memory block.
+
+Reference addressing:
+
+```text
+for g in 0 .. group_count-1:
+  src_g = src + g * src_outer_stride
+  dst_g = dst + g * dst_loop4_stride * 32
+
+  for n in 0 .. n_value-1:
+    for d in 0 .. d_value-1:
+      if mode == nd2nz:
+        value = load(src_g + n * src_inner_stride + d * sizeof(T))
+      else:
+        value = load(src_g + d * src_inner_stride + n * sizeof(T))
+      store value into NZ position for logical [n, d] under dst_g
+
+  invalid lanes in the final C0 group are written as zero
+```
 
 **Constraints:**
 
-- `src_inner_stride` and `src_outer_stride` are byte strides. Do not pass
-  element counts. For example, a row-major `16 x 16` f16 matrix uses
-  `src_layout(32)`.
-- The destination pointer still selects the base L1 address. Destination
-  grouping/strides are offsets relative to that base.
-- `smallc0_en` is only valid for the target-supported small-C0 cases; the
-  combination is invalid when `d_value > 4`.
+- Source strides are bytes. For row-major `16 x 16` f16 input,
+  `src_layout(32)` describes consecutive rows.
+- Destination strides are C0-size units, not bytes and not elements.
+- `smallc0_en = true` is valid only for target-supported small-C0 cases. The
+  current contract rejects `d_value > 4` in small-C0 mode.
+- In normal C0 mode, each destination C0 burst is padded to 32 bytes. In
+  small-C0 mode, each destination burst is padded to 4 logical channels, and
+  the generated inner-N and C0 destination placement is fixed by that
+  small-C0 packing rule. `%dst_loop4_stride` still places adjacent matrix
+  groups.
+- In small-C0 mode, missing logical `N` rows and invalid `D` lanes are written
+  as zero, and the tail of a generated NZ matrix is padded to the 32-byte C0
+  boundary.
+- Destination regions selected by `%dst` and `dst_group(...)` must not overlap.
+  If two generated writes target the same bytes, the final value is not a
+  stable program result.
 
 **Example:**
 
 ```mlir
 pto.cube_load_frac %src, %dst, nd2nz,
-  shape(%n, %d),
-  src_layout(%sis),
-  dst_group(%g, %l2s, %l3s, %l4s),
-  ctrl(%l2, %small)
-  : !pto.ptr<f16, gm>, !pto.ptr<f16, mat>, nd2nz, shape i64, i64, src_layout(i64), dst_group i64, i64, i64, i64, ctrl i64, i1
+  shape(%c32_i64, %c16_i64),
+  src_layout(%c32_i64, %c1024_i64),
+  dst_group(%c2_i64, %c1_i64, %c16_i64, %c64_i64),
+  ctrl(%c0_i64, %false)
+  : !pto.ptr<f16, gm>, !pto.ptr<f16, mat>, nd2nz, shape i64, i64,
+    src_layout(i64, i64), dst_group i64, i64, i64, i64, ctrl i64, i1
 ```
 
 ---
@@ -447,41 +493,41 @@ pto.bias_load %src, %dst, %len_burst
   nburst(%count, %src_gap, %dst_gap)
   : !pto.ptr<T, mat>, !pto.ptr<U, bias>, i64, i64, i64, i64
 ```
-- **semantics:** Structured helper for L1 (`cbuf`) to bias-buffer load. It
-  prepares the per-output-channel bias vector consumed by `pto.mad_bias` and
-  `pto.mad_mx_bias`. For f16/bf16 sources, the source data in L1 is stored
-  compactly and can be converted to f32 values in the bias buffer.
+- **semantics:** Load an L1 bias payload into the `bias` address space for
+  later `pto.mad_bias` / `pto.mad_mx_bias` consumption. The consumer interprets
+  the result as an `N`-element bias vector `bias[n]`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | L1 source pointer (`mat`) |
-| `%dst` | ptr | Bias destination pointer (`bias`) |
-| `%len_burst` | i64 | Source burst length in the bias-load unit. For `f16->f32`, one unit covers 32B of compact f16 source data and produces 16 f32 bias values. |
+| `%src` | ptr | L1 source pointer in `mat` |
+| `%dst` | ptr | Bias destination pointer in `bias` |
+| `%len_burst` | i64 | Number of bias-load units per burst |
 | `%count` | i64 | Burst count |
-| `%src_gap` | i64 | Source gap between bursts in the bias-load unit |
-| `%dst_gap` | i64 | Destination gap between bursts in the bias-load unit; must preserve target N0 alignment |
+| `%src_gap` | i64 | Source gap between bursts, in bias-load units |
+| `%dst_gap` | i64 | Destination gap between bursts, in bias-load units |
+
+One burst loads `%len_burst` units from `%src` and writes the corresponding
+bias values to `%dst`. After each burst except the last, source and destination
+advance by the burst length plus the corresponding gap.
 
 **Constraints:**
 
 - Supported type pairs: `f32->f32`, `i32->i32`, `f16->f32`, `bf16->f32`.
-- For `f16->f32`, each compact f16 source value is converted to f32 before
-  being written to the bias buffer.
-- This op only prepares the bias buffer. The `mad_bias` consumer reads `N`
-  consecutive bias values and broadcasts them across M.
-- The bias buffer contains channel bias values, not an `M x N` result-shaped
-  tile. Load exactly the N-channel bias data needed by the consumer tile.
+- For `bf16->f32`, compact bf16 source values are always widened to f32 bias
+  values. For `f16->f32`, compact f16 source values are widened when the load
+  is used as an f32 bias payload; otherwise the f16 payload is stored in the
+  32-bit bias slot with unused high bits.
+- Load exactly the channel bias values needed by the consumer tile; the bias
+  payload is not result-shaped.
 
 **Example:**
 
 ```mlir
-pto.bias_load %l1_bias, %bt, %c16_i64 nburst(%c1_i64, %c0_i64, %c0_i64)
+pto.bias_load %l1_bias, %bt, %c1_i64 nburst(%c4_i64, %c0_i64, %c0_i64)
   : !pto.ptr<f16, mat>, !pto.ptr<f32, bias>, i64, i64, i64, i64
 ```
-
-This example loads one 32B source burst, i.e. 16 compact f16 bias values, and
-materializes 16 f32 bias-buffer values for a `N = 16` `mad_bias`.
 
 ---
 
@@ -493,31 +539,56 @@ pto.fp_load %src, %dst, %len_burst
   nburst(%count, %src_gap, %dst_gap)
   : !pto.ptr<T, mat>, !pto.ptr<U, scaling>, i64, i64, i64, i64
 ```
-- **semantics:** Structured helper for L1 (`cbuf`) to Fixpipe Buffer (`scaling`) load.
+- **semantics:** Load FIXPIPE parameter payloads from L1 into `scaling`.
+  Vector `pre_quant(...)` and `pre_relu(...)` clauses in `pto.acc_store*`
+  later consume these payloads through `scaling` pointers.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | L1 source pointer (`mat`) |
-| `%dst` | ptr | Fixpipe-buffer destination pointer (`scaling`) |
-| `%len_burst` | i64 | Burst length |
+| `%src` | ptr | L1 source pointer in `mat` |
+| `%dst` | ptr | Scaling destination pointer in `scaling` |
+| `%len_burst` | i64 | Number of parameter-load units per burst |
 | `%count` | i64 | Burst count |
-| `%src_gap` | i64 | Source gap |
-| `%dst_gap` | i64 | Destination gap |
+| `%src_gap` | i64 | Source gap between bursts, in parameter-load units |
+| `%dst_gap` | i64 | Destination gap between bursts, in parameter-load units |
+
+The copy unit of `pto.fp_load` is the parameter-load unit of this op. It is
+separate from the row size consumed by `acc_store*` vector payloads.
+`%len_burst` and the `nburst(...)` gaps are counted in these load units, not
+in bytes and not in destination elements. After `pto.fp_load` materializes the
+payload in `scaling`, vector pre-ReLU consumers read it as 64B parameter rows
+and vector pre-quant consumers read it as 128B parameter rows. The payload
+pointer passed to `acc_store*` must point at the first row for the logical
+output tile, and rows must follow the same channel/NZ order consumed by that
+store.
 
 **Constraints:**
 
 - `%src` must be in `mat`, `%dst` must be in `scaling`.
+- Vector `pre_quant` and `pre_relu` consumers require parameter data prepared
+  in the row order documented by [FIXPIPE MTE Ops](#fixpipe-mte-ops).
 
 **Example:**
 
 ```mlir
-pto.fp_load %l1_fp, %fb_fp, %c2_i64 nburst(%c1_i64, %c0_i64, %c0_i64)
-  : !pto.ptr<f32, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+pto.fp_load %l1_fp, %fb_fp, %c2_i64 nburst(%c4_i64, %c0_i64, %c0_i64)
+  : !pto.ptr<f32, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
 ```
 
 ---
+
+### Left / Right Tile Load Model
+
+`pto.left_load` and `pto.right_load` move L1 cube-fractal tiles into the
+compute operand domains. `%src` must already point to an L1 cube-fractal tile;
+these ops do not convert arbitrary row-major matrices. Use
+`pto.cube_load_frac` first when the original data is plain ND/DN layout.
+
+If `transpose = true`, the selected logical source tile is transposed before it
+is placed in the destination operand domain. Omitting the attribute means
+`transpose = false`.
 
 ### `pto.left_load`
 
@@ -526,25 +597,29 @@ pto.fp_load %l1_fp, %fb_fp, %c2_i64 nburst(%c1_i64, %c0_i64, %c0_i64)
 pto.left_load %src, %dst, %m, %k
   : !pto.ptr<T, mat>, !pto.ptr<T, left>, i64, i64
 ```
-- **semantics:** Structured L1-to-L0A wrapper.
+- **semantics:** Load a logical `%m x %k` left tile from L1 `mat` into `left`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | L1 source pointer (`mat`) |
-| `%dst` | ptr | L0A destination pointer (`left`) |
-| `%m` | i64 | M tile size |
-| `%k` | i64 | K tile size |
+| `%src` | ptr | L1 cube-fractal source tile in `mat` |
+| `%dst` | ptr | Left operand destination in `left` |
+| `%m` | i64 | Logical M extent |
+| `%k` | i64 | Logical K extent |
+| `transpose` | attr | Optional boolean source-tile transpose before destination placement |
 
 **Constraints:**
 
 - `%src` must be in `mat`, `%dst` must be in `left`.
+- `%src` and `%dst` must satisfy the target alignment for Cube tile loads.
+- `transpose = true` requires a tile shape supported by the element-type
+  transpose granularity.
 
 **Example:**
 
 ```mlir
-pto.left_load %l1_a, %l0a, %c16_i64, %c16_i64
+pto.left_load %l1_a, %l0a, %c16_i64, %c32_i64
   : !pto.ptr<f16, mat>, !pto.ptr<f16, left>, i64, i64
 ```
 
@@ -557,29 +632,44 @@ pto.left_load %l1_a, %l0a, %c16_i64, %c16_i64
 pto.right_load %src, %dst, %k, %n
   : !pto.ptr<T, mat>, !pto.ptr<T, right>, i64, i64
 ```
-- **semantics:** Structured L1-to-L0B wrapper.
+- **semantics:** Load a logical `%k x %n` right tile from L1 `mat` into
+  `right`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | L1 source pointer (`mat`) |
-| `%dst` | ptr | L0B destination pointer (`right`) |
-| `%k` | i64 | K tile size |
-| `%n` | i64 | N tile size |
+| `%src` | ptr | L1 cube-fractal source tile in `mat` |
+| `%dst` | ptr | Right operand destination in `right` |
+| `%k` | i64 | Logical K extent |
+| `%n` | i64 | Logical N extent |
+| `transpose` | attr | Optional boolean source-tile transpose before destination placement |
 
 **Constraints:**
 
 - `%src` must be in `mat`, `%dst` must be in `right`.
+- `%src` and `%dst` must satisfy the target alignment for Cube tile loads.
+- `transpose = true` requires a tile shape supported by the element-type
+  transpose granularity.
 
 **Example:**
 
 ```mlir
-pto.right_load %l1_b, %l0b, %c16_i64, %c16_i64
+pto.right_load %l1_b, %l0b, %c32_i64, %c16_i64
   : !pto.ptr<f16, mat>, !pto.ptr<f16, right>, i64, i64
 ```
 
 ---
+
+### MX Scale Load Model
+
+MX scale loads prepare the scale payloads consumed by `pto.mad_mx*`. Each scale
+entry applies to one 32-element K group.
+
+- Left scale logical shape: `[M, ceil(K / 32)]`.
+- Right scale logical shape: `[ceil(K / 32), N]`.
+- L1 source data is organized as 32B scale fragments in the same logical order
+  as the associated data tile.
 
 ### `pto.left_load_mx`
 
@@ -588,25 +678,27 @@ pto.right_load %l1_b, %l0b, %c16_i64, %c16_i64
 pto.left_load_mx %src, %dst, %m, %k
   : !pto.ptr<T, mat>, !pto.ptr<T, left>, i64, i64
 ```
-- **semantics:** MX-mode L1-to-L0A wrapper.
+- **semantics:** Load left-side MX scale fragments for a logical `%m x %k`
+  left data tile.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | MX-formatted L1 source pointer (`mat`) |
-| `%dst` | ptr | MX L0A destination pointer (`left`) |
-| `%m` | i64 | M tile size |
-| `%k` | i64 | K tile size |
+| `%src` | ptr | L1 MX scale source in `mat` |
+| `%dst` | ptr | Left-side MX payload destination associated with `left` |
+| `%m` | i64 | M extent of the associated left data tile |
+| `%k` | i64 | K extent; scale grouping is by 32 K elements |
 
 **Constraints:**
 
 - `%src` must be in `mat`, `%dst` must be in `left`.
+- `%src` and `%dst` must satisfy 32B MX scale-fragment alignment.
 
 **Example:**
 
 ```mlir
-pto.left_load_mx %l1_a, %l0a, %c16_i64, %c64_i64
+pto.left_load_mx %l1_a_scale, %l0a_scale, %c16_i64, %c64_i64
   : !pto.ptr<f8E4M3FN, mat>, !pto.ptr<f8E4M3FN, left>, i64, i64
 ```
 
@@ -619,99 +711,293 @@ pto.left_load_mx %l1_a, %l0a, %c16_i64, %c64_i64
 pto.right_load_mx %src, %dst, %k, %n
   : !pto.ptr<T, mat>, !pto.ptr<T, right>, i64, i64
 ```
-- **semantics:** MX-mode L1-to-L0B wrapper.
+- **semantics:** Load right-side MX scale fragments for a logical `%k x %n`
+  right data tile.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | MX-formatted L1 source pointer (`mat`) |
-| `%dst` | ptr | MX L0B destination pointer (`right`) |
-| `%k` | i64 | K tile size |
-| `%n` | i64 | N tile size |
+| `%src` | ptr | L1 MX scale source in `mat` |
+| `%dst` | ptr | Right-side MX payload destination associated with `right` |
+| `%k` | i64 | K extent; scale grouping is by 32 K elements |
+| `%n` | i64 | N extent of the associated right data tile |
 
 **Constraints:**
 
 - `%src` must be in `mat`, `%dst` must be in `right`.
+- `%src` and `%dst` must satisfy 32B MX scale-fragment alignment.
 
 **Example:**
 
 ```mlir
-pto.right_load_mx %l1_b, %l0b, %c64_i64, %c16_i64
+pto.right_load_mx %l1_b_scale, %l0b_scale, %c64_i64, %c16_i64
   : !pto.ptr<f8E4M3FN, mat>, !pto.ptr<f8E4M3FN, right>, i64, i64
 ```
 
 ---
 
+## FIXPIPE MTE Ops
+
+`pto.acc_store*` writes logical accumulator results from `acc` to `mat`, `gm`,
+or `ub`. The family shares this pipeline order:
+
+```text
+1. Read logical acc[m, n] from %src using the selected layout mode.
+2. Optionally participate in consumer-side unit-flag synchronization.
+3. Optionally apply pre_quant(payload, mode).
+4. Optionally apply pre_relu(payload, mode), then optional clip.
+5. Convert to the destination element type using sat/nosat behavior.
+6. Write to the selected destination layout and address space.
+7. Apply store-target effects such as GM atomic or UB dual destination.
+```
+
+Only the clauses documented here affect `pto.acc_store*`. Other transforms
+must be represented by separate PTO ops before producing `acc` or after the
+writeback destination is materialized.
+
+### FIXPIPE Common Clauses
+
+| Clause | Values | Effect |
+|--------|--------|--------|
+| `unit_flag(...)` | `check_only`, `check_and_clear` | Checks that the accumulator tile is ready for consumption. `check_and_clear` also clears the consumed tile state for later reuse. Omit when the schedule does not use unit flags. |
+| `pre_quant(%payload, mode = ...)` | see below | Applies the selected pre-quantization or conversion before ReLU/clip and final store. |
+| `pre_relu([%payload, ]mode = ...[, clip = %clip])` | `no_relu`, `normal_relu`, `scalar_relu`, `vector_relu` | Applies ReLU-family activation before final destination conversion. `clip` is part of this clause and applies after the selected ReLU mode. |
+| `nz2nd` / `nz2dn(...)` / `nz2nz(...)` | layout modes | Selects how logical `acc[m, n]` is written to the destination layout. |
+| `loop3(%count, %src_stride3, %dst_stride3)` | i64 triple | Repeats the whole selected `m x n` writeback pattern. |
+| `sat` / `sat(preserve_nan)` / `nosat` | flags | Selects final conversion behavior for floating exceptional values and finite overflow where the destination type is affected. |
+
+`pre_quant` legal modes:
+
+```text
+f32_f16,
+qf322hif8_pre_vec, qf322hif8_pre_scalar,
+qf322hif8_pre_hybrid_vec, qf322hif8_pre_hybrid_scalar,
+deqs32_int_vec, deqs32_int_scalar,
+req8_vec, req8_scalar,
+deqf16_vec, deqf16_scalar,
+qf322fp8_pre_vec, qf322fp8_pre_scalar,
+qf322f32_pre_vec, qf322f32_pre_scalar,
+f32_bf16,
+qf162b8_pre_vec, qf162b8_pre_scalar,
+qf162s4_pre_vec, qf162s4_pre_scalar,
+req4_vec, req4_scalar,
+qf322b8_pre_vec, qf322b8_pre_scalar,
+qf322s4_pre_vec, qf322s4_pre_scalar,
+deqs16_vec, deqs16_scalar,
+qf162s16_pre_vec, qf162s16_pre_scalar,
+qf322f16_pre_vec, qf322f16_pre_scalar,
+qf322bf16_pre_vec, qf322bf16_pre_scalar,
+qs322bf16_pre_vec, qs322bf16_pre_scalar
+```
+
+`_scalar` modes take one floating scalar payload (`f16`, `bf16`, or `f32`)
+broadcast to the whole logical output tile. `f16` and `bf16` scalar payloads
+are first interpreted as numeric values and widened to `f32`; `f32` payloads
+are used directly. `_vec` modes take a `!pto.ptr<f16|bf16|f32, scaling>`
+payload pointer. The pointer element type is the logical parameter element
+type, not a packed transport carrier. The pointer names the first parameter
+row for this store; later rows
+advance in the same channel/NZ order as the logical accumulator elements
+consumed by the selected layout mode. Each vector pre-quant row is a 128B
+parameter row prepared by `pto.fp_load`; each row supplies the per-channel
+scale and any mode-specific offset/sign controls used by the selected
+quantization family. Vector pre-ReLU rows are 64B parameter rows and supply
+the per-channel alpha values consumed by `vector_relu`.
+
+`pre_quant` mode families:
+
+| Family | Acc source | Result meaning | Payload |
+|--------|------------|----------------|---------|
+| `f32_f16`, `f32_bf16` | `f32` | Convert f32 accumulator values to f16 or bf16; rounding is nearest, ties to even | Scalar payload is required by syntax but does not select per-channel scaling |
+| `qf322hif8_pre_*`, `qf322fp8_pre_*` | `f32` | Scale and quantize f32 to hif8/fp8-style destination payloads | Scalar scale or vector scale rows; hybrid modes use the target hybrid rule |
+| `qf322f32_pre_*` | `f32` | Apply quant scaling while keeping f32 destination values | Scalar scale or vector scale rows |
+| `qf322f16_pre_*`, `qf322bf16_pre_*` | `f32` | Scale f32, then convert to f16 or bf16 destination values | Scalar scale or vector scale rows |
+| `qf322b8_pre_*`, `qf322s4_pre_*` | `f32` | Scale, offset, round, and narrow f32 to 8-bit or signed 4-bit integer payloads | Scalar or vector scale/offset parameter set |
+| `qf162b8_pre_*`, `qf162s4_pre_*` | `f32` | Convert through an f16-domain pre-stage, then scale/narrow to integer payloads | Scalar or vector scale/offset parameter set |
+| `qf162s16_pre_*` | `i32` | Convert through an f16-domain pre-stage, then scale/narrow to signed 16-bit payloads | Scalar or vector scale/offset parameter set |
+| `deqs32_int_*`, `deqs16_*` | `i32` | Rescale integer accumulator values in an integer destination family | Scalar or vector multiplier/offset parameter set |
+| `req8_*`, `req4_*` | `i32` | Requantize i32 accumulator values to 8-bit or 4-bit integer payloads | Scalar or vector multiplier/offset/sign parameter set |
+| `deqf16_*` | `i32` | Dequantize i32 accumulator values to f16 destination values | Scalar or vector multiplier/offset parameter set |
+| `qs322bf16_pre_*` | `i32` | Scale i32 accumulator values and convert to bf16 destination values | Scalar or vector multiplier/offset parameter set |
+
+The mode name determines the accepted accumulator source family. `f32_f16`,
+`f32_bf16`, `qf322hif8_pre_*`, `qf322fp8_pre_*`, `qf322f32_pre_*`,
+`qf322f16_pre_*`, `qf322bf16_pre_*`, `qf322b8_pre_*`,
+`qf322s4_pre_*`, `qf162b8_pre_*`, and `qf162s4_pre_*` consume `f32`
+accumulator values. `deqs32_int_*`, `deqs16_*`, `req8_*`, `req4_*`,
+`deqf16_*`, `qf162s16_pre_*`, and `qs322bf16_pre_*` consume `i32`
+accumulator values. The final destination element type must match the result
+family implied by the mode name; for example, `qf322f16_pre_*` writes an
+f16-family result, while `req8_*` writes an 8-bit integer-family result.
+
+Integer quantization families with `b8` in the name can produce either signed
+8-bit or unsigned 8-bit results according to the sign control carried by the
+scalar or vector parameter set. Families with `s4` or `s16` produce signed
+4-bit or signed 16-bit results. Offset fields are added after scaling and
+before the final narrow/saturate step. When a family has no offset/sign in its
+payload, the payload scale alone controls the conversion.
+
+`pre_relu` semantics:
+
+```text
+no_relu:      y = x
+normal_relu:  y = max(x, 0)
+scalar_relu:  y = x >= 0 ? x : alpha * x
+vector_relu:  y = x >= 0 ? x : alpha[channel] * x
+```
+
+`scalar_relu` takes a floating scalar payload (`f16`, `bf16`, or `f32`) and
+broadcasts it to all negative values in the logical tile. `vector_relu` takes
+a `!pto.ptr<f16|bf16|f32, scaling>` pointer whose elements are per-channel
+alpha values and whose 64B rows follow the same channel/NZ order as the store.
+`no_relu` and `normal_relu` do not take a payload. If
+`clip = %clip` is present:
+
+```text
+y = min(y, clip)
+```
+
+`sat`, `sat(preserve_nan)`, and `nosat` control final conversion to destination
+element types affected by FIXPIPE saturation:
+
+- `sat`: finite overflow clamps to the destination finite range; `+/-inf`
+  clamps to finite extrema; `nan` writes as 0.
+- `sat(preserve_nan)`: same finite overflow and infinity handling as `sat`,
+  but NaN writes as NaN when the destination format can represent NaN. This is
+  intended for fp8 and hif8 destination families; for formats without a NaN
+  encoding it is equivalent to `sat`.
+- `nosat`: finite overflow may produce destination exceptional values;
+  exceptional input values are preserved where the destination format supports
+  them.
+- For fp8 and hif8 destination families, `nosat` preserves NaN; overflow
+  becomes the destination exceptional value when the destination encoding
+  supports it.
+- For integer destination families, `sat`/`nosat` is not the integer overflow
+  policy; integer narrowing and clipping are determined by the selected
+  pre-quant mode, its payload, and any `clip` clause.
+- For `f32` destinations, floating exceptional values are preserved; `sat`
+  does not force f32 `inf`/`nan` into finite values.
+
+### FIXPIPE Layout Model
+
+`%src` points to the base accumulator tile. `%m` and `%n` select the logical
+result rectangle to write. If the physical accumulator tile contains dummy rows
+or lanes outside that rectangle, they are not written to the destination.
+
+Layout modes:
+
+| Mode | Destination layout | Extra operand |
+|------|--------------------|---------------|
+| omitted | Normal target-profile writeback layout | none |
+| `nz2nd` | Logical ND order | none |
+| `nz2dn(%loop0_src_stride)` | Logical D/N-swapped order | `%loop0_src_stride` in C0-size units |
+| `nz2nz(%split)` | NZ-style destination | `%split`, destination split point |
+
+`%src_stride` is measured in C0-size units and advances the accumulator source
+between adjacent source groups selected by the layout mode. `%dst_stride` is
+measured in destination elements and advances the destination row/group
+selected by the layout mode. In `loop3`, `%src_stride3` is in C0-size units and
+`%dst_stride3` is in destination elements.
+
+Reference semantics:
+
+```text
+repeat_count = loop3.count if loop3 is present else 1
+
+for r in 0 .. repeat_count-1:
+  src_r = src + r * loop3.src_stride * 32
+  dst_r = dst + r * loop3.dst_stride * sizeof(dst_element)
+
+  for m in 0 .. M-1:
+    for n in 0 .. N-1:
+      x = read_acc_logical(src_r, m, n, src_stride, layout_mode)
+
+      if pre_quant:
+        x = apply_pre_quant(x, payload, mode)
+
+      if pre_relu:
+        x = apply_pre_relu(x, payload, mode)
+        if clip:
+          x = min(x, clip)
+
+      y = convert_to_destination_type(x, sat_or_nosat)
+      write_destination(dst_r, y, m, n, dst_stride, layout_mode)
+```
+
+When no layout clause is present, the store uses the target-profile normal
+writeback layout for the destination address space. This mode performs no
+explicit ND/DN/NZ layout transform; `%dst_stride` is still the destination
+start-to-start stride in destination elements for the normal writeback rows or
+groups.
+
+For `nz2nd`, `write_destination` stores logical `y[m, n]` in ND order. For
+`nz2dn`, it stores the same logical result with the D/N dimensions swapped; the
+extra `%loop0_src_stride` selects how the swapped source walk advances through
+the accumulator tile. For `nz2nz`, it preserves NZ-style destination packing
+and uses `%split` as the destination split point.
+
 ### `pto.acc_store`
-
-`pto.acc_store*` 是结构化的 fixpipe 写回族，用来把 `pto.mad*` 产出的 L0C(`acc`) 结果写到不同目标空间。
-从语义上看，这条流水按下面的顺序组织：
-
-1. 读取 `%src` 指向的 L0C 累加结果，并按 `%m/%n` 解释逻辑输出区域。
-2. 如指定 `unit_flag(...)`，在消费这次 L0C 结果前执行完成态检查；`check_and_clear` 还会在消费后清除该完成态，便于后续下一轮生产/消费配对。
-3. 如指定 `pre_quant(%payload, mode = ...)`，先对 L0C 元素做预量化。这里的 `%payload` 是该量化模式所需的标量参数或 scaling 指针；标量模式允许直接传 `f16`、`bf16`、`f32`，向量模式要求 `scaling` 指针。
-4. 如指定 `pre_relu(...)`，在写回前对结果做 ReLU 预处理。`scalar_relu`/`vector_relu` 需要额外 payload；`normal_relu`/`no_relu` 不接 payload。`scalar_relu` 允许直接传 `f16`、`bf16`、`f32` alpha，`vector_relu` 要求 `scaling` 指针。`clip = %clip` 是 `pre_relu(...)` 子句的一部分，用于在支持的目标元素类型上启用 clip 阶段。
-5. 按 `nz2nd` / `nz2dn` / `nz2nz` 将 L0C 中的 NZ 累加布局转换成目标布局，并结合 `%src_stride`、`%dst_stride` 以及可选 `loop3(...)`/`%loop0_src_stride`/`%split` 控制跨 tile 的遍历方式。
-6. 如指定 `sat`，则在最终写回目标元素类型时启用饱和语义。
-7. 将结果写入目标空间。`acc_store` 写 L1(`mat`)，`acc_store_ub` 写 UB，`acc_store_gm` 写 GM；GM 路径还可额外指定原子更新语义。
 
 - **syntax:**
 ```mlir
 pto.acc_store %src, %dst, %m, %n, %src_stride, %dst_stride
     [, unit_flag(check_only | check_and_clear)]?
     [, pre_quant(%payload, mode = <quant_pre_mode>)]?
-    [, pre_relu(%payload, mode = <relu_pre_mode> [, clip = %clip])]?
+    [, pre_relu([%payload, ]mode = <relu_pre_mode> [, clip = %clip])]?
     [, nz2nd | nz2dn(%loop0_src_stride) | nz2nz(%split)?]
     [, loop3(%count, %src_stride3, %dst_stride3)]?
-    [, sat]?
+    [, sat | sat(preserve_nan) | nosat]?
   : ...
 ```
-- **semantics:** Structured L0C (`acc`) to L1 (`cbuf`) wrapper.
+- **semantics:** FIXPIPE writeback from `acc` to L1 `mat`.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | buffer-like | L0C source buffer (`acc`)，可为 typed `!pto.ptr` 或等价 memref |
-| `%dst` | buffer-like | L1 destination buffer (`mat`)，可为 typed `!pto.ptr` 或等价 memref |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%src_stride` | i64 | 源 NZ 布局在 fixpipe 写回过程中的主 stride 参数 |
-| `%dst_stride` | i64 | 目标布局在 fixpipe 写回过程中的主 stride 参数 |
-| `unit_flag(...)` | optional clause | 是否在消费这次 L0C 结果前检查完成态；`check_and_clear` 还会在消费后清除完成态 |
-| `pre_quant(%payload, mode = ...)` | optional clause | 写回前的预量化；payload 为该量化模式需要的浮点标量或 `scaling` 指针 |
-| `pre_relu(..., mode = ...[, clip = %clip])` | optional clause | 写回前的 ReLU 预处理；`clip` 只能作为 `pre_relu` 的一部分出现 |
-| `nz2nd` / `nz2dn(%loop0_src_stride)` / `nz2nz(%split)?` | mode clause | L0C NZ 布局到目标布局的写回模式 |
-| `loop3(%count, %src_stride3, %dst_stride3)` | optional i64 triple | 额外的外层重复写回控制，用于跨 tile 迭代 |
-| `sat` | optional flag | 最终写回到目标元素类型时启用饱和语义 |
+| `%src` | buffer-like | Accumulator source in `acc` |
+| `%dst` | buffer-like | L1 destination in `mat` |
+| `%m` | i64 | Logical M element count |
+| `%n` | i64 | Logical N element count |
+| `%src_stride` | i64 | Source stride in C0-size units |
+| `%dst_stride` | i64 | Destination stride in destination elements |
+| optional clauses | - | See [FIXPIPE Common Clauses](#fixpipe-common-clauses) and [FIXPIPE Layout Model](#fixpipe-layout-model) |
 
 **Constraints:**
 
-- 子句顺序固定为 `unit_flag` -> `pre_quant` -> `pre_relu` -> `mode` -> `loop3` -> `sat`。
-- `pre_quant` 必须同时提供 payload 和 `mode`。
-- `pre_quant` 仅支持 L0C 源元素类型为 `f32` 或 `i32`。
-- 标量 `pre_quant` 模式要求 payload 为 `f16`/`bf16`/`f32` 标量；其中 `f16`/`bf16` 会在 lowering 中先扩成 `f32`，再以 32-bit 浮点 bit pattern 形式配置到 fixpipe 标量参数寄存器。向量 `pre_quant` 模式要求 `scaling !pto.ptr<ui64>` payload。
-- `pre_relu` 的 payload 规则取决于 `mode`：
-  - `no_relu` / `normal_relu` 不接受 payload。
-  - `scalar_relu` 要求 payload 为 `f16`/`bf16`/`f32` 标量；其中 `f16`/`bf16` 会在 lowering 中先扩成 `f32`，再以 32-bit 浮点 bit pattern 形式配置到 fixpipe 标量参数寄存器。
-  - `vector_relu` 要求 `scaling !pto.ptr<ui64>` payload。
-- `clip` 只能出现在 `pre_relu(...)` 中。
-- `clip` 仅支持目标元素类型为 `f16`、`ui8`、或有符号 `i4/i8/i16`。
-- `clip` payload 必须与目标元素类型匹配：
-  - `f16` 目标要求 `f16` payload。
-  - `ui8` 目标要求 `ui16` 风格的 16-bit payload；在 PTO IR 中通常写成 `signless i16`。
-  - 有符号 `i4/i8/i16` 目标要求有符号或 signless 的 `i4/i8/i16` payload。
-- `loop3(...)` 必须三个操作数同时提供。
-- `nz2dn` 必须提供 `%loop0_src_stride`；`nz2nd`/`nz2nz` 不接受它。
-- 当 `nz2dn(%loop0_src_stride)` 中 `%loop0_src_stride != 1` 时，`unit_flag` 必须关闭。
-- `nz2nz` 不接受 `loop3(...)`，且目标元素类型必须是 `f32`。
+- Clauses must appear in canonical order:
+  `unit_flag` -> `pre_quant` -> `pre_relu` -> layout -> `loop3` -> `sat`/`nosat`.
+- `pre_quant` requires payload and mode together.
+- Vector `pre_quant` modes require a `scaling` pointer with `f16`, `bf16`, or
+  `f32` element type.
+- Scalar `pre_quant` modes require an `f16`, `bf16`, or `f32` scalar payload.
+- `pre_quant` source element type must be `f32` or `i32`, and the selected
+  mode must be compatible with the source and destination element types.
+- `no_relu` and `normal_relu` do not accept a payload.
+- `scalar_relu` requires an `f16`, `bf16`, or `f32` scalar payload.
+- `vector_relu` requires a `scaling` pointer with `f16`, `bf16`, or `f32`
+  element type.
+- `clip` can appear only inside `pre_relu(...)`.
+- `clip` is supported for destination `f16`, `ui8`, and signed/signless
+  4/8/16-bit integer destinations. The clip payload must match the destination
+  family: `f16` for f16, 16-bit unsigned/signless payload for `ui8`, and
+  signed/signless `i4/i8/i16` for signed integer destinations.
+- `nz2dn` requires `%loop0_src_stride`; `nz2nd` and `nz2nz` do not accept it.
+- `unit_flag` must be omitted when `nz2dn(%loop0_src_stride)` uses a value
+  other than 1.
+- `nz2nz` requires `f32` destination element type and does not accept `loop3`.
+- `sat`, `sat(preserve_nan)`, and `nosat` are mutually exclusive.
 
 **Example:**
 
 ```mlir
-pto.acc_store %l0c, %l1_out, %c16_i64, %c16_i64, %c16_i64, %c16_i64, nz2dn(%c64_i64), loop3(%c3_i64, %c4_i64, %c5_i64)
-  : !pto.ptr<f32, acc>, !pto.ptr<f32, mat>, i64, i64, i64, i64, i64, i64, i64, i64
+pto.acc_store %l0c, %l1_out, %c16_i64, %c32_i64, %c16_i64, %c32_i64,
+  pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
+  pre_relu(%c025_f32, mode = scalar_relu),
+  nz2nd,
+  sat
+  : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64, f32, f32
 ```
 
 ---
@@ -723,41 +1009,59 @@ pto.acc_store %l0c, %l1_out, %c16_i64, %c16_i64, %c16_i64, %c16_i64, nz2dn(%c64_
 pto.acc_store_gm %src, %dst, %m, %n, %src_stride, %dst_stride, %sid, %l2_cache_ctrl
     [, unit_flag(check_only | check_and_clear)]?
     [, pre_quant(%payload, mode = <quant_pre_mode>)]?
-    [, pre_relu(%payload, mode = <relu_pre_mode> [, clip = %clip])]?
+    [, pre_relu([%payload, ]mode = <relu_pre_mode> [, clip = %clip])]?
     [, nz2nd | nz2dn(%loop0_src_stride) | nz2nz(%split)?]
     [, loop3(%count, %src_stride3, %dst_stride3)]?
-    [, sat]?
+    [, sat | sat(preserve_nan) | nosat]?
     [, atomic(type = <atomic_type>, op = <atomic_op>)]?
   : ...
 ```
-- **semantics:** Structured L0C (`acc`) to GM wrapper.
+- **semantics:** FIXPIPE writeback from `acc` to GM. The data transform clauses
+  match `pto.acc_store`; GM-specific operands select the GM write path and
+  optional atomic update behavior.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | buffer-like | L0C source buffer (`acc`)，可为 typed `!pto.ptr` 或等价 memref |
-| `%dst` | buffer-like | GM destination buffer，可为 typed `!pto.ptr` 或等价 memref |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%src_stride` | i64 | 源 NZ 布局在 fixpipe 写回过程中的主 stride 参数 |
-| `%dst_stride` | i64 | 目标布局在 fixpipe 写回过程中的主 stride 参数 |
-| `%sid` | i64 | GM 写回使用的 stream/session 标识参数 |
-| `%l2_cache_ctrl` | i64 | GM 路径的 L2 cache 策略参数 |
-| (optional clauses) | — | 与 `pto.acc_store` 相同的语义子句，外加 GM 独有的 `atomic(...)` |
+| `%src`, `%m`, `%n`, `%src_stride` | - | Same as `pto.acc_store` |
+| `%dst` | buffer-like | GM destination |
+| `%dst_stride` | i64 | GM destination stride in destination elements |
+| `%sid` | i64 | GM stream/session hint for the OUT/GM path; does not change written values |
+| `%l2_cache_ctrl` | i64 | GM store cache hint; does not change written values |
+| `atomic(type = ..., op = ...)` | clause | Optional GM read-modify-write |
+| other optional clauses | - | Same as `pto.acc_store` |
+
+`%sid` and `%l2_cache_ctrl` affect the memory path only. They do not change
+the logical result, destination layout, numeric conversion, or atomic
+operation. For target-profile GM writeback, constant `%sid` values must be in
+`[0, 3]`; use `0` unless the surrounding memory system deliberately assigns a
+different stream/session hint. Constant `%l2_cache_ctrl` values must fit in the
+target cache-control hint range `[0, 15]`.
+
+`atomic(type = T, op = add|max|min)` performs an atomic read-modify-write at
+each GM destination element. `add` accumulates the converted value into the
+existing GM value. `max` and `min` compare using `T` and write the selected
+value. Supported atomic types are `f32`, `f16`, `bf16`, `s32`, `s16`, and `s8`.
 
 **Constraints:**
 
-- GM output path controls (`sid`, `l2_cache_ctrl`) must be provided.
-- `atomic(type = ..., op = ...)` 只允许出现在 `pto.acc_store_gm`。
-- `atomic` 必须同时提供 `type` 和 `op`。
-- 当前 `op` 取值为 `add` / `max` / `min`；`type` 取值为 `f32` / `f16` / `bf16` / `s32` / `s16` / `s8`。
+- `atomic(...)` is valid only on `pto.acc_store_gm`.
+- `atomic` requires both `type` and `op`.
+- Atomic op values are `add`, `max`, and `min`.
+- If `%sid` or `%l2_cache_ctrl` is a constant, it must be in the target range
+  described above.
+- Other constraints match `pto.acc_store`.
 
 **Example:**
 
 ```mlir
-pto.acc_store_gm %l0c, %c_gm, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %c0_i64, nz2nd
-  : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64
+pto.acc_store_gm %l0c, %out, %c16_i64, %c32_i64, %c16_i64, %c32_i64,
+  %c0_i64, %c0_i64,
+  pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
+  nz2nd,
+  atomic(type = f16, op = add)
+  : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64, f32
 ```
 
 ---
@@ -766,38 +1070,96 @@ pto.acc_store_gm %l0c, %c_gm, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %
 
 - **syntax:**
 ```mlir
-pto.acc_store_ub %src, %dst, %m, %n, %src_stride, %dst_stride, %dual_dst_mode, %sub_blockid
+pto.acc_store_ub %src, %dst, %m, %n, %src_stride, %dst_stride,
+    dst_mode(%sub_blockid | split_m | split_n)
     [, unit_flag(check_only | check_and_clear)]?
     [, pre_quant(%payload, mode = <quant_pre_mode>)]?
-    [, pre_relu(%payload, mode = <relu_pre_mode> [, clip = %clip])]?
+    [, pre_relu([%payload, ]mode = <relu_pre_mode> [, clip = %clip])]?
     [, nz2nd | nz2dn(%loop0_src_stride) | nz2nz(%split)?]
     [, loop3(%count, %src_stride3, %dst_stride3)]?
-    [, sat]?
+    [, sat | sat(preserve_nan) | nosat]?
   : ...
 ```
-- **semantics:** Structured L0C (`acc`) to UB wrapper.
+- **semantics:** FIXPIPE writeback from `acc` to UB. The data transform clauses
+  match `pto.acc_store`; UB-specific operands select single or dual destination
+  behavior.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | buffer-like | L0C source buffer (`acc`)，可为 typed `!pto.ptr` 或等价 memref |
-| `%dst` | buffer-like | UB destination buffer，可为 typed `!pto.ptr` 或等价 memref |
-| `%m` | i64 | M size |
-| `%n` | i64 | N size |
-| `%src_stride` | i64 | 源 NZ 布局在 fixpipe 写回过程中的主 stride 参数 |
-| `%dst_stride` | i64 | 目标布局在 fixpipe 写回过程中的主 stride 参数 |
-| `%dual_dst_mode` | i64 | UB 路径的双目标写回模式参数 |
-| `%sub_blockid` | i64 | UB 路径的子块选择参数 |
-| (optional clauses) | — | 与 `pto.acc_store` 相同，但不支持 `atomic(...)` |
+| `%src`, `%m`, `%n`, `%src_stride` | - | Same as `pto.acc_store` |
+| `%dst` | buffer-like | UB destination |
+| `%dst_stride` | i64 | UB destination stride in destination elements |
+| `dst_mode(%sub_blockid)` | i64 operand | Single-destination mode. `%sub_blockid` selects UB sub-block `0` or `1`; the value may be dynamic. |
+| `dst_mode(split_m)` | keyword | Dual-destination mode that splits the logical tile along M. |
+| `dst_mode(split_n)` | keyword | Dual-destination mode that splits the logical tile along N. |
+| optional clauses | - | Same as `pto.acc_store`; `atomic(...)` is not supported |
+
+In `dst_mode(%sub_blockid)`, the whole logical result tile is written to the
+selected UB sub-block using the selected layout mode and `%dst` as that
+sub-block's base destination pointer.
+
+In `dst_mode(split_m)`, the logical tile is split into two M ranges:
+`[0, m/2)` and `[m/2, m)`. The first range is written to UB sub-block 0 and the
+second range is written to UB sub-block 1. Each sub-block sees its own
+destination origin at `%dst`; within each sub-block, the written logical tile
+has shape `(m / 2) x n`.
+
+In `dst_mode(split_n)`, the logical tile is split into two N ranges:
+`[0, n/2)` and `[n/2, n)`. The first range is written to UB sub-block 0 and the
+second range is written to UB sub-block 1. Each sub-block sees its own
+destination origin at `%dst`; within each sub-block, the written logical tile
+has shape `m x (n / 2)`.
 
 **Constraints:**
 
-- 不支持 `atomic(...)`。
+- `atomic(...)` is not supported.
+- `dst_mode(%sub_blockid)` writes the whole logical tile to one UB sub-block.
+  Runtime `%sub_blockid` values must be `0` or `1`; constant values are checked
+  statically when available.
+- `dst_mode(split_m)` splits the logical tile along M into two equal-height
+  sub-block regions. `%m` must be even; each sub-block receives an
+  `(m / 2) x n` tile.
+- `dst_mode(split_n)` splits the logical tile along N into two equal-width
+  sub-block regions. `%n` must be a multiple of 32; each sub-block receives an
+  `m x (n / 2)` tile.
+- Dual-destination split modes are valid only for target-supported normal or
+  `nz2nd` writeback cases with pre-quant, pre-ReLU/clip, and other transform
+  clauses omitted.
+- Other constraints match `pto.acc_store`.
 
 **Example:**
 
 ```mlir
-pto.acc_store_ub %l0c, %ub_out, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %c0_i64, nz2nd
-  : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64
+pto.acc_store_ub %l0c, %ub_out, %c16_i64, %c32_i64, %c16_i64, %c32_i64,
+  dst_mode(%c1_i64),
+  nz2nd
+  : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
 ```
+
+---
+
+## Typical Usage / Patterns
+
+A common Cube matmul flow is:
+
+```text
+GM row/column-major data
+  -> pto.cube_load_frac or pto.cube_load into L1 mat
+  -> pto.left_load / pto.right_load into left/right tiles
+  -> pto.mad* produces acc tile
+  -> pto.acc_store* writes L1, GM, or UB with optional FIXPIPE transforms
+```
+
+For MX matmul, load the data tiles and the matching MX scale payloads before
+calling `pto.mad_mx*`:
+
+```text
+left data tile + left scale payload
+right data tile + right scale payload
+  -> pto.mad_mx*
+```
+
+For bias matmul, prepare the `bias[N]` vector with `pto.bias_load` before the
+`pto.mad_bias` / `pto.mad_mx_bias` consumer.

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -10,11 +10,11 @@
 
 ### Overview
 
-This document defines the PTO micro Instruction, a compiler-internal and externally facing specification designed to represent vector compute kernels within the PTO architecture. Much like NVVM provides a robust IR for GPU architectures, the PTO micro Instruction serves as the direct bridge between high-level programming models and the underlying hardware ISA, providing a precise, low-level representation of vector workloads explicitly designed for the Ascend 950 architecture.
+This document defines the PTO micro Instruction, a compiler-internal and externally facing specification designed to represent vector compute kernels within the PTO architecture. Much like NVVM provides a robust IR for GPU architectures, the PTO micro Instruction serves as the direct bridge between high-level programming models and the underlying hardware ISA, providing a precise, architecture-aware representation of vector workloads explicitly designed for the Ascend 950 architecture.
 
 #### Position in the Stack and Layer Modeled
 
-The PTO micro Instruction operates as a very low-level intermediate representation within the PTO compiler stack. It is uniquely designed to accurately and comprehensively express all architectural information of the Ascend 950 hardware. It specifically models the bare-metal vector execution layer, making hardware-specific capabilities and constraints, such as exact vector lane configurations, memory space hierarchies, and hardware-specific fusion semantics, fully transparent and controllable.
+The PTO micro Instruction operates as an explicit intermediate representation within the PTO compiler stack. It is designed to accurately express the user-visible architectural information needed for Ascend 950 kernels, including vector lane organization, memory space hierarchy, synchronization, and hardware-specific fusion semantics.
 
 #### PTO Instruction Modes and Compilation Flows
 
@@ -149,8 +149,7 @@ The PTO micro Instruction enforces a strict memory hierarchy. The Unified Buffer
 
 The grouped DMA surface in this specification covers `pto.dma_load`
 (GM→UB), `pto.dma_store` (UB→GM), and `pto.dma_copy`
-(UB→UB or UB→CBUF). Low-level raw copy families remain available with
-separate operand contracts.
+(UB→UB or UB→CBUF).
 
 **Load/Store Access Patterns**:
 
@@ -401,16 +400,16 @@ AIV1's UB simultaneously, with the tile split in hardware along either the row a
 This 1→2 broadcast with in-hardware tile split is the architectural basis for 1:2
 Cube-to-Vector tile distribution.
 
-##### V→C: Vector UB → Cube L1 (TMOV ub2l1)
+##### V→C: Vector UB → Cube L1
 
-The reverse path uses `TMOV ub2l1` to transfer data from a Vector block's UB into Cube's L1
-buffer. A key architectural constraint: Cube's L1 stores tiles in **NZ fractal layout** (e.g.
+The reverse path transfers data from a Vector block's UB into Cube's L1 buffer.
+A key architectural constraint: Cube's L1 stores tiles in **NZ fractal layout** (e.g.
 `K1M1M0K0` — for fp16: `K0=16`, `M0=16`) so they can be loaded into L0A/L0B for MMAD
 computation. Since Vector produces tiles in **ND layout**, the layout conversion from ND to NZ
 must be applied as part of the V→C transfer:
 
 ```
-Vector UB  (ND layout)  ──[TMOV ub2l1, ND→NZ]──▶  Cube L1  (NZ K1M1M0K0)
+Vector UB  (ND layout)  ──[ND→NZ movement]──▶  Cube L1  (NZ K1M1M0K0)
 ```
 
 For 1:2 mode, both AIV0 and AIV1 each transfer a sub-tile into Cube's L1. The two sub-tiles are
@@ -453,8 +452,8 @@ Physical layout: K1 x M1 x M0 x K0  (last dimension contiguous)
 
 | Buffer | Logical shape | Physical NZ layout | Notes |
 |--------|--------------|-------------------|-------|
-| L1 (cbuf) - Tensor A | `[M, K]` | `K1 M1 M0 K0` | `pto.copy_gm_to_cbuf_multi_nd2nz` of row-major A |
-| L1 (cbuf) - Tensor B | `[K, N]` | `K1 N1 K0 N0` | `pto.copy_gm_to_cbuf_multi_nd2nz` of row-major B |
+| L1 (cbuf) - Tensor A | `[M, K]` | `K1 M1 M0 K0` | Row-major A staged into NZ layout |
+| L1 (cbuf) - Tensor B | `[K, N]` | `K1 N1 K0 N0` | Row-major B staged into NZ layout |
 | L0A (left operand)   | -        | `K1 M1 M0 K0` | FRACTAL_NZ (A5) / FRACTAL_ZZ (A3): same NZ order as L1 cbuf |
 | L0B (right operand)  | -        | `K1 N1 N0 K0` | FRACTAL_ZN: row-major outer, col-major inner (K0 innermost) |
 | L0C (accumulator)    | `[M, N]` | `N1 M1 M0 N0` | output of MMAD (FRACTAL_NZ: col-major outer, row-major inner) |
@@ -483,7 +482,7 @@ row|   +--------------------+         row|   +--------------------+
 
 STEP 2 - GM -> L1 (cbuf): NDtoNZ fractal repack
 -------------------------------------------------
- op: pto.copy_gm_to_cbuf_multi_nd2nz  (A and B; use pto.copy_gm_to_cbuf_multi_dn2nz only for pre-transposed B)
+ Use the structured cube load surface to stage row-major A and B into L1 NZ layout.
 
  A in L1: K1 x M1 x M0 x K0          B in L1: K1 x N1 x K0 x N0
  For each outer block (k1, m1):       For each outer block (k1, n1):
@@ -500,29 +499,23 @@ STEP 2 - GM -> L1 (cbuf): NDtoNZ fractal repack
 
 
 
- NOTE: For GEMM (row-major A/B), prefer pto.copy_gm_to_cbuf_multi_nd2nz for both A and B.
-   pto.copy_gm_to_cbuf_multi_dn2nz is intended for NCHW-layout inputs (e.g. convolution)
-   where the data is already transposed in GM. Using dn2nz for row-major B forces
-   non-contiguous GM access (striding across N to gather K), which hurts burst BW.
-   The B fractal transpose for cube compatibility is done at STEP 3 (L1->L0B).
-   Note: A2/A3 does not have dn2nz, so using nd2nz only is backward compatible
-   across all generations.
+ NOTE: For GEMM with row-major A/B, stage both operands from GM to L1 as
+   logical ND-to-NZ movement. If the source is already in a transposed logical
+   layout, express that at the structured load level instead of relying on a
+   later interpretation of the same bytes.
 
 
 STEP 3 - L1 -> L0A / L0B
 --------------------------
- ops: pto.load_cbuf_to_ca  (no transpose)
-      pto.load_cbuf_to_cb  (transpose via load_2d_v2)
-
- L0A: cbuf K1 M1 M0 K0 -(load_cbuf_to_ca)-> L0A K1 M1 M0 K0  (FRACTAL_NZ on A5)
- L0B: cbuf K1 N1 K0 N0 --(TMOV/ZN)---> L0B K1 N1 N0 K0  (FRACTAL_ZN, K0 innermost)
+ L0A: cbuf K1 M1 M0 K0 --left_load-->  L0A K1 M1 M0 K0  (FRACTAL_NZ on A5)
+ L0B: cbuf K1 N1 K0 N0 --right_load--> L0B K1 N1 N0 K0  (FRACTAL_ZN, K0 innermost)
 
  Why transpose at L1->L0B and not at GM->L1?
  --------------------------------------------
  The cube reduction axis is K. L0B requires K innermost (N1 K1 K0 N0)
  so the cube hardware reads all K0 elements per cycle without striding.
- The inner-box transpose is performed on-the-fly by the MTE hardware
- during the L1->L0B transfer itself — no extra pass required.
+ The inner-box transpose is performed as part of the structured right-load
+ movement itself; no separate user-visible pass is required.
  Each 512B fractal z-block is permuted as it moves from L1 to L0B.
 
   L0A tile (cube LEFT port):           L0B tile (cube RIGHT port):
@@ -548,21 +541,19 @@ STEP 4 - L0C output layout: N1 M1 M0 N0
   +------------------------------+
   Physical: C_nz[n1][m1][m0][n0]  ->  C_nd[m1*M0+m0][n1*N0+n0]
 
-  Writeback: pto.copy_matrix_cc_to_gm   (FRACTAL_NZ -> ND, normal output)
-             pto.copy_matrix_cc_to_cbuf  (stays FRACTAL_NZ, for fused ops)
-             pto.copy_matrix_cc_to_ub    (FRACTAL_NZ -> ND to UB, A5 only;
-                                          used in fixed-point (fixp) datapath)
+  Writeback: FIXPIPE MTE ops convert the L0C NZ result to the requested
+             destination layout and memory space.
 
 
 Full pipeline summary
 ----------------------
   GM (ND)          L1/cbuf (NZ)            L0A/B (NZ)          L0C (NZ)    GM (ND)
 
-  A[M,K] -nd2nz(copy_gm_to_cbuf_multi_nd2nz)-> K1 M1 M0 K0 --load_cbuf_to_ca-> K1 M1 M0 K0 -+
+  A[M,K] --cube_load_frac/cube_load--> K1 M1 M0 K0 --left_load-->  K1 M1 M0 K0 -+
                                                                +-MAD-> N1 M1 M0 N0 --> C[M,N]
-  B[K,N] -nd2nz(copy_gm_to_cbuf_multi_nd2nz)-> K1 N1 K0 N0 --load_cbuf_to_cb-> K1 N1 N0 K0 -+
+  B[K,N] --cube_load_frac/cube_load--> K1 N1 K0 N0 --right_load--> K1 N1 N0 K0 -+
                                  ^
-                      transpose at L1->L0B (load_cbuf_to_cb, load_2d_v2)
+                      transpose as part of right_load when requested
                       NOT at GM->L1
 ```
 
@@ -1162,7 +1153,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 10 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4`, `pto.get_vms4_sr` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
-| 16 | [Cube Matrix Multiply (MAT)](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`cbuf`) staging, L1 (`cbuf`)↔UB side moves, L1→L0A/L0B loads, L0C (`acc`) matmul, and wrapper bridge load/store ops | 16+ | `pto.copy_gm_to_cbuf`, `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz`, `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb`, `pto.load_cbuf_to_ca_mx`, `pto.load_cbuf_to_cb_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.copy_matrix_cc_to_gm`, `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub`, `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf`, `pto.cube_load`, `pto.cube_store`, `pto.cube_load_frac`, `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx`, `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |
+| 16 | [Cube Matrix Multiply (MAT)](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`cbuf`) staging, L1 (`cbuf`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`acc`) matmul, and FIXPIPE MTE writeback | 19 | `pto.cube_load`, `pto.cube_store`, `pto.cube_load_frac`, `pto.bias_load`, `pto.fp_load`, `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |
 
 ---
 
@@ -1175,20 +1166,12 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | GM→UB DMA | 2 | `pto.dma_load` |
 | UB→GM DMA | 2 | `pto.dma_store` |
 | UB→UB / UB→CBUF copy | 2 | `pto.dma_copy` |
-| GM→L1 | 16 | `pto.copy_gm_to_cbuf` |
-| GM→L1 | 16 | `pto.copy_gm_to_cbuf_multi_nd2nz`, `pto.copy_gm_to_cbuf_multi_dn2nz` |
 | GM→L1 | 16 | `pto.cube_load`, `pto.cube_load_frac` |
-| L1→UB bridge wrapper | 16 | `pto.cube_store` |
-| L1→BT (bridge wrapper) | 16 | `pto.bias_load` |
-| L1→FB (bridge wrapper) | 16 | `pto.fp_load` |
-| L1→L0A / L1→L0B | 16 | `pto.load_cbuf_to_ca`, `pto.load_cbuf_to_cb` |
-| L1→L0A / L1→L0B bridge wrapper | 16 | `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx` |
-| L0C→GM cube writeback | 16 | `pto.copy_matrix_cc_to_gm` |
-| L0C→L1 bridge wrapper | 16 | `pto.acc_store` |
-| L0C→GM bridge wrapper | 16 | `pto.acc_store_gm` |
-| L0C→UB bridge wrapper | 16 | `pto.acc_store_ub` |
-| L0C→L1 / L0C→UB | 16 | `pto.copy_matrix_cc_to_cbuf`, `pto.copy_matrix_cc_to_ub` |
-| L1→BT / L1→FB | 16 | `pto.copy_cbuf_to_bt`, `pto.copy_cbuf_to_fbuf` |
+| L1→UB | 16 | `pto.cube_store` |
+| L1→BT | 16 | `pto.bias_load` |
+| L1→FB | 16 | `pto.fp_load` |
+| L1→L0A / L1→L0B | 16 | `pto.left_load`, `pto.right_load`, `pto.left_load_mx`, `pto.right_load_mx` |
+| L0C→L1 / GM / UB (FIXPIPE MTE) | 16 | `pto.acc_store`, `pto.acc_store_gm`, `pto.acc_store_ub` |
 | Contiguous Load | 3 | `pto.vlds` with `NORM` dist |
 | Broadcast Load | 3 | `pto.vlds` with `BRC` family dist |
 | Gather | 3 | `pto.vgather2`, `pto.vgatherb` |
@@ -1238,48 +1221,26 @@ Group 14 covers the full scalar `arith` surface. The rows below list common PTO 
 | Conditional Regions | 15 | `scf.if`, `scf.yield` |
 | Break-like Structured Loops | 15 | `scf.while`, `scf.condition`, `scf.yield` |
 
-### Recent A5 Additions (Implemented)
+### Cube Operation Surface
 
-- `pto.set_quant_pre` (lowered to `llvm.hivm.SET.QUANT.PRE.v300`)
-- `pto.set_atomic_s32`, `pto.set_atomic_s8` (A5-selectable atomic mode controls)
-- Cube-side movement additions:
-  - `pto.copy_gm_to_cbuf_multi_nd2nz`
-  - `pto.copy_gm_to_cbuf_multi_dn2nz`
-  - `pto.copy_matrix_cc_to_cbuf`
-  - `pto.copy_matrix_cc_to_ub`
-  - `pto.copy_cbuf_to_bt`
-  - `pto.copy_cbuf_to_fbuf`
-
-### Verified Op List (Current Batch)
-
-- `pto.copy_cbuf_to_bt`
 - `pto.bias_load`
-- `pto.copy_cbuf_to_fbuf`
-- `pto.copy_gm_to_cbuf_multi_dn2nz`
-- `pto.copy_gm_to_cbuf_multi_nd2nz`
+- `pto.fp_load`
+- `pto.cube_load`
+- `pto.cube_load_frac`
+- `pto.cube_store`
+- `pto.left_load`
+- `pto.right_load`
+- `pto.left_load_mx`
+- `pto.right_load_mx`
 - `pto.mad`
 - `pto.mad_acc`
 - `pto.mad_bias`
 - `pto.mad_mx`
 - `pto.mad_mx_acc`
 - `pto.mad_mx_bias`
-- `pto.copy_matrix_cc_to_cbuf`
-- `pto.copy_matrix_cc_to_ub`
-- `pto.load_cbuf_to_ca_mx`
-- `pto.load_cbuf_to_ca_s4`
-- `pto.load_cbuf_to_cb_mx`
-- `pto.load_cbuf_to_cb_s4`
-- `pto.set_atomic_s32`
-- `pto.set_atomic_s8`
-- `pto.set_channel_para`
-- `pto.set_fpc`
-- `pto.set_loop1_stride_outtol1`
-- `pto.set_loop2_stride_outtol1`
-- `pto.set_loop3_para`
-- `pto.set_loop_size_outtol1`
-- `pto.set_mte2_nz_para`
-- `pto.set_pad_val_outtol1`
-- `pto.set_quant_pre`
+- `pto.acc_store`
+- `pto.acc_store_gm`
+- `pto.acc_store_ub`
 
 ---
 

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -613,6 +613,30 @@ def PTO_AccStoreModeAttr : EnumAttr<PTO_Dialect, PTO_AccStoreModeEnum, "acc_stor
   let summary = "acc_store layout conversion mode";
 }
 
+def PTO_AccStoreUbDstModeEnum : PTO_I32Enum<
+  "AccStoreUbDstMode", "PTO accumulator store UB destination mode", [
+    I32EnumAttrCase<"Single", 0, "single">,
+    I32EnumAttrCase<"SplitM", 1, "split_m">,
+    I32EnumAttrCase<"SplitN", 2, "split_n">
+  ]>;
+
+def PTO_AccStoreUbDstModeAttr
+    : EnumAttr<PTO_Dialect, PTO_AccStoreUbDstModeEnum, "acc_store_ub_dst_mode"> {
+  let summary = "acc_store_ub destination mode attribute";
+}
+
+def PTO_AccStoreSatModeEnum : PTO_I32Enum<
+  "AccStoreSatMode", "PTO accumulator store saturation mode", [
+    I32EnumAttrCase<"Sat", 0, "sat">,
+    I32EnumAttrCase<"NoSat", 1, "nosat">,
+    I32EnumAttrCase<"SatPreserveNan", 2, "sat_preserve_nan">
+  ]>;
+
+def PTO_AccStoreSatModeAttr
+    : EnumAttr<PTO_Dialect, PTO_AccStoreSatModeEnum, "acc_store_sat_mode"> {
+  let summary = "acc_store saturation mode attribute";
+}
+
 def PTO_CubeLoadFracModeEnum : PTO_I32Enum<
   "CubeLoadFracMode", "PTO cube fractal load source layout mode", [
     I32EnumAttrCase<"Nd2nz", 0, "nd2nz">,

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -42,13 +42,12 @@ def PTO_BufferType : Type<
   "pointer-like buffer type">;
 def PTO_ScalingPtrType : Type<
   CPred<"::llvm::isa<::mlir::pto::PtrType>($_self) && "
-        "::llvm::cast<::mlir::pto::PtrType>($_self).getElementType().isUnsignedInteger(64) && "
         "::llvm::cast<::mlir::pto::PtrType>($_self).getMemorySpace().getAddressSpace() == ::mlir::pto::AddressSpace::SCALING">,
-  "scaling !pto.ptr<ui64> type">;
+  "scaling pointer type">;
 def PTO_BufferLikeType : AnyTypeOf<[AnyMemRef, PTO_BufferType],
                                     "memref or pointer-like buffer type">;
 def PTO_AccStorePayloadType : AnyTypeOf<[AnySignlessInteger, AnyFloat, PTO_ScalingPtrType],
-                                        "signless integer, float scalar, or scaling !pto.ptr<ui64>">;
+                                        "signless integer, float scalar, or scaling pointer">;
 def PTO_AccStoreClipPayloadType : AnyTypeOf<[AnyInteger, AnyFloat],
                                             "integer or float clip scalar">;
 
@@ -2191,7 +2190,7 @@ def PTO_AccStoreOp : PTO_Op<"acc_store", [
     OptionalAttr<PTO_ReluPreModeAttr>:$pre_relu_mode,
     OptionalAttr<PTO_AccStoreAtomicTypeAttr>:$atomic_type,
     OptionalAttr<PTO_AccStoreAtomicOpAttr>:$atomic_op,
-    OptionalAttr<UnitAttr>:$sat
+    OptionalAttr<PTO_AccStoreSatModeAttr>:$sat_mode
   );
 
   let results = (outs);
@@ -2227,7 +2226,7 @@ def PTO_AccStoreGmOp : PTO_Op<"acc_store_gm", [
     OptionalAttr<PTO_ReluPreModeAttr>:$pre_relu_mode,
     OptionalAttr<PTO_AccStoreAtomicTypeAttr>:$atomic_type,
     OptionalAttr<PTO_AccStoreAtomicOpAttr>:$atomic_op,
-    OptionalAttr<UnitAttr>:$sat
+    OptionalAttr<PTO_AccStoreSatModeAttr>:$sat_mode
   );
 
   let results = (outs);
@@ -2250,18 +2249,18 @@ def PTO_AccStoreUbOp : PTO_Op<"acc_store_ub", [
     Optional<PTO_AccStorePayloadType>:$pre_quant,
     Optional<PTO_AccStorePayloadType>:$pre_relu,
     Optional<PTO_AccStoreClipPayloadType>:$clip_value,
-    I64:$dual_dst_mode,
-    I64:$sub_blockid,
+    Optional<I64>:$sub_blockid,
     Optional<I64>:$split,
     Optional<I64>:$loop0_src_stride,
     Optional<I64>:$loop3_count,
     Optional<I64>:$loop3_src_stride,
     Optional<I64>:$loop3_dst_stride,
+    PTO_AccStoreUbDstModeAttr:$dst_mode,
     OptionalAttr<PTO_AccStoreModeAttr>:$mode,
     OptionalAttr<PTO_UnitFlagCtrlAttr>:$unit_flag,
     OptionalAttr<PTO_AccStoreQuantPreModeAttr>:$pre_quant_mode,
     OptionalAttr<PTO_ReluPreModeAttr>:$pre_relu_mode,
-    OptionalAttr<UnitAttr>:$sat
+    OptionalAttr<PTO_AccStoreSatModeAttr>:$sat_mode
   );
 
   let results = (outs);

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1638,7 +1638,7 @@ struct StructuredAccStoreAsmState {
   std::optional<AccStoreMode> mode;
   std::optional<AccStoreAtomicType> atomicType;
   std::optional<AccStoreAtomicOp> atomicOp;
-  bool sat = false;
+  std::optional<AccStoreSatMode> satMode;
 
   SmallVector<OpAsmParser::UnresolvedOperand, 1> preQuantOperands;
   SmallVector<OpAsmParser::UnresolvedOperand, 1> preReluOperands;
@@ -1697,15 +1697,21 @@ static bool isStructuredAccStoreVectorQuantMode(AccStoreQuantPreMode mode) {
 static bool isStructuredAccStoreScalingPayload(Value value) {
   auto ptrType = dyn_cast_or_null<PtrType>(value.getType());
   return ptrType &&
-         ptrType.getElementType().isUnsignedInteger(64) &&
          ptrType.getMemorySpace().getAddressSpace() == AddressSpace::SCALING;
 }
 
 static bool isStructuredAccStoreScalingPayloadType(Type type) {
   auto ptrType = dyn_cast_or_null<PtrType>(type);
   return ptrType &&
-         ptrType.getElementType().isUnsignedInteger(64) &&
          ptrType.getMemorySpace().getAddressSpace() == AddressSpace::SCALING;
+}
+
+static Type getStructuredAccStoreScalingElementType(Value value) {
+  auto ptrType = dyn_cast_or_null<PtrType>(value.getType());
+  if (!ptrType ||
+      ptrType.getMemorySpace().getAddressSpace() != AddressSpace::SCALING)
+    return {};
+  return ptrType.getElementType();
 }
 
 static bool isStructuredAccStoreIntegerPayload(Value value) {
@@ -2015,7 +2021,7 @@ static ParseResult parseStructuredAccStoreClauses(
       kind = StructuredAccStoreClauseKind::Layout;
     else if (keyword == "loop3")
       kind = StructuredAccStoreClauseKind::Loop3;
-    else if (keyword == "sat")
+    else if (keyword == "sat" || keyword == "nosat")
       kind = StructuredAccStoreClauseKind::Sat;
     else if (keyword == "atomic")
       kind = StructuredAccStoreClauseKind::Atomic;
@@ -2046,9 +2052,23 @@ static ParseResult parseStructuredAccStoreClauses(
       parseResult = parseStructuredAccStoreLoop3(parser, state);
       break;
     case StructuredAccStoreClauseKind::Sat:
-      if (state.sat)
-        return parser.emitError(parser.getCurrentLocation(), "duplicate sat clause");
-      state.sat = true;
+      if (state.satMode)
+        return parser.emitError(parser.getCurrentLocation(), "duplicate sat/nosat clause");
+      if (keyword == "nosat") {
+        state.satMode = AccStoreSatMode::NoSat;
+        break;
+      }
+      if (succeeded(parser.parseOptionalLParen())) {
+        StringRef satOption;
+        if (parser.parseKeyword(&satOption) || satOption != "preserve_nan")
+          return parser.emitError(parser.getCurrentLocation(),
+                                  "expected preserve_nan");
+        if (parser.parseRParen())
+          return failure();
+        state.satMode = AccStoreSatMode::SatPreserveNan;
+      } else {
+        state.satMode = AccStoreSatMode::Sat;
+      }
       break;
     case StructuredAccStoreClauseKind::Atomic:
       parseResult = parseStructuredAccStoreAtomic(parser, state);
@@ -2094,6 +2114,10 @@ static LogicalResult verifyStructuredAccStoreLike(
     if (isStructuredAccStoreVectorQuantMode(*preQuantMode)) {
       if (!isStructuredAccStoreScalingPayload(preQuant))
         return op->emitOpError("vector pre_quant mode requires scaling pointer payload");
+      if (!isStructuredAccStoreFloatScalarPayloadType(
+              getStructuredAccStoreScalingElementType(preQuant)))
+        return op->emitOpError(
+            "vector pre_quant mode requires scaling pointer element type to be f16, bf16, or f32");
     } else if (!isStructuredAccStoreFloatScalarPayload(preQuant)) {
       return op->emitOpError(
           "scalar pre_quant mode requires f16/bf16/f32 payload");
@@ -2153,6 +2177,10 @@ static LogicalResult verifyStructuredAccStoreLike(
         return op->emitOpError("vector_relu requires payload");
       if (!isStructuredAccStoreScalingPayload(preRelu))
         return op->emitOpError("vector_relu requires scaling pointer payload");
+      if (!isStructuredAccStoreFloatScalarPayloadType(
+              getStructuredAccStoreScalingElementType(preRelu)))
+        return op->emitOpError(
+            "vector_relu requires scaling pointer element type to be f16, bf16, or f32");
       break;
     case ReluPreMode::Pwl:
       return op->emitOpError("pwl is not supported for target_profile acc_store");
@@ -2219,7 +2247,8 @@ static void printStructuredAccStoreClauses(
     std::optional<AccStoreQuantPreMode> preQuantMode, Value preRelu,
     std::optional<ReluPreMode> preReluMode, Value clipValue,
     std::optional<AccStoreMode> mode, Value split, Value loop0SrcStride,
-    Value loop3Count, Value loop3SrcStride, Value loop3DstStride, bool sat,
+    Value loop3Count, Value loop3SrcStride, Value loop3DstStride,
+    std::optional<AccStoreSatMode> satMode,
     std::optional<AccStoreAtomicType> atomicType,
     std::optional<AccStoreAtomicOp> atomicOp) {
   if (unitFlag && *unitFlag != AccStoreUnitFlagCtrl::Off) {
@@ -2262,8 +2291,19 @@ static void printStructuredAccStoreClauses(
     printer << ", loop3(" << loop3Count << ", " << loop3SrcStride << ", "
             << loop3DstStride << ")";
   }
-  if (sat)
-    printer << ", sat";
+  if (satMode) {
+    switch (*satMode) {
+    case AccStoreSatMode::Sat:
+      printer << ", sat";
+      break;
+    case AccStoreSatMode::NoSat:
+      printer << ", nosat";
+      break;
+    case AccStoreSatMode::SatPreserveNan:
+      printer << ", sat(preserve_nan)";
+      break;
+    }
+  }
   if (atomicType && atomicOp) {
     printer << ", atomic(type = " << stringifyAccStoreAtomicType(*atomicType)
             << ", op = " << stringifyAccStoreAtomicOp(*atomicOp) << ")";
@@ -2357,8 +2397,10 @@ static void addStructuredAccStoreAttrs(OperationState &result,
     result.addAttribute("atomic_op",
                         AccStoreAtomicOpAttr::get(builder.getContext(),
                                                   *state.atomicOp));
-  if (state.sat)
-    result.addAttribute("sat", builder.getUnitAttr());
+  if (state.satMode)
+    result.addAttribute("sat_mode",
+                        AccStoreSatModeAttr::get(builder.getContext(),
+                                                 *state.satMode));
 }
 
 static ParseResult resolveStructuredAccStoreOptionalOperands(
@@ -6398,7 +6440,7 @@ void AccStoreOp::print(OpAsmPrinter &printer) {
                                  getPreReluMode(), getClipValue(), getMode(),
                                  getSplit(), getLoop0SrcStride(),
                                  getLoop3Count(), getLoop3SrcStride(),
-                                 getLoop3DstStride(), static_cast<bool>(getSat()),
+                                 getLoop3DstStride(), getSatMode(),
                                  getAtomicType(), getAtomicOp());
   printer.printOptionalAttrDict((*this)->getAttrs(),
                                 /*elidedAttrs=*/{"operandSegmentSizes",
@@ -6408,7 +6450,7 @@ void AccStoreOp::print(OpAsmPrinter &printer) {
                                                  "pre_relu_mode",
                                                  "atomic_type",
                                                  "atomic_op",
-                                                 "sat"});
+                                                 "sat_mode"});
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getM().getType() << ", " << getN().getType() << ", "
           << getSrcStride().getType() << ", " << getDstStride().getType();
@@ -6568,7 +6610,7 @@ void AccStoreGmOp::print(OpAsmPrinter &printer) {
                                  getPreReluMode(), getClipValue(), getMode(),
                                  getSplit(), getLoop0SrcStride(),
                                  getLoop3Count(), getLoop3SrcStride(),
-                                 getLoop3DstStride(), static_cast<bool>(getSat()),
+                                 getLoop3DstStride(), getSatMode(),
                                  getAtomicType(), getAtomicOp());
   printer.printOptionalAttrDict((*this)->getAttrs(),
                                 /*elidedAttrs=*/{"operandSegmentSizes",
@@ -6578,7 +6620,7 @@ void AccStoreGmOp::print(OpAsmPrinter &printer) {
                                                  "pre_relu_mode",
                                                  "atomic_type",
                                                  "atomic_op",
-                                                 "sat"});
+                                                 "sat_mode"});
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getM().getType() << ", " << getN().getType() << ", "
           << getSrcStride().getType() << ", " << getDstStride().getType()
@@ -6619,35 +6661,66 @@ ParseResult AccStoreUbOp::parse(OpAsmParser &parser, OperationState &result) {
   Builder builder(parser.getContext());
   StructuredAccStoreAsmState state;
   OpAsmParser::UnresolvedOperand source, destination, m, n, srcStride,
-      dstStride, dualDstMode, subBlockId;
+      dstStride, subBlockId;
+  bool hasSubBlockId = false;
+  AccStoreUbDstMode dstMode = AccStoreUbDstMode::Single;
   if (parseRequiredOperandWithComma(parser, source) ||
       parseRequiredOperandWithComma(parser, destination) ||
       parseRequiredOperandWithComma(parser, m) ||
       parseRequiredOperandWithComma(parser, n) ||
       parseRequiredOperandWithComma(parser, srcStride) ||
-      parseRequiredOperandWithComma(parser, dstStride) ||
-      parseRequiredOperandWithComma(parser, dualDstMode) ||
-      parseRequiredOperandWithComma(parser, subBlockId) ||
-      parseStructuredAccStoreClauses(parser, state) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+      parseRequiredOperandWithComma(parser, dstStride))
+    return failure();
+  if (parser.parseKeyword("dst_mode") || parser.parseLParen())
+    return failure();
+  OptionalParseResult subBlockIdParse =
+      parser.parseOptionalOperand(subBlockId);
+  if (subBlockIdParse.has_value()) {
+    if (failed(*subBlockIdParse))
+      return failure();
+    hasSubBlockId = true;
+  } else {
+    StringRef dstModeKeyword;
+    if (parser.parseKeyword(&dstModeKeyword))
+      return failure();
+    if (dstModeKeyword == "split_m") {
+      dstMode = AccStoreUbDstMode::SplitM;
+    } else if (dstModeKeyword == "split_n") {
+      dstMode = AccStoreUbDstMode::SplitN;
+    } else {
+      return parser.emitError(
+          parser.getCurrentLocation(),
+          "expected dst_mode(%sub_blockid), dst_mode(split_m), or "
+          "dst_mode(split_n)");
+    }
+  }
+  if (parser.parseRParen())
+    return failure();
+  if (succeeded(parser.parseOptionalComma()) &&
+      parseStructuredAccStoreClauses(parser, state))
+    return failure();
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
     return failure();
 
   Type sourceType, destinationType, mType, nType, srcStrideType, dstStrideType,
-      dualDstModeType, subBlockIdType;
+      subBlockIdType;
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(mType) || parser.parseComma() || parser.parseType(nType) ||
       parser.parseComma() || parser.parseType(srcStrideType) ||
-      parser.parseComma() || parser.parseType(dstStrideType) ||
-      parser.parseComma() || parser.parseType(dualDstModeType) ||
-      parser.parseComma() || parser.parseType(subBlockIdType) ||
-      parseStructuredAccStoreTailTypes(parser, state))
+      parser.parseComma() || parser.parseType(dstStrideType))
+    return failure();
+  if (hasSubBlockId &&
+      (parser.parseComma() || parser.parseType(subBlockIdType)))
+    return failure();
+  if (parseStructuredAccStoreTailTypes(parser, state))
     return failure();
 
   setStructuredAccStoreSegmentSizes<AccStoreUbOp>(
       result, {1, 1, 1, 1, 1, 1, !state.preQuantOperands.empty() ? 1 : 0,
                !state.preReluOperands.empty() ? 1 : 0,
-               !state.clipValueOperands.empty() ? 1 : 0, 1, 1,
+               !state.clipValueOperands.empty() ? 1 : 0,
+               hasSubBlockId ? 1 : 0,
                !state.splitOperands.empty() ? 1 : 0,
                !state.loop0SrcStrideOperands.empty() ? 1 : 0,
                !state.loop3CountOperands.empty() ? 1 : 0,
@@ -6658,6 +6731,8 @@ ParseResult AccStoreUbOp::parse(OpAsmParser &parser, OperationState &result) {
                             "atomic is only supported for acc_store_gm");
   }
   addStructuredAccStoreAttrs<AccStoreUbOp>(result, builder, state);
+  result.addAttribute("dst_mode",
+                      AccStoreUbDstModeAttr::get(builder.getContext(), dstMode));
 
   if (parser.resolveOperand(source, sourceType, result.operands) ||
       parser.resolveOperand(destination, destinationType, result.operands) ||
@@ -6671,8 +6746,8 @@ ParseResult AccStoreUbOp::parse(OpAsmParser &parser, OperationState &result) {
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(state.clipValueOperands, state.clipValueTypes,
                              parser.getCurrentLocation(), result.operands) ||
-      parser.resolveOperand(dualDstMode, dualDstModeType, result.operands) ||
-      parser.resolveOperand(subBlockId, subBlockIdType, result.operands) ||
+      (hasSubBlockId &&
+       parser.resolveOperand(subBlockId, subBlockIdType, result.operands)) ||
       parser.resolveOperands(state.splitOperands, state.splitTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(state.loop0SrcStrideOperands,
@@ -6693,14 +6768,25 @@ ParseResult AccStoreUbOp::parse(OpAsmParser &parser, OperationState &result) {
 void AccStoreUbOp::print(OpAsmPrinter &printer) {
   printer << " " << getSource() << ", " << getDestination() << ", " << getM()
           << ", " << getN() << ", " << getSrcStride() << ", "
-          << getDstStride() << ", " << getDualDstMode() << ", "
-          << getSubBlockid();
+          << getDstStride() << ", dst_mode(";
+  switch (getDstMode()) {
+  case AccStoreUbDstMode::Single:
+    printer << getSubBlockid();
+    break;
+  case AccStoreUbDstMode::SplitM:
+    printer << "split_m";
+    break;
+  case AccStoreUbDstMode::SplitN:
+    printer << "split_n";
+    break;
+  }
+  printer << ")";
   printStructuredAccStoreClauses(printer, getUnitFlag(), getPreQuant(),
                                  getPreQuantMode(), getPreRelu(),
                                  getPreReluMode(), getClipValue(), getMode(),
                                  getSplit(), getLoop0SrcStride(),
                                  getLoop3Count(), getLoop3SrcStride(),
-                                 getLoop3DstStride(), static_cast<bool>(getSat()),
+                                 getLoop3DstStride(), getSatMode(),
                                  std::nullopt, std::nullopt);
   printer.printOptionalAttrDict((*this)->getAttrs(),
                                 /*elidedAttrs=*/{"operandSegmentSizes",
@@ -6708,12 +6794,13 @@ void AccStoreUbOp::print(OpAsmPrinter &printer) {
                                                  "unit_flag",
                                                  "pre_quant_mode",
                                                  "pre_relu_mode",
-                                                 "sat"});
+                                                 "dst_mode",
+                                                 "sat_mode"});
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getM().getType() << ", " << getN().getType() << ", "
-          << getSrcStride().getType() << ", " << getDstStride().getType()
-          << ", " << getDualDstMode().getType() << ", "
-          << getSubBlockid().getType();
+          << getSrcStride().getType() << ", " << getDstStride().getType();
+  if (getSubBlockid())
+    printer << ", " << getSubBlockid().getType();
   printStructuredAccStoreOptionalTypes(
       printer, getPreQuant(), getPreRelu(), getClipValue(), getSplit(),
       getLoop0SrcStride(), getLoop3Count(), getLoop3SrcStride(),
@@ -6731,12 +6818,46 @@ LogicalResult AccStoreUbOp::verify() {
   if (sourceSpace != AddressSpace::ACC || destinationSpace != AddressSpace::VEC) {
     return emitOpError("requires ACC source and UB destination");
   }
-  return verifyStructuredAccStoreLike(
+  if (failed(verifyStructuredAccStoreLike(
       *this, getSource().getType(), getDestination().getType(), getPreQuant(), getPreRelu(),
       getClipValue(), getSplit(), getLoop0SrcStride(), getLoop3Count(),
       getLoop3SrcStride(), getLoop3DstStride(), getUnitFlag(),
       getPreQuantMode(), getPreReluMode(), getMode(), std::nullopt,
-      std::nullopt, /*allowAtomic=*/false);
+      std::nullopt, /*allowAtomic=*/false)))
+    return failure();
+
+  if (getDstMode() == AccStoreUbDstMode::Single) {
+    if (!getSubBlockid())
+      return emitOpError("dst_mode(%sub_blockid) requires a sub_blockid operand");
+    APInt subBlockId;
+    if (matchPattern(getSubBlockid(), m_ConstantInt(&subBlockId)) &&
+        subBlockId.ugt(1))
+      return emitOpError("sub_blockid must be 0 or 1");
+    return success();
+  }
+  if (getSubBlockid())
+    return emitOpError("split destination modes do not accept sub_blockid");
+
+  if (getPreQuant() || getPreRelu() || getClipValue() || getPreQuantMode() ||
+      getPreReluMode() || getSplit() || getLoop0SrcStride() ||
+      getLoop3Count() || getLoop3SrcStride() || getLoop3DstStride()) {
+    return emitOpError("dual destination mode cannot be combined with "
+                       "pre_quant, pre_relu, clip, nz2dn, nz2nz, or loop3");
+  }
+  if (getMode() && *getMode() != AccStoreMode::Nz2nd)
+    return emitOpError("dual destination mode requires normal or nz2nd layout");
+
+  APInt mValue;
+  APInt nValue;
+  if (getDstMode() == AccStoreUbDstMode::SplitM &&
+      matchPattern(getM(), m_ConstantInt(&mValue)) &&
+      mValue.getZExtValue() % 2 != 0)
+    return emitOpError("split-M dual destination requires m to be even");
+  if (getDstMode() == AccStoreUbDstMode::SplitN &&
+      matchPattern(getN(), m_ConstantInt(&nValue)) &&
+      nValue.getZExtValue() % 32 != 0)
+    return emitOpError("split-N dual destination requires n to be a multiple of 32");
+  return success();
 }
 
 void AccStoreUbOp::getEffects(

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -335,9 +335,9 @@ static void configureAccStoreScalarPreOps(Location loc, Value preQuant,
 static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
                                    std::optional<pto::AccStoreAtomicType> atomicType,
                                    std::optional<pto::AccStoreAtomicOp> atomicOp,
-                                   std::optional<bool> sat,
+                                   std::optional<pto::AccStoreSatMode> satMode,
                                    PatternRewriter &rewriter) {
-  if ((!allowAtomic || !atomicType || !atomicOp) && !sat)
+  if ((!allowAtomic || !atomicType || !atomicOp) && !satMode)
     return {};
 
   Value originalCtrl = rewriter.create<pto::GetCtrlOp>(loc);
@@ -346,8 +346,9 @@ static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
   if (allowAtomic && atomicType && atomicOp)
     clearMaskValue |= (static_cast<uint64_t>(0x7) << 6) |
                       (static_cast<uint64_t>(0x3) << 9);
-  if (sat.has_value())
-    clearMaskValue |= static_cast<uint64_t>(1) << 48;
+  if (satMode)
+    clearMaskValue |= (static_cast<uint64_t>(1) << 48) |
+                      (static_cast<uint64_t>(1) << 50);
   Value clearMask = getI64Constant(loc, rewriter, clearMaskValue);
   Value fullMask = getI64Constant(loc, rewriter, ~static_cast<uint64_t>(0));
   Value keepMask = rewriter.create<arith::XOrIOp>(loc, clearMask, fullMask);
@@ -358,6 +359,16 @@ static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
                           (static_cast<uint64_t>(static_cast<uint32_t>(*atomicOp)) << 9);
     ctrl = rewriter.create<arith::OrIOp>(loc, ctrl,
                                          getI64Constant(loc, rewriter, atomicBits));
+  }
+  if (satMode && *satMode == pto::AccStoreSatMode::NoSat) {
+    ctrl = rewriter.create<arith::OrIOp>(
+        loc, ctrl, getI64Constant(loc, rewriter,
+                                  static_cast<uint64_t>(1) << 48));
+  }
+  if (satMode && *satMode == pto::AccStoreSatMode::SatPreserveNan) {
+    ctrl = rewriter.create<arith::OrIOp>(
+        loc, ctrl, getI64Constant(loc, rewriter,
+                                  static_cast<uint64_t>(1) << 50));
   }
   rewriter.create<pto::SetCtrlOp>(loc, ctrl);
   return originalCtrl;
@@ -1364,7 +1375,7 @@ struct ExpandAccStorePattern : public OpRewritePattern<pto::AccStoreOp> {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/false, std::nullopt,
-                              std::nullopt, op.getSat(), rewriter);
+                              std::nullopt, op.getSatMode(), rewriter);
     pto::DmaLoopConfig hwLoop{one, zero, zero};
     if (Value loop3Count = op.getLoop3Count()) {
       hwLoop = {loop3Count, op.getLoop3SrcStride(), op.getLoop3DstStride()};
@@ -1456,7 +1467,7 @@ struct ExpandAccStoreGmPattern : public OpRewritePattern<pto::AccStoreGmOp> {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/true, op.getAtomicType(),
-                              op.getAtomicOp(), op.getSat(), rewriter);
+                              op.getAtomicOp(), op.getSatMode(), rewriter);
     pto::DmaLoopConfig hwLoop{one, zero, zero};
     if (Value loop3Count = op.getLoop3Count()) {
       hwLoop = {loop3Count, op.getLoop3SrcStride(), op.getLoop3DstStride()};
@@ -1547,7 +1558,7 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::AccStoreUbOp> {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/false, std::nullopt,
-                              std::nullopt, op.getSat(), rewriter);
+                              std::nullopt, op.getSatMode(), rewriter);
     pto::DmaLoopConfig hwLoop{one, zero, zero};
     if (Value loop3Count = op.getLoop3Count()) {
       hwLoop = {loop3Count, op.getLoop3SrcStride(), op.getLoop3DstStride()};
@@ -1604,10 +1615,13 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::AccStoreUbOp> {
             : std::nullopt,
         rewriter);
 
+    Value dualDstMode =
+        getI64Constant(loc, rewriter, static_cast<int64_t>(op.getDstMode()));
+    Value subBlockId = op.getSubBlockid() ? op.getSubBlockid() : zero;
     Value config0 = packCopyMatrixCcToGmXm(loc, zero, op.getN(), op.getM(),
                                            op.getDstStride(), rewriter);
     Value config1 = packCopyMatrixCcToUbConfig1(
-        loc, op.getSrcStride(), op.getDualDstMode(), op.getSubBlockid(),
+        loc, op.getSrcStride(), dualDstMode, subBlockId,
         clipReluPre, unitFlagCtrl, quantPreMode, reluPreMode, nz2ndEn,
         channelSplitEn, nz2dnEn, rewriter);
     rewriter.create<pto::CopyMatrixCcToUbOp>(loc, op.getSource(),

--- a/test/lit/vpto/acc_store_gm.pto
+++ b/test/lit/vpto/acc_store_gm.pto
@@ -4,8 +4,8 @@
 module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
   func.func @acc_store_gm_probe(%src: !pto.ptr<f32, acc>,
                                 %dst: !pto.ptr<f16, gm>,
-                                %qfb: !pto.ptr<ui64, scaling>,
-                                %rfb: !pto.ptr<ui64, scaling>) {
+                                %qfb: !pto.ptr<f32, scaling>,
+                                %rfb: !pto.ptr<f32, scaling>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
     %c3_i64 = arith.constant 3 : i64
@@ -21,7 +21,7 @@ module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<
       nz2dn(%c1_i64),
       atomic(type = f32, op = max)
       : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-      !pto.ptr<ui64, scaling>, !pto.ptr<ui64, scaling>, i64
+      !pto.ptr<f32, scaling>, !pto.ptr<f32, scaling>, i64
 
     return
   }
@@ -31,8 +31,8 @@ module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<
 // ROUNDTRIP: pto.acc_store_gm %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, unit_flag(check_and_clear), pre_quant(%{{.*}}, mode = qf322f16_pre_vec), pre_relu(%{{.*}}, mode = vector_relu), nz2dn(%{{.*}}), atomic(type = f32, op = max)
 
 // EXPAND-LABEL: func.func @acc_store_gm_probe(
-// EXPAND: %[[QFB:.*]] = pto.castptr %{{.*}} : !pto.ptr<ui64, scaling> -> i64
-// EXPAND: %[[RFB:.*]] = pto.castptr %{{.*}} : !pto.ptr<ui64, scaling> -> i64
+// EXPAND: %[[QFB:.*]] = pto.castptr %{{.*}} : !pto.ptr<f32, scaling> -> i64
+// EXPAND: %[[RFB:.*]] = pto.castptr %{{.*}} : !pto.ptr<f32, scaling> -> i64
 // EXPAND: pto.set_fpc
 // EXPAND: pto.get_ctrl
 // EXPAND: pto.set_ctrl

--- a/test/lit/vpto/acc_store_gm_sat.pto
+++ b/test/lit/vpto/acc_store_gm_sat.pto
@@ -16,8 +16,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %c0_i64,
       nz2nd,
       loop3(%c1_i64, %c0_i64, %c16_i64),
       sat

--- a/test/lit/vpto/acc_store_gm_unit_flag.pto
+++ b/test/lit/vpto/acc_store_gm_unit_flag.pto
@@ -16,8 +16,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %c0_i64,
       unit_flag(check_and_clear),
       nz2nd,
       loop3(%c1_i64, %c0_i64, %c16_i64)

--- a/test/lit/vpto/acc_store_gm_verify_invalid_duplicate_sat.pto
+++ b/test/lit/vpto/acc_store_gm_verify_invalid_duplicate_sat.pto
@@ -14,15 +14,14 @@ module attributes {"pto.target_arch" = "a5"} {
     %c0_i64 = arith.constant 0 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, %c0_i64, %c0_i64,
       nz2nd,
       sat,
-      sat
+      nosat
       : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: duplicate sat clause
+// CHECK: duplicate sat/nosat clause

--- a/test/lit/vpto/acc_store_pre_relu_clip.pto
+++ b/test/lit/vpto/acc_store_pre_relu_clip.pto
@@ -12,13 +12,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c025_f32 = arith.constant 2.500000e-01 : f32
     %c8_f16 = arith.constant 8.000000e+00 : f16
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
       pre_relu(%c025_f32, mode = scalar_relu, clip = %c8_f16),
       nz2nd,
       loop3(%c1_i64, %c0_i64, %c32_i64)
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
         f32, f32, f16, i64, i64, i64
 
     return
@@ -26,7 +25,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 }
 
 // ROUNDTRIP-LABEL: func.func @acc_store_pre_relu_clip_probe(
-// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, pre_quant(%{{.*}}, mode = qf322f16_pre_scalar), pre_relu(%{{.*}}, mode = scalar_relu, clip = %{{.*}}), nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}})
+// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, dst_mode(%{{.*}}), pre_quant(%{{.*}}, mode = qf322f16_pre_scalar), pre_relu(%{{.*}}, mode = scalar_relu, clip = %{{.*}}), nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}})
 
 // EXPAND-LABEL: func.func @acc_store_pre_relu_clip_probe(
 // EXPAND: pto.set_quant_pre

--- a/test/lit/vpto/acc_store_sat.pto
+++ b/test/lit/vpto/acc_store_sat.pto
@@ -21,6 +21,16 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       loop3(%c1_i64, %c0_i64, %c16_i64),
       sat
       : !pto.ptr<f32, acc>, !pto.ptr<f32, mat>, i64, i64, i64, i64, i64, i64, i64
+    pto.acc_store %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
+      nz2nd,
+      loop3(%c1_i64, %c0_i64, %c16_i64),
+      sat(preserve_nan)
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, mat>, i64, i64, i64, i64, i64, i64, i64
+    pto.acc_store %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
+      nz2nd,
+      loop3(%c1_i64, %c0_i64, %c16_i64),
+      nosat
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, mat>, i64, i64, i64, i64, i64, i64, i64
 
     return
   }
@@ -28,8 +38,22 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 
 // ROUNDTRIP-LABEL: func.func @acc_store_sat_probe(
 // ROUNDTRIP: pto.acc_store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}}), sat
+// ROUNDTRIP: pto.acc_store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}}), sat(preserve_nan)
+// ROUNDTRIP: pto.acc_store %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}}), nosat
 
 // EXPAND-LABEL: func.func @acc_store_sat_probe(
+// EXPAND: pto.get_ctrl
+// EXPAND: pto.set_ctrl
+// EXPAND: pto.set_loop3_para
+// EXPAND: pto.set_channel_para
+// EXPAND: pto.copy_matrix_cc_to_cbuf
+// EXPAND: pto.set_ctrl
+// EXPAND: pto.get_ctrl
+// EXPAND: pto.set_ctrl
+// EXPAND: pto.set_loop3_para
+// EXPAND: pto.set_channel_para
+// EXPAND: pto.copy_matrix_cc_to_cbuf
+// EXPAND: pto.set_ctrl
 // EXPAND: pto.get_ctrl
 // EXPAND: pto.set_ctrl
 // EXPAND: pto.set_loop3_para

--- a/test/lit/vpto/acc_store_ub.pto
+++ b/test/lit/vpto/acc_store_ub.pto
@@ -10,12 +10,11 @@ module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c2_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_relu(mode = normal_relu),
       nz2nz(%c1_i64),
       sat
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64,
       i64
 
     return
@@ -23,7 +22,7 @@ module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<
 }
 
 // ROUNDTRIP-LABEL: func.func @acc_store_ub_probe(
-// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, pre_relu(mode = normal_relu), nz2nz(%{{.*}}), sat
+// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, dst_mode(%{{.*}}), pre_relu(mode = normal_relu), nz2nz(%{{.*}}), sat
 
 // EXPAND-LABEL: func.func @acc_store_ub_probe(
 // EXPAND: pto.get_ctrl

--- a/test/lit/vpto/acc_store_ub_clip.pto
+++ b/test/lit/vpto/acc_store_ub_clip.pto
@@ -10,12 +10,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_f32 = arith.constant 1.000000e+00 : f32
     %c8_f16 = arith.constant 8.000000e+00 : f16
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
       pre_relu(mode = no_relu, clip = %c8_f16),
       nz2nd
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
       f32, f16
 
     return
@@ -23,7 +22,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 }
 
 // ROUNDTRIP-LABEL: func.func @acc_store_ub_clip_probe(
-// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, pre_quant(%{{.*}}, mode = qf322f16_pre_scalar), pre_relu(mode = no_relu, clip = %{{.*}}), nz2nd
+// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, dst_mode(%{{.*}}), pre_quant(%{{.*}}, mode = qf322f16_pre_scalar), pre_relu(mode = no_relu, clip = %{{.*}}), nz2nd
 
 // EXPAND-LABEL: func.func @acc_store_ub_clip_probe(
 // EXPAND: pto.set_quant_pre

--- a/test/lit/vpto/acc_store_ub_clip_ui8.pto
+++ b/test/lit/vpto/acc_store_ub_clip_ui8.pto
@@ -18,12 +18,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_f32 = arith.constant 1.000000e+00 : f32
     %c255_i16 = arith.constant 255 : i16
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_quant(%c1_f32, mode = qf322b8_pre_scalar),
       pre_relu(mode = no_relu, clip = %c255_i16),
       nz2nd
-      : !pto.ptr<f32, acc>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64,
       f32, i16
 
     return

--- a/test/lit/vpto/acc_store_ub_sat.pto
+++ b/test/lit/vpto/acc_store_ub_sat.pto
@@ -16,19 +16,18 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(%c0_i64),
       nz2nd,
       loop3(%c1_i64, %c0_i64, %c16_i64),
       sat
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64, i64
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64
 
     return
   }
 }
 
 // ROUNDTRIP-LABEL: func.func @acc_store_ub_sat_probe(
-// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}}), sat
+// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, dst_mode(%{{.*}}), nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}}), sat
 
 // EXPAND-LABEL: func.func @acc_store_ub_sat_probe(
 // EXPAND: pto.get_ctrl

--- a/test/lit/vpto/acc_store_ub_unit_flag.pto
+++ b/test/lit/vpto/acc_store_ub_unit_flag.pto
@@ -16,19 +16,18 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(%c0_i64),
       unit_flag(check_only),
       nz2nd,
       loop3(%c1_i64, %c0_i64, %c16_i64)
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64, i64
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64
 
     return
   }
 }
 
 // ROUNDTRIP-LABEL: func.func @acc_store_ub_unit_flag_probe(
-// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, unit_flag(check_only), nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}})
+// ROUNDTRIP: pto.acc_store_ub %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, dst_mode(%{{.*}}), unit_flag(check_only), nz2nd, loop3(%{{.*}}, %{{.*}}, %{{.*}})
 
 // EXPAND-LABEL: func.func @acc_store_ub_unit_flag_probe(
 // EXPAND: %[[XT:.*]] = arith.constant 8804682956816 : i64

--- a/test/lit/vpto/acc_store_ub_verify_invalid_atomic.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_atomic.pto
@@ -8,10 +8,9 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c2_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       atomic(type = f32, op = add)
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
 
     return
   }

--- a/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_mode.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_mode.pto
@@ -2,28 +2,25 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
 
 module attributes {"pto.target_arch" = "a5"} {
-  func.func @acc_store_verify_invalid_req8_vec_f32_to_f16(
-      %src: !pto.ptr<f32, acc>, %dst: !pto.ptr<f16, ub>) {
+  func.func @acc_store_ub_verify_invalid_dual_dst_mode(%src: !pto.ptr<f32, acc>,
+                                                       %dst: !pto.ptr<f32, ub>) {
     %c0_i64 = arith.constant 0 : i64
+    %c3_i64 = arith.constant 3 : i64
     %c16_i64 = arith.constant 16 : i64
-    %c32_i64 = arith.constant 32 : i64
-    %fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
-      pre_quant(%fp, mode = req8_vec),
-      nz2nd
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
-      !pto.ptr<f32, scaling>
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(bad_mode),
+      sat
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: pre_quant mode req8_vec is incompatible with source element type 'f32' and destination element type 'f16'
+// CHECK: expected dst_mode(%sub_blockid), dst_mode(split_m), or dst_mode(split_n)

--- a/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_shape.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_shape.pto
@@ -2,28 +2,26 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
 
 module attributes {"pto.target_arch" = "a5"} {
-  func.func @acc_store_verify_invalid_req8_vec_f32_to_f16(
-      %src: !pto.ptr<f32, acc>, %dst: !pto.ptr<f16, ub>) {
+  func.func @acc_store_ub_verify_invalid_dual_dst_shape(%src: !pto.ptr<f32, acc>,
+                                                        %dst: !pto.ptr<f32, ub>) {
     %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c15_i64 = arith.constant 15 : i64
     %c16_i64 = arith.constant 16 : i64
-    %c32_i64 = arith.constant 32 : i64
-    %fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
-      pre_quant(%fp, mode = req8_vec),
-      nz2nd
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
-      !pto.ptr<f32, scaling>
+    pto.acc_store_ub %src, %dst, %c15_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(split_m),
+      sat
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: pre_quant mode req8_vec is incompatible with source element type 'f32' and destination element type 'f16'
+// CHECK: split-M dual destination requires m to be even

--- a/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_transform.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_dual_dst_transform.pto
@@ -2,28 +2,25 @@
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
 
 module attributes {"pto.target_arch" = "a5"} {
-  func.func @acc_store_verify_invalid_req8_vec_f32_to_f16(
-      %src: !pto.ptr<f32, acc>, %dst: !pto.ptr<f16, ub>) {
+  func.func @acc_store_ub_verify_invalid_dual_dst_transform(%src: !pto.ptr<f32, acc>,
+                                                            %dst: !pto.ptr<f32, ub>) {
     %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
-    %c32_i64 = arith.constant 32 : i64
-    %fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
-      pre_quant(%fp, mode = req8_vec),
-      nz2nd
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
-      !pto.ptr<f32, scaling>
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(split_m),
+      pre_relu(mode = normal_relu)
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: pre_quant mode req8_vec is incompatible with source element type 'f32' and destination element type 'f16'
+// CHECK: dual destination mode cannot be combined with pre_quant, pre_relu, clip, nz2dn, nz2nz, or loop3

--- a/test/lit/vpto/acc_store_ub_verify_invalid_duplicate_sat.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_duplicate_sat.pto
@@ -14,15 +14,14 @@ module attributes {"pto.target_arch" = "a5"} {
     %c0_i64 = arith.constant 0 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(%c0_i64),
       nz2nd,
       sat,
-      sat
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64
+      nosat
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: duplicate sat clause
+// CHECK: duplicate sat/nosat clause

--- a/test/lit/vpto/acc_store_ub_verify_invalid_unit_flag_nz2dn.pto
+++ b/test/lit/vpto/acc_store_ub_verify_invalid_unit_flag_nz2dn.pto
@@ -15,11 +15,10 @@ module attributes {"pto.target_arch" = "a5"} {
     %c2_i64 = arith.constant 2 : i64
     %c16_i64 = arith.constant 16 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64, dst_mode(%c0_i64),
       unit_flag(check_only),
       nz2dn(%c2_i64)
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64,
       i64
 
     return

--- a/test/lit/vpto/acc_store_verify_invalid_clip_payload_ui8.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_clip_payload_ui8.pto
@@ -16,10 +16,9 @@ module attributes {"pto.target_arch" = "a5"} {
     %c32_i64 = arith.constant 32 : i64
     %c7_i8 = arith.constant 7 : i8
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_relu(mode = no_relu, clip = %c7_i8)
-      : !pto.ptr<f32, acc>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64,
         i8
 
     return

--- a/test/lit/vpto/acc_store_verify_invalid_clip_type.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_clip_type.pto
@@ -7,10 +7,9 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_relu(mode = no_relu, clip = %c16_i64)
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64,
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64,
         i64
 
     return

--- a/test/lit/vpto/acc_store_verify_invalid_duplicate_sat.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_duplicate_sat.pto
@@ -16,11 +16,11 @@ module attributes {"pto.target_arch" = "a5"} {
     pto.acc_store %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
       nz2nd,
       sat,
-      sat
+      nosat
       : !pto.ptr<f32, acc>, !pto.ptr<f32, mat>, i64, i64, i64, i64
 
     return
   }
 }
 
-// CHECK: duplicate sat clause
+// CHECK: duplicate sat/nosat clause

--- a/test/lit/vpto/acc_store_verify_invalid_nz2dn.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_nz2dn.pto
@@ -7,8 +7,7 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, %c0_i64, %c0_i64,
       nz2dn
       : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64
 

--- a/test/lit/vpto/acc_store_verify_invalid_nz2nz.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_nz2nz.pto
@@ -7,9 +7,8 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64, nz2nz
-      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64), nz2nz
+      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
 
     return
   }

--- a/test/lit/vpto/acc_store_verify_invalid_pre_quant_vec_payload_type.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_pre_quant_vec_payload_type.pto
@@ -1,0 +1,21 @@
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @acc_store_verify_invalid_pre_quant_vec_payload_type(
+      %src: !pto.ptr<f32, acc>, %dst: !pto.ptr<f16, ub>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %payload = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui64, scaling>
+
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
+      dst_mode(%c0_i64),
+      pre_quant(%payload, mode = qf322f16_pre_vec)
+      : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+        !pto.ptr<ui64, scaling>
+
+    return
+  }
+}
+
+// CHECK: vector pre_quant mode requires scaling pointer element type to be f16, bf16, or f32

--- a/test/lit/vpto/acc_store_verify_invalid_scalar_relu_payload.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_scalar_relu_payload.pto
@@ -7,10 +7,9 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, dst_mode(%c0_i64),
       pre_relu(mode = scalar_relu)
-      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
 
     return
   }

--- a/test/lit/vpto/acc_store_verify_invalid_unit_flag_nz2dn.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_unit_flag_nz2dn.pto
@@ -8,8 +8,7 @@ module attributes {"pto.target_arch" = "a5"} {
     %c16_i64 = arith.constant 16 : i64
     %c32_i64 = arith.constant 32 : i64
 
-    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
-      %c0_i64, %c0_i64,
+    pto.acc_store_gm %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64, %c0_i64, %c0_i64,
       unit_flag(check_only),
       nz2dn(%c2_i64)
       : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64,

--- a/test/lit/vpto/acc_store_verify_invalid_vector_relu_payload_type.pto
+++ b/test/lit/vpto/acc_store_verify_invalid_vector_relu_payload_type.pto
@@ -1,0 +1,21 @@
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @acc_store_verify_invalid_vector_relu_payload_type(
+      %src: !pto.ptr<f32, acc>, %dst: !pto.ptr<f32, ub>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %payload = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui64, scaling>
+
+    pto.acc_store_ub %src, %dst, %c16_i64, %c16_i64, %c16_i64, %c32_i64,
+      dst_mode(%c0_i64),
+      pre_relu(%payload, mode = vector_relu)
+      : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64,
+        !pto.ptr<ui64, scaling>
+
+    return
+  }
+}
+
+// CHECK: vector_relu requires scaling pointer element type to be f16, bf16, or f32

--- a/test/lit/vpto/fp_load.pto
+++ b/test/lit/vpto/fp_load.pto
@@ -3,14 +3,14 @@
 
 module attributes {"pto.target_arch" = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
   func.func @fp_load_probe(%src: !pto.ptr<f32, mat>,
-                           %dst: !pto.ptr<ui64, scaling>) {
+                           %dst: !pto.ptr<f32, scaling>) {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
     %c2_i64 = arith.constant 2 : i64
 
     pto.fp_load %src, %dst, %c2_i64
       nburst(%c1_i64, %c0_i64, %c0_i64)
-      : !pto.ptr<f32, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+      : !pto.ptr<f32, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
     return
   }
 }

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-atomic-f32-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-atomic-f32-cv/kernel.pto
@@ -73,31 +73,27 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
-      pto.acc_store_gm %l0c, %out_plain_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_plain_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64,
           i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_atomic_add_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_atomic_add_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         atomic(type = f32, op = add)
         : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64,
           i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_atomic_max_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_atomic_max_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         atomic(type = f32, op = max)
         : !pto.ptr<f32, acc>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64,
           i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_atomic_min_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_atomic_min_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         atomic(type = f32, op = min)

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/compare.py
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/compare.py
@@ -15,30 +15,24 @@ import numpy as np
 
 def compare_bin(golden_path: str, output_path: str) -> bool:
     if not os.path.exists(golden_path) or not os.path.exists(output_path):
-        print(f"[ERROR] missing file: {golden_path} or {output_path}")
         return False
-    golden = np.fromfile(golden_path, dtype=np.float16)
-    output = np.fromfile(output_path, dtype=np.float16)
+    golden = np.fromfile(golden_path, dtype=np.float32)
+    output = np.fromfile(output_path, dtype=np.float32)
     if golden.shape != output.shape:
         print(f"[ERROR] shape mismatch: {golden.shape} vs {output.shape}")
         return False
-    equal = golden.view(np.uint16) == output.view(np.uint16)
-    equal |= np.isnan(golden) & np.isnan(output)
-    if bool(np.all(equal)):
+    if np.allclose(golden, output, atol=1e-3, rtol=1e-3):
         return True
-    diff = np.where(~equal)[0]
+    diff = np.where(np.abs(golden - output) > (1e-3 + 1e-3 * np.abs(golden)))[0]
     idx = int(diff[0]) if diff.size else 0
-    print(
-        f"[ERROR] first mismatch at idx={idx}: "
-        f"golden={float(golden[idx])}, out={float(output[idx])}"
-    )
+    print(f"[ERROR] first mismatch at idx={idx}: golden={float(golden[idx])}, out={float(output[idx])}")
     return False
 
 
 def main() -> None:
     strict = os.getenv("COMPARE_STRICT", "1") != "0"
     ok = True
-    for index in range(4, 10):
+    for index in range(3, 7):
         ok = compare_bin(f"golden_v{index}.bin", f"v{index}.bin") and ok
     if not ok:
         if strict:

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/golden.py
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/golden.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lhs = (np.arange(40 * 50, dtype=np.float16).reshape(40, 50) * np.float16(0.5) +
+           np.float16(17)).astype(np.float16)
+    rhs = (np.arange(50 * 64, dtype=np.float16).reshape(50, 64) * np.float16(0.25) +
+           np.float16(3)).astype(np.float16)
+    golden = lhs.astype(np.float32) @ rhs.astype(np.float32)
+
+    lhs.reshape(-1).tofile(output_dir / "v1.bin")
+    rhs.reshape(-1).tofile(output_dir / "v2.bin")
+    outputs = {
+        3: golden[:20, :],
+        4: golden[20:, :],
+        5: golden[:, :32],
+        6: golden[:, 32:],
+    }
+    for index, value in outputs.items():
+        np.zeros_like(value, dtype=np.float32).reshape(-1).tofile(output_dir / f"v{index}.bin")
+        value.astype(np.float32).reshape(-1).tofile(output_dir / f"golden_v{index}.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/kernel.pto
@@ -7,20 +7,27 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // -----------------------------------------------------------------------------
-// case: micro-op/cv-mixed/fixpipe-acc-ub-cv
+// case: micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv
 // family: cv-mixed
 // target_ops: pto.cube_load_frac, pto.left_load, pto.right_load, pto.mad,
 //   pto.acc_store_ub, pto.dma_store, pto.sync.set, pto.sync.wait
-// scenarios: nd2nz-functional-load, cc-to-ub, ub-to-gm
+// scenarios: nd2nz-functional-load, acc_store_ub split-M, acc_store_ub split-N,
+//   per-subblock UB writeback
 // -----------------------------------------------------------------------------
 
 module attributes {pto.target_arch = "a5"} {
-  func.func @fixpipe_acc_ub_cv_kernel(%src_gm: !pto.ptr<f16, gm>,
-                                      %id_gm: !pto.ptr<f16, gm>,
-                                      %out_gm: !pto.ptr<f32, gm>)
+  func.func @fixpipe_acc_store_dual_ub_cv_kernel(%src_gm: !pto.ptr<f16, gm>,
+                                                 %id_gm: !pto.ptr<f16, gm>,
+                                                 %out_split_m0_gm: !pto.ptr<f32, gm>,
+                                                 %out_split_m1_gm: !pto.ptr<f32, gm>,
+                                                 %out_split_n0_gm: !pto.ptr<f32, gm>,
+                                                 %out_split_n1_gm: !pto.ptr<f32, gm>)
       attributes {pto.aicore} {
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c20_i64 = arith.constant 20 : i64
+    %c32_i64 = arith.constant 32 : i64
     %c40_i64 = arith.constant 40 : i64
     %c48_i64 = arith.constant 48 : i64
     %c50_i64 = arith.constant 50 : i64
@@ -29,15 +36,15 @@ module attributes {pto.target_arch = "a5"} {
     %c100_i64 = arith.constant 100 : i64
     %c128_i64 = arith.constant 128 : i64
     %c256_i64 = arith.constant 256 : i64
-    %c2560_i64 = arith.constant 2560 : i64
-    %c49152_i64 = arith.constant 49152 : i64
+    %c32768_i64 = arith.constant 32768 : i64
     %c65536_i64 = arith.constant 65536 : i64
 
     %false = arith.constant false
 
     %mat_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, mat>
     %mat_id = pto.castptr %c65536_i64 : i64 -> !pto.ptr<f16, mat>
-    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_split_m = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_split_n = pto.castptr %c32768_i64 : i64 -> !pto.ptr<f32, ub>
     %l0a = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, left>
     %l0b = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, right>
     %l0c = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, acc>
@@ -76,12 +83,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
-      pto.acc_store_ub %l0c, %ub_out, %c40_i64, %c64b_i64, %c48_i64, %c64b_i64, dst_mode(%c0_i64),
-        unit_flag(check_only),
+      pto.acc_store_ub %l0c, %ub_split_m, %c40_i64, %c64b_i64, %c48_i64, %c64b_i64, dst_mode(split_m),
         nz2nd,
-        loop3(%c1_i64, %c49152_i64, %c2560_i64),
         sat
-        : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64
+        : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64
+      pto.acc_store_ub %l0c, %ub_split_n, %c40_i64, %c64b_i64, %c48_i64, %c64b_i64, dst_mode(split_n),
+        nz2nd,
+        sat
+        : !pto.ptr<f32, acc>, !pto.ptr<f32, ub>, i64, i64, i64, i64
 
       pto.sync.set <PIPE_FIX>, 1
       pto.sync.set <PIPE_FIX>, 17
@@ -90,11 +99,24 @@ module attributes {pto.target_arch = "a5"} {
     pto.section.vector {
       %subblock = pto.get_subblock_idx
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
+      %is_subblock1 = arith.cmpi eq, %subblock, %c1_i64 : i64
 
       scf.if %is_subblock0 {
         pto.sync.wait <PIPE_MTE3>, 1
-        pto.dma_store %ub_out, %out_gm, %c256_i64
-          nburst(%c40_i64, %c256_i64, %c256_i64)
+        pto.dma_store %ub_split_m, %out_split_m0_gm, %c256_i64
+          nburst(%c20_i64, %c256_i64, %c256_i64)
+          : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+        pto.dma_store %ub_split_n, %out_split_n0_gm, %c128_i64
+          nburst(%c40_i64, %c256_i64, %c128_i64)
+          : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+      }
+      scf.if %is_subblock1 {
+        pto.sync.wait <PIPE_MTE3>, 1
+        pto.dma_store %ub_split_m, %out_split_m1_gm, %c256_i64
+          nburst(%c20_i64, %c256_i64, %c256_i64)
+          : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+        pto.dma_store %ub_split_n, %out_split_n1_gm, %c128_i64
+          nburst(%c40_i64, %c256_i64, %c128_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
       }
       pto.barrier #pto.pipe<PIPE_ALL>

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/launch.cpp
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/launch.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+
+#include <cstdint>
+
+#if defined(__CCE_AICORE__) && defined(PTOAS_ENABLE_CCE_PRINT)
+#include <ccelib/print/print.h>
+#endif
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void fixpipe_acc_store_dual_ub_cv_kernel(
+    __gm__ __fp16 *src, __gm__ __fp16 *id, __gm__ float *outSplitM0,
+    __gm__ float *outSplitM1, __gm__ float *outSplitN0,
+    __gm__ float *outSplitN1);
+
+void LaunchFixpipe_acc_store_dual_ub_cv_kernel(
+    __fp16 *src, __fp16 *id, float *outSplitM0, float *outSplitM1,
+    float *outSplitN0, float *outSplitN1, void *stream) {
+  fixpipe_acc_store_dual_ub_cv_kernel<<<1, nullptr, stream>>>(
+      (__gm__ __fp16 *)src, (__gm__ __fp16 *)id,
+      (__gm__ float *)outSplitM0, (__gm__ float *)outSplitM1,
+      (__gm__ float *)outSplitN0, (__gm__ float *)outSplitN1);
+}

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/main.cpp
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/main.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+
+using namespace PtoTestCommon;
+
+#ifndef TMRGSORT_HPP
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      const char *_recent = aclGetRecentErrMsg();                                \
+      if (_recent != nullptr && _recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", _recent);             \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+#define FILE_CHECK(expr, path)                                                   \
+  do {                                                                           \
+    if (!(expr)) {                                                               \
+      std::fprintf(stderr, "[ERROR] file operation failed: %s (%s:%d)\n",        \
+                   path, __FILE__, __LINE__);                                    \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchFixpipe_acc_store_dual_ub_cv_kernel(
+    __fp16 *src, __fp16 *id, float *outSplitM0, float *outSplitM1,
+    float *outSplitN0, float *outSplitN1, void *stream);
+
+int main() {
+  constexpr size_t kSrcElem = 50 * 64;
+  constexpr size_t kIdElem = 40 * 50;
+  constexpr size_t kOutSplitMElem = 20 * 64;
+  constexpr size_t kOutSplitNElem = 40 * 32;
+  constexpr size_t kSrcSize = kSrcElem * sizeof(__fp16);
+  constexpr size_t kIdSize = kIdElem * sizeof(__fp16);
+  constexpr size_t kOutSplitMSize = kOutSplitMElem * sizeof(float);
+  constexpr size_t kOutSplitNSize = kOutSplitNElem * sizeof(float);
+
+  __fp16 *srcHost = nullptr;
+  __fp16 *idHost = nullptr;
+  float *outSplitM0Host = nullptr;
+  float *outSplitM1Host = nullptr;
+  float *outSplitN0Host = nullptr;
+  float *outSplitN1Host = nullptr;
+  __fp16 *srcDevice = nullptr;
+  __fp16 *idDevice = nullptr;
+  float *outSplitM0Device = nullptr;
+  float *outSplitM1Device = nullptr;
+  float *outSplitN0Device = nullptr;
+  float *outSplitN1Device = nullptr;
+
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+  size_t inputSize = 0;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost((void **)&srcHost, kSrcSize));
+  ACL_CHECK(aclrtMallocHost((void **)&idHost, kIdSize));
+  ACL_CHECK(aclrtMallocHost((void **)&outSplitM0Host, kOutSplitMSize));
+  ACL_CHECK(aclrtMallocHost((void **)&outSplitM1Host, kOutSplitMSize));
+  ACL_CHECK(aclrtMallocHost((void **)&outSplitN0Host, kOutSplitNSize));
+  ACL_CHECK(aclrtMallocHost((void **)&outSplitN1Host, kOutSplitNSize));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, kSrcSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&idDevice, kIdSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&outSplitM0Device, kOutSplitMSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&outSplitM1Device, kOutSplitMSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&outSplitN0Device, kOutSplitNSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&outSplitN1Device, kOutSplitNSize, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  inputSize = kIdSize;
+  FILE_CHECK(ReadFile("./v1.bin", inputSize, idHost, kIdSize) && inputSize == kIdSize,
+             "./v1.bin");
+  inputSize = kSrcSize;
+  FILE_CHECK(ReadFile("./v2.bin", inputSize, srcHost, kSrcSize) && inputSize == kSrcSize,
+             "./v2.bin");
+  inputSize = kOutSplitMSize;
+  FILE_CHECK(ReadFile("./v3.bin", inputSize, outSplitM0Host, kOutSplitMSize) && inputSize == kOutSplitMSize,
+             "./v3.bin");
+  inputSize = kOutSplitMSize;
+  FILE_CHECK(ReadFile("./v4.bin", inputSize, outSplitM1Host, kOutSplitMSize) && inputSize == kOutSplitMSize,
+             "./v4.bin");
+  inputSize = kOutSplitNSize;
+  FILE_CHECK(ReadFile("./v5.bin", inputSize, outSplitN0Host, kOutSplitNSize) && inputSize == kOutSplitNSize,
+             "./v5.bin");
+  inputSize = kOutSplitNSize;
+  FILE_CHECK(ReadFile("./v6.bin", inputSize, outSplitN1Host, kOutSplitNSize) && inputSize == kOutSplitNSize,
+             "./v6.bin");
+
+  ACL_CHECK(aclrtMemcpy(srcDevice, kSrcSize, srcHost, kSrcSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(idDevice, kIdSize, idHost, kIdSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outSplitM0Device, kOutSplitMSize, outSplitM0Host, kOutSplitMSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outSplitM1Device, kOutSplitMSize, outSplitM1Host, kOutSplitMSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outSplitN0Device, kOutSplitNSize, outSplitN0Host, kOutSplitNSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outSplitN1Device, kOutSplitNSize, outSplitN1Host, kOutSplitNSize, ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchFixpipe_acc_store_dual_ub_cv_kernel(
+      srcDevice, idDevice, outSplitM0Device, outSplitM1Device,
+      outSplitN0Device, outSplitN1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+
+  ACL_CHECK(aclrtMemcpy(outSplitM0Host, kOutSplitMSize, outSplitM0Device, kOutSplitMSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(outSplitM1Host, kOutSplitMSize, outSplitM1Device, kOutSplitMSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(outSplitN0Host, kOutSplitNSize, outSplitN0Device, kOutSplitNSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(outSplitN1Host, kOutSplitNSize, outSplitN1Device, kOutSplitNSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  FILE_CHECK(WriteFile("./v3.bin", outSplitM0Host, kOutSplitMSize), "./v3.bin");
+  FILE_CHECK(WriteFile("./v4.bin", outSplitM1Host, kOutSplitMSize), "./v4.bin");
+  FILE_CHECK(WriteFile("./v5.bin", outSplitN0Host, kOutSplitNSize), "./v5.bin");
+  FILE_CHECK(WriteFile("./v6.bin", outSplitN1Host, kOutSplitNSize), "./v6.bin");
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(idDevice);
+  aclrtFree(outSplitM0Device);
+  aclrtFree(outSplitM1Device);
+  aclrtFree(outSplitN0Device);
+  aclrtFree(outSplitN1Device);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(idHost);
+  aclrtFreeHost(outSplitM0Host);
+  aclrtFreeHost(outSplitM1Host);
+  aclrtFreeHost(outSplitN0Host);
+  aclrtFreeHost(outSplitN1Host);
+  if (stream != nullptr)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/golden.py
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/golden.py
@@ -19,8 +19,18 @@ N = 64
 K = 50
 FP_QUANT_ELEMS = 64
 FP_TRANSPORT_ELEMS = FP_QUANT_ELEMS * 2
-SRC_VALUE = np.float16(400.0)
-ID_VALUE = np.float16(400.0)
+K_ACTIVE = 6
+CASE_VALUES = np.array(
+    [
+        np.float16(12000.0),
+        np.float16(-12000.0),
+        np.float16(np.inf),
+        np.float16(-np.inf),
+        np.float16(np.nan),
+        np.float16(20.0),
+    ],
+    dtype=np.float16,
+)
 
 
 def encode_scale(scale: float) -> np.uint64:
@@ -30,18 +40,26 @@ def encode_scale(scale: float) -> np.uint64:
 def generate(output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    lhs = np.full((M, K), ID_VALUE, dtype=np.float16)
-    rhs = np.full((K, N), SRC_VALUE, dtype=np.float16)
+    lhs = np.zeros((M, K), dtype=np.float16)
+    rhs = np.zeros((K, N), dtype=np.float16)
+    lhs[:, :K_ACTIVE] = np.float16(1.0)
+    for col in range(N):
+        rhs[:K_ACTIVE, col] = CASE_VALUES[col % len(CASE_VALUES)]
     fp = np.full(FP_QUANT_ELEMS, encode_scale(1.0), dtype=np.uint64)
 
     matmul = lhs.astype(np.float32) @ rhs.astype(np.float32)
-    sat_golden = np.clip(
+    sat_golden = np.nan_to_num(
         matmul,
-        np.finfo(np.float16).min,
-        np.finfo(np.float16).max,
-    ).astype(np.float16)
+        nan=np.float32(0.0),
+        posinf=np.finfo(np.float16).max,
+        neginf=np.finfo(np.float16).min,
+    )
+    sat_golden = np.clip(sat_golden, np.finfo(np.float16).min,
+                         np.finfo(np.float16).max).astype(np.float16)
     with np.errstate(over="ignore", invalid="ignore"):
         nosat_golden = matmul.astype(np.float16)
+    if np.array_equal(sat_golden.view(np.uint16), nosat_golden.view(np.uint16)):
+        raise AssertionError("sat and nosat golden outputs must differ")
 
     zero = np.zeros((M, N), dtype=np.float16)
     lhs.reshape(-1).tofile(output_dir / "v1.bin")

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/kernel.pto
@@ -53,7 +53,7 @@ module attributes {pto.target_arch = "a5"} {
     %l1_fp = pto.castptr %c131072_i64 : i64 -> !pto.ptr<ui64, mat>
     %l1_sat = pto.castptr %c196608_i64 : i64 -> !pto.ptr<f16, mat>
     %l1_nosat = pto.castptr %c262144_i64 : i64 -> !pto.ptr<f16, mat>
-    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui64, scaling>
+    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
     %ub_sat = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_nosat = pto.castptr %c32768_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_l1_sat = pto.castptr %c65536_i64 : i64 -> !pto.ptr<f16, ub>
@@ -101,41 +101,41 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.fp_load %l1_fp, %fb_fp, %c8_i64
         nburst(%c1_i64, %c0_i64, %c0_i64)
-        : !pto.ptr<ui64, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+        : !pto.ptr<ui64, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
 
       %ctrl = pto.get_ctrl : i64
       %ctrl_preserve_inf = pto.sbitset1 %ctrl, %c48_i64 : i64, i64 -> i64
       pto.set_ctrl %ctrl_preserve_inf : i64
 
-      pto.acc_store_ub %l0c, %ub_sat, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
+      pto.acc_store_ub %l0c, %ub_sat, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         sat
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_nosat, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
+      pto.acc_store_ub %l0c, %ub_nosat, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
-        loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+        loop3(%c1_i64, %c49152_i64, %c2560_i64),
+        nosat
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_sat_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_sat_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         sat
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_nosat_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
+      pto.acc_store_gm %l0c, %out_gm_nosat_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
-        loop3(%c1_i64, %c49152_i64, %c2560_i64)
+        loop3(%c1_i64, %c49152_i64, %c2560_i64),
+        nosat
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
 
       pto.acc_store %l0c, %l1_sat, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
@@ -143,13 +143,14 @@ module attributes {pto.target_arch = "a5"} {
         loop3(%c1_i64, %c49152_i64, %c2560_i64),
         sat
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
       pto.acc_store %l0c, %l1_nosat, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
-        loop3(%c1_i64, %c49152_i64, %c2560_i64)
+        loop3(%c1_i64, %c49152_i64, %c2560_i64),
+        nosat
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
 
       pto.set_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]
       pto.wait_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-clip-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-clip-ub-cv/kernel.pto
@@ -84,16 +84,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
-      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f16, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-clip-f16-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-clip-f16-ub-cv/kernel.pto
@@ -54,7 +54,7 @@ module attributes {pto.target_arch = "a5"} {
     %l1_fp = pto.castptr %c131072_i64 : i64 -> !pto.ptr<ui64, mat>
     %l1_quant = pto.castptr %c196608_i64 : i64 -> !pto.ptr<f16, mat>
     %l1_clip = pto.castptr %c262144_i64 : i64 -> !pto.ptr<f16, mat>
-    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui64, scaling>
+    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
     %ub_quant = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_clip = pto.castptr %c32768_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_l1_quant = pto.castptr %c65536_i64 : i64 -> !pto.ptr<f16, ub>
@@ -102,53 +102,49 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.fp_load %l1_fp, %fb_fp, %c8_i64
         nburst(%c1_i64, %c0_i64, %c0_i64)
-        : !pto.ptr<ui64, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+        : !pto.ptr<ui64, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
 
-      pto.acc_store_ub %l0c, %ub_quant, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_quant, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
+      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, f16, i64, i64, i64
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          !pto.ptr<f32, scaling>, f16, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_quant_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_quant_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
+      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, f16, i64, i64, i64
+          !pto.ptr<f32, scaling>, f16, i64, i64, i64
 
       pto.acc_store %l0c, %l1_quant, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
       pto.acc_store %l0c, %l1_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, f16, i64, i64, i64
+          !pto.ptr<f32, scaling>, f16, i64, i64, i64
 
       pto.set_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]
       pto.wait_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-normal-relu-clip-f16-scalar-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-normal-relu-clip-f16-scalar-ub-cv/kernel.pto
@@ -92,33 +92,29 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
-      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f16, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
           f32, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu, clip = %c8_f16),
         nz2nd,

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-clip-f16-scalar-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-clip-f16-scalar-ub-cv/kernel.pto
@@ -93,33 +93,29 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
-      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f32, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f32, f16, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
           f32, f32, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu, clip = %c8_f16),
         nz2nd,

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-float-payload-f16-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-float-payload-f16-ub-cv/kernel.pto
@@ -91,16 +91,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
 
-      pto.acc_store_ub %l0c, %ub_out, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_ub %l0c, %ub_out, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f32, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f16, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f16, mode = scalar_relu),
         nz2nd,

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-ub-cv/kernel.pto
@@ -47,7 +47,7 @@ module attributes {pto.target_arch = "a5"} {
     %l1_fp_raw = pto.castptr %c131072_i64 : i64 -> !pto.ptr<ui32, mat>
     %l1_fp = pto.castptr %c131072_i64 : i64 -> !pto.ptr<ui64, mat>
     %l1_out = pto.castptr %c196608_i64 : i64 -> !pto.ptr<f16, mat>
-    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui64, scaling>
+    %fb_fp = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, scaling>
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_l1_out = pto.castptr %c32768_i64 : i64 -> !pto.ptr<f16, ub>
     %l0a = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, left>
@@ -93,28 +93,26 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.fp_load %l1_fp, %fb_fp, %c8_i64
         nburst(%c1_i64, %c0_i64, %c0_i64)
-        : !pto.ptr<ui64, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+        : !pto.ptr<ui64, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
 
-      pto.acc_store_ub %l0c, %ub_out, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_out, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          !pto.ptr<f32, scaling>, i64, i64, i64
+      pto.acc_store_gm %l0c, %out_gm_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
       pto.acc_store %l0c, %l1_out, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%fb_fp, mode = qf322f16_pre_vec),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          !pto.ptr<ui64, scaling>, i64, i64, i64
+          !pto.ptr<f32, scaling>, i64, i64, i64
 
       pto.set_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]
       pto.wait_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/golden.py
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/golden.py
@@ -19,6 +19,7 @@ N = 64
 K = 50
 FP_RELU_ELEMS = 128
 ALPHA = np.float32(0.25)
+VECTOR_ALPHA_PATTERN = np.array([0.125, 0.25, 0.5, 0.75], dtype=np.float32)
 SEED = 521
 
 
@@ -30,11 +31,29 @@ def scalar_relu(data: np.ndarray) -> np.ndarray:
     return np.where(data >= np.float32(0.0), data, data * ALPHA)
 
 
+def make_vector_alphas() -> np.ndarray:
+    return np.resize(VECTOR_ALPHA_PATTERN, N).astype(np.float32)
+
+
+def make_vector_relu_params(vector_alphas: np.ndarray) -> np.ndarray:
+    payload = np.resize(vector_alphas, FP_RELU_ELEMS).astype(np.float32)
+    return np.array([encode_scale(float(alpha)) for alpha in payload], dtype=np.uint32)
+
+
+def vector_relu(data: np.ndarray, vector_alphas: np.ndarray) -> np.ndarray:
+    return np.where(
+        data >= np.float32(0.0),
+        data,
+        data * vector_alphas.reshape(1, N),
+    )
+
+
 def generate(output_dir: Path, seed: int) -> None:
     rng = np.random.default_rng(seed)
     lhs = rng.uniform(-2.0, 2.0, size=(M, K)).astype(np.float16)
     rhs = rng.uniform(-1.5, 1.5, size=(K, N)).astype(np.float16)
-    relu_fp = np.full(FP_RELU_ELEMS, encode_scale(float(ALPHA)), dtype=np.uint32)
+    vector_alphas = make_vector_alphas()
+    relu_fp = make_vector_relu_params(vector_alphas)
 
     lhs32 = lhs.astype(np.float32)
     rhs32 = rhs.astype(np.float32)
@@ -42,7 +61,10 @@ def generate(output_dir: Path, seed: int) -> None:
     for k_idx in range(K):
         matmul += lhs32[:, k_idx:k_idx + 1] * rhs32[k_idx:k_idx + 1, :]
 
-    golden = scalar_relu(matmul).astype(np.float16)
+    scalar_golden = scalar_relu(matmul).astype(np.float16)
+    vector_golden = vector_relu(matmul, vector_alphas).astype(np.float16)
+    if np.array_equal(scalar_golden, vector_golden):
+        raise AssertionError("vector relu golden must differ from scalar relu golden")
 
     output_dir.mkdir(parents=True, exist_ok=True)
     lhs.reshape(-1).tofile(output_dir / "v1.bin")
@@ -50,6 +72,7 @@ def generate(output_dir: Path, seed: int) -> None:
     relu_fp.reshape(-1).tofile(output_dir / "v3.bin")
     for index in range(4, 10):
         np.zeros((M, N), dtype=np.float16).reshape(-1).tofile(output_dir / f"v{index}.bin")
+        golden = scalar_golden if index in (4, 6, 8) else vector_golden
         golden.reshape(-1).tofile(output_dir / f"golden_v{index}.bin")
 
 

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/kernel.pto
@@ -56,7 +56,7 @@ module attributes {pto.target_arch = "a5"} {
     %l1_fp_raw = pto.castptr %c131072_i64 : i64 -> !pto.ptr<ui32, mat>
     %l1_scalar = pto.castptr %c196608_i64 : i64 -> !pto.ptr<f16, mat>
     %l1_vector = pto.castptr %c262144_i64 : i64 -> !pto.ptr<f16, mat>
-    %fb_relu = pto.castptr %c65600_i64 : i64 -> !pto.ptr<ui64, scaling>
+    %fb_relu = pto.castptr %c65600_i64 : i64 -> !pto.ptr<f32, scaling>
     %ub_scalar = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_vector = pto.castptr %c32768_i64 : i64 -> !pto.ptr<f16, ub>
     %ub_l1_scalar = pto.castptr %c65536_i64 : i64 -> !pto.ptr<f16, ub>
@@ -104,41 +104,37 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.fp_load %l1_fp_raw, %fb_relu, %c8_i64
         nburst(%c1_i64, %c0_i64, %c0_i64)
-        : !pto.ptr<ui32, mat>, !pto.ptr<ui64, scaling>, i64, i64, i64, i64
+        : !pto.ptr<ui32, mat>, !pto.ptr<f32, scaling>, i64, i64, i64, i64
 
-      pto.acc_store_ub %l0c, %ub_scalar, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_ub %l0c, %ub_scalar, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f32, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_vector, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_ub %l0c, %ub_vector, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%fb_relu, mode = vector_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
-          f32, !pto.ptr<ui64, scaling>, i64, i64, i64
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
+          f32, !pto.ptr<f32, scaling>, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_scalar_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_scalar_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%c025_f32, mode = scalar_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
           f32, f32, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_vector_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_vector_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(%fb_relu, mode = vector_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
-          f32, !pto.ptr<ui64, scaling>, i64, i64, i64
+          f32, !pto.ptr<f32, scaling>, i64, i64, i64
 
       pto.acc_store %l0c, %l1_scalar, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
@@ -153,7 +149,7 @@ module attributes {pto.target_arch = "a5"} {
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, mat>, i64, i64, i64, i64,
-          f32, !pto.ptr<ui64, scaling>, i64, i64, i64
+          f32, !pto.ptr<f32, scaling>, i64, i64, i64
 
       pto.set_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]
       pto.wait_flag["PIPE_FIX", "PIPE_MTE1", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-ub-cv/kernel.pto
@@ -90,33 +90,29 @@ module attributes {pto.target_arch = "a5"} {
       pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
       pto.set_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE2", "PIPE_FIX", "EVENT_ID0"]
-      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_relu, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, i64, i64, i64
-      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64,
-        %c0_i64,
+      pto.acc_store_ub %l0c, %ub_clip, %c40_i64, %c64_i64, %c48_i64, %c64_i64, dst_mode(%c0_i64),
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
-        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64,
+        : !pto.ptr<f32, acc>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64,
           f32, f16, i64, i64, i64
 
-      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_relu_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = normal_relu),
         nz2nd,
         loop3(%c1_i64, %c49152_i64, %c2560_i64)
         : !pto.ptr<f32, acc>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64,
           f32, i64, i64, i64
-      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64,
-        %c0_i64, %c0_i64,
+      pto.acc_store_gm %l0c, %out_gm_clip_gm, %c40_i64, %c64_i64, %c48_i64, %c64_i64, %c0_i64, %c0_i64,
         pre_quant(%c1_f32, mode = qf322f16_pre_scalar),
         pre_relu(mode = no_relu, clip = %c8_f16),
         nz2nd,


### PR DESCRIPTION
## Summary
- add semantic MAD/MAD_MX wrapper ops and expand them through the VPTO wrapper-op pass
- finalize Cube/FIXPIPE MTE semantic documentation, operand constraints, and manual-authoring guidance
- complete acc_store structured interface coverage, including sat/nosat, dual UB destination, typed scaling payload pointers, and focused lit/SIM tests

## Validation
- `cmake --build .work/build -j64 --target ptoas`
- focused `lit` coverage for acc_store/fp_load/FIXPIPE verifier cases
- focused VPTO SIM compare coverage:
  - `micro-op/cv-mixed/fixpipe-quant-ub-cv`
  - `micro-op/cv-mixed/fixpipe-quant-clip-f16-ub-cv`
  - `micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv`
  - `micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv`
