### PR TITLE
feat(fusion): port tile fusion onto feature-vpto-backend

### DIFF
--- a/docs/ptoas-tile-fusion-design.md
+++ b/docs/ptoas-tile-fusion-design.md
@@ -1,0 +1,700 @@
+# Tile Fusion 设计说明文档
+
+## 1. 引言
+
+### 1.1 背景与动机
+
+PTO 指令在 Davinci 架构上以 Unified Buffer（UB）中驻留的数据块（Tile）为操作对象。这种模型虽然表达能力很强，但在多条 PTO 指令连续执行时会引入两类开销：
+
+- **访存开销**：每条 PTO 指令（如 `pto.tadd`）将输入从 UB 读入向量寄存器，计算后再将结果写回 UB。当多条指令串联时，中间结果需要经历 UB 的一次完整往返——由生产者写入、再由消费者重新读出——产生冗余的带宽消耗。
+- **控制开销**：每条 PTO 指令会展开为一组以 Tile 形状为参数的硬件循环。多条 PTO 指令意味着多组循环初始化、分支预测和指令发射。
+
+**示例：`D = Relu(Add(A, B))`**
+
+*非融合执行：*
+
+1. **循环 1 (Add)**：从 UB 读取 Tile A, B → 执行加法 → 结果 Tile C 写回 UB。
+2. **循环 2 (Relu)**：从 UB 读取 Tile C → 执行 ReLU → 结果 Tile D 写回 UB。
+
+*瓶颈*：Tile C 被写入 UB 后立即又被读回——这是一次完全冗余的往返。此外两组独立的循环控制器被分别创建和销毁。
+
+*融合执行：*
+
+1. **单一循环**：从 UB 读取 Tile A, B → 执行加法 → **寄存器级直传** → 执行 ReLU → 结果 Tile D 写回 UB。
+
+*收益*：消除了中间 Tile C 的 UB 读写。两组循环控制器合并为一组，循环管理开销减半。
+
+**数据流对比：**
+
+```text
+      [非融合模式]                           [融合模式]
+      (循环1: Add)                        (单一循环)
+    ┌───────────────┐                     ┌───────────────┐
+    │ Read A, B     │                     │ Read A, B     │
+    │      │        │                     │      │        │
+    │ Compute Add   │                     │      │        │
+    │      │        │                     │      │ (Reg)  │
+    │ Write C to UB │──┐ (UB 延迟)        │ Compute Relu  │
+    └───────────────┘  │                  │      │        │
+    (循环2: Relu)      │                  │ Write D to UB │
+    ┌───────────────┐  │                  └───────────────┘
+    │ Read C fr UB  │◀─┘
+    │      │        │               >> 消除中间写回/读取
+    │ Compute Relu  │               >> 合并循环控制逻辑
+    │      │        │
+    │ Write D to UB │
+    └───────────────┘
+```
+
+**现有瓶颈总结**：串联 PTO 指令间频繁的 UB 读写导致带宽争抢、循环控制指令占比过高、以及计算单元在等待访存时空闲。
+
+### 1.2 设计目标与范围
+
+#### 1.2.1 融合范围
+
+本特性首期聚焦于 `docs/PTO_IR_manual.md` 中所有硬件映射为 **Vector Pipeline（`PIPE_V`）** 的 PTO 指令。
+
+**支持的指令：**
+
+| 类别 | 指令 |
+|---|---|
+| 向量算术运算（逐点） | `pto.tadd`, `pto.tsub`, `pto.tmul`, `pto.tdiv`, `pto.tmax`, `pto.tprelu` |
+| 向量-标量算术运算 | `pto.tadds`, `pto.tsubs`, `pto.tmuls`, `pto.tmaxs` |
+| 向量规约与广播 | `pto.trowsum`, `pto.tcolmax`, `pto.trowexpand`, `pto.tcolexpand` |
+| 向量位运算 | `pto.tand`, `pto.tor`, `pto.txor` |
+| 局部数据搬运 | `pto.tmov`（ACC ↔ VEC 域移动）, `pto.ttrans`（转置） |
+
+**不在范围内：** Matrix Pipeline（`PIPE_M`）的矩阵乘法指令和 DMA Pipeline（`PIPE_MTE`）的数据搬运指令不参与内部融合逻辑，但它们可以作为融合链路的起点或终点。
+
+#### 1.2.2 融合准则
+
+并非任意两条 `PIPE_V` 指令都可以融合。必须满足以下核心准则：
+
+##### 准则一：迭代空间一致性
+
+参与融合的指令必须在相同的逻辑迭代域内执行。对于 PTO Tile 而言，这意味着其逻辑计算形状（有效形状，即 `v_row` 和 `v_col`）必须能够对齐到同一个循环空间。
+
+- **物理与逻辑解耦**：物理形状决定内存分配，可以不同；逻辑形状决定计算范围，必须一致。
+- **可融合示例**：
+  - *场景 A（完全匹配）*：OP1 和 OP2 的逻辑形状均为 `16×128`。融合后生成单一 `16 × 128` 硬件循环。
+  - *场景 B（物理布局不同）*：OP1 的 Tile 物理大小为 `32×128`，有效区域为 `v_row=16, v_col=128`；OP2 的 Tile 物理大小为 `16×128`，有效区域亦为 `16×128`。两者在相同的逻辑域内迭代——可融合。
+  - *场景 C（异构输出形状、同域）*：`OP1: C = Add(A, B)`（输出 Tile 16×128）后接 `OP2: d = RowSum(C)`（输出向量 16×1）。迭代域兼容。
+- **不可融合示例**：
+  - *场景 D（逻辑形状冲突）*：OP1 逻辑形状 `16×128`，OP2 逻辑形状 `8×128`。迭代边界不一致会导致循环次数错误，首期不支持此类非对齐融合。
+  - *场景 E（动态形状无法证明）*：OP1 的 `v_row` 为动态值 `%M1`，OP2 的 `v_row` 为动态值 `%M2`。若编译器无法静态证明 `%M1 == %M2`（例如通过符号分析追溯两者来自同一个 `pto.get_tensor_view_dim`），则保守拒绝融合。
+
+##### 准则二：数据依赖与映射规则
+
+- **逐点指令的普适性**：逐点指令（如 `Add`, `Mul`, `Relu`）不改变数据索引映射关系，是构建融合链的最灵活基础单元。
+- **弱依赖规则**：融合不强制要求指令间存在数据流依赖。处于同一迭代空间且无依赖的并行独立指令仍可通过"控制流融合"受益——合并循环逻辑以降低控制开销。
+- **深度融合规则**：当指令间存在生产者-消费者关系且满足逐点对逐点（1:1）映射时，触发"访存消除融合"，利用寄存器级直传彻底省去中间 Tile 的 UB 读写。
+- **规约适配规则**：在 A5 硬件支持下，逐点指令与规约（Reduce）指令的组合同样遵循深度融合规则，支持在寄存器内完成即时累加并消除访存。
+- **示例**：
+  - *场景 F（并行无依赖融合）*：`OP1: C = Add(A, B)` 和 `OP2: F = Mul(D, E)`。虽无数据依赖，但合并为单一循环可降低控制开销并提升计算单元利用率。
+  - *场景 G（逐点深度融合，1:1 映射）*：`OP1: C = Add(A, B)`, `OP2: D = Relu(C)`。最典型的 1:1 场景。`C` 在寄存器中直接被 `Relu` 消费，彻底消除了中间 Tile 的物理内存分配。
+  - *场景 H（跨模式融合，逐点 + 规约）*：`OP1: C = Add(A, B)`, `OP2: d = RowSum(C)`。在 A5 上，`RowSum` 指令可在向量寄存器内跨列累加的同时完成加法运算。融合不仅合并了循环，还消除了大尺寸 Tile `C` 在 UB 上的存储和加载开销。
+
+##### 准则三：内存布局兼容性与弹性适配
+
+**标准规则（布局一致）**：参与融合的输入/输出 Tile 在元数据和硬件访问模式上必须完全兼容：
+
+- **元数据对齐**：Tile 的基础布局（`blayout`，如行优先/列优先）、二级布局（`slayout`）、分形大小（`fractal`）以及数据类型（`dtype`）必须完全一致。
+- **内存映射一致**：在硬件层面，逻辑索引为 `(i, j)` 的元素在寄存器序列中的物理位置，无论由哪条指令访问都必须相同。
+- **不匹配的后果**：若布局不同（例如 OP1 输出为行优先，OP2 要求列优先输入），即使迭代空间相同，元素在寄存器中的排列顺序也是"错位"的。因此标准规则要求物理布局对齐，以支持零开销的寄存器级传参。
+
+**特殊场景适配：**
+
+- **虚拟布局变换**：若中间指令为纯布局转换（如 `pto.ttrans`），编译器可将布局转换开销吸收到计算循环的索引映射中，通过调整向量寄存器访问步长或偏移来消除物理转置代价。
+- **硬件重排加速**：利用 A5 硬件在向量寄存器内部的混叠/排列指令，在计算过程中实时调整数据顺序，从而支持不同布局指令的融合。
+
+**示例：**
+
+- *场景 I（转置消除融合）*：`OP1: B = Transpose(A)`（通过 `pto.ttrans`），`OP2: C = Relu(B)`。若单独执行，`Transpose` 需要在 UB 上进行物理搬移。通过融合，编译器可生成一个"按列遍历"的 `Relu` 计算核心直接处理 Tile `A`。逻辑上的中间变量 `B` 消失了，物理转置的冗余访存也被彻底消除。
+
+##### 准则四：寄存器与硬件参数预算约束
+
+- **物理寄存器限制**：Davinci A5 拥有 32 个向量寄存器（`V0`–`V31`）。融合链中所有活跃变量（输入、中间结果、临时变量）总数不得超过此阈值，否则会产生寄存器溢出（Spill），导致数据被迫写回 UB/L1，严重拖慢性能。
+- **VF 参数限制**：向量函数（Vector Function, VF）硬件循环的参数列表（包括 Tile 物理地址、步长 Stride、形状 Shape 等元数据）上限为 32。如果融合后的单一大循环涉及过多独立 Tile 对象，将导致 VF 调用参数超限。
+- **示例**：
+  - *场景 J（参数与寄存器双重超限）*：尝试将一个涉及 18 个不同输入项的复杂融合链（如 18 路 Tile 加法）进行融合。
+    - *分析*：(1) **参数溢出**：18 个输入 Tile 地址 + 1 个输出 Tile 地址 + 对应的 Stride 元数据，总参数数量极易触碰 32 个 VF 参数的硬件上限。(2) **寄存器溢出**：若循环展开导致超过 32 个 128-bit 向量值同时处于活跃状态，硬件无法在不写回内存的情况下维持寄存器级传参。
+    - *决策*：此时编译器必须在中间点强制截断融合链，将部分结果写回 UB，在两个独立的 VF 循环中执行。
+
+##### 准则五：典型支持模式
+
+- **线性链路**：`A → B → C` 的连续逐点运算。
+- **并行独立融合**：将处于同一迭代空间、无直接数据流依赖的多条指令组合进同一硬件循环，降低控制开销。
+- **广播融合**：`pto.trowexpand` / `pto.tcolexpand` 后紧跟逐点运算。
+- **末端规约融合**：一系列逐点运算后紧跟 `pto.trowsum` 或 `pto.tcolmax`。
+- **规约 + 逐点**：规约指令的输出向量直接作为后续逐点指令的输入。
+- **逐点 + 广播**：逐点运算的结果 Tile 直接作为广播指令的输入，在寄存器层面完成扩展。
+- **规约 + 广播**：常见的 Softmax 结构优化。规约得到的行/列极值直接通过广播扩展回 Tile 形状进行后续计算。
+
+### 1.3 核心设计思想
+
+核心思路是在 MLIR 层面将多条 PTO 指令的循环体进行融合，通过向量寄存器直接传递中间数据。这实现了以下优化目标：
+
+- **减少 UB 访存**：通过寄存器级数据流水化替代物理 Tile 的中间写回与读取，消除冗余带宽消耗。
+- **降低控制开销**：将多组硬件循环合并为单一循环结构，减少循环初始化、分支预测及指令发射开销。
+- **提升计算效率**：通过指令重排与循环展开，使向量计算单元尽可能保持在满载状态。
+- **可预期性**：融合边界显式且可预测，上层编译器框架可以明确预期哪些指令组合能够获得寄存器级加速。
+
+---
+
+## 2. 硬件架构与约束
+
+### 2.1 Davinci A5 存储层次与访存成本
+
+- **Global Memory (GM)**：百 GB/s 级带宽，高访存延迟（数百周期）。
+- **Unified Buffer (UB)**：TB/s 级带宽，中等访存延迟。PTO 指令默认以此为输入输出媒介。
+- **向量寄存器 (Vector Register)**：指令级单时钟周期访问。
+
+**融合驱动力**：PTO 指令间若通过 UB 传递数据，会受限于 UB 的读写带宽；通过寄存器直传可将数据流提升至寄存器级带宽，消除物理存取延迟。
+
+### 2.2 向量计算流水线与执行机制
+
+- **双发射流水线**：Davinci 支持两组向量计算流水线（Pipe V），通过合理的指令调度可隐藏计算延迟。
+- **硬件循环 (Vector Function)**：内置硬件循环控制器，初始化开销不可忽略。融合后的"单大循环"能有效摊薄循环头（Prologue）和循环尾（Epilogue）的指令周期。
+- **向量掩码 (VMSK)**：用于处理非对齐边界。融合时需确保不同指令的掩码逻辑在同一个循环迭代内是可组合的。
+
+### 2.3 物理对齐与 Tile 布局约束
+
+- **32B/512B 对齐要求**：Davinci 架构对 UB 地址及 Tile 宽度有严格的对齐要求。
+- **Padding 填充**：当逻辑（有效）形状小于物理形状时，硬件会在物理 Tile 边缘填充无效数据。融合时必须严格限定计算边界，防止对无效填充区进行错误累加。
+- **分形布局机制**：针对矩阵/分形操作的特殊布局。向量运算在处理此类布局时需要额外的混叠或步长计算。
+
+---
+
+## 3. 设计难点与挑战
+
+### 3.1 寄存器压力
+
+- **溢出风险**：融合多条指令会显著增加活跃变量数量。若所需向量寄存器超过硬件上限，会产生寄存器溢出，导致数据写回 UB 或 L1，抵消融合的访存收益。
+- **生命周期重叠**：融合后的长循环会延长中间结果的生命周期，增加寄存器分配算法的复杂度。
+
+### 3.2 内存布局与对齐
+
+- **布局不匹配**：例如生产者指令输出行优先数据，但消费者指令要求列优先输入。融合此类指令可能需要插入昂贵的转置或混排指令，抵消访存收益。
+- **非逐点操作**：规约或数据搬运指令的融合涉及复杂的索引变换和同步逻辑。
+
+### 3.3 循环控制与同步
+
+- **循环结构差异**：具有不同遍历范围或步长的指令融合时，需要精细的循环剥离或填充技术。
+- **细粒度同步**：在某些流水线架构中，融合后的长指令序列可能导致硬件流水线死锁或违反数据依赖顺序。
+
+### 3.4 成本模型与边界决策
+
+- **贪心策略的局限性**：过度融合可能导致代码膨胀和指令 Cache 缺失。
+- **自适应决策**：在不同 Tile Shape 和硬件配置下自动决定最优融合边界，在一般情形下是一个 NP-hard 问题。
+
+---
+
+## 4. IR 表示与流水线集成
+
+### 4.1 PTO Dialect 背景
+
+融合系统工作在 PTO Tile 级 Dialect 之上，包括 `pto.alloc_tile`、`pto.load_tile`、`pto.store_tile` 等核心指令以及 §1.2.1 中列出的计算指令。这些指令现有的 Lowering 路径构成了融合机制的基础。
+
+### 4.2 融合流水线位置
+
+#### 4.2.1 生效条件
+
+融合仅在 `tools/ptoas/ptoas.cpp` 的 A5 VPTO 后端主线上生效，需同时满足以下全部条件：
+
+- `--pto-backend=vpto`
+- `--pto-arch=a5`
+- 显式传入 `--enable-op-fusion`
+
+#### 4.2.2 输入层级支持
+
+| Level | 状态 | 说明 |
+|---|---|---|
+| `level2` | 支持 | 融合适配器在 `PlanMemory` 之前运行。 |
+| `level3` | 支持 | 融合适配器直接工作在 manual-address tile-native IR 上。 |
+| `level1` | N/A | 当前迁移范围内无可支持的输入面。 |
+
+#### 4.2.3 主线 Pass 序列
+
+1. **共享 tile-native 预处理**：
+   ```
+   PTOAssignDefaultFrontendPipeId → PTOLowerFrontendPipeOps →
+   PTOInferValidatePipeInit → LoweringSyncToPipe → InferPTOLayout →
+   PTOA5NormalizeTMov
+   ```
+
+2. **融合核心**（在 `PlanMemory` 决策点之前插入，当 A5 VPTO 融合条件满足时）：
+   ```
+   FusionPlan → OpScheduling → PTOFusionRegionGen
+   ```
+
+3. **Level 特定适配器**：
+   - `level2`：`共享融合核心 → PlanMemory → PTOResolveReservedBuffers → (可选) PTOInsertSync`
+   - `level3`：`共享融合核心 → 跳过 PlanMemory → PTOResolveReservedBuffers`
+     （若在 `level3` 下显式开启 `--enable-insert-sync`，会打印 warning 并忽略。）
+
+4. **ExpandTileOp 分界**（过渡到 VPTO 后端 Lowering）：
+   ```
+   ExpandTileOp → PTOInlineLibCall → FoldTileBufIntrinsics → SCCP → Canonicalizer
+   ```
+
+5. **Post-lowering 融合生命周期**（仅 fused A5 VPTO 路径）：
+   ```
+   PTOLowLevelLoopFusion → Canonicalizer → CSE →
+   PTOFusionPredicateElision → PTOFusionLoadStoreElision →
+   PTOFlattenFusionRegion → CSE
+   ```
+
+6. **VPTO 发射准备**：
+   ```
+   Canonicalizer/CSE → VPTOPtrNormalize → VPTOPtrCastCleanup →
+   ReconcileUnrealizedCasts → PTOVPTOExpandBridgeOps →
+   PTOInferVPTOVecScope → Canonicalizer → CSE →
+   PTOValidateVPTOEmissionIR
+   ```
+
+#### 4.2.4 非目标路径
+
+- EmitC 后端会忽略 `--enable-op-fusion`。
+- 未开启 `--enable-op-fusion` 时，普通 VPTO 路径不会形成 `pto.fusion_region`，也不会进入 post-lowering 融合生命周期。
+- 后端分界线已固定为 `ExpandTileOp`；原有的 `View2Memref` / `PTOToA5VM` 主线已移除。
+
+---
+
+## 5. Pass 详细设计
+
+### 5.0 融合转换流水线总览
+
+```text
+    [tile-native PTO IR]
+               │
+               ▼
+    5.1  PreFusionAnalysis（纯分析）
+               │
+               ▼
+    5.2  迭代域证明（内嵌于预分析；无独立 ShapeInferencePass）
+               │
+               ▼
+    5.3  FusionPlan
+               │
+               ▼
+    5.4  OpScheduling（组内物理聚拢）
+               │
+               ▼
+    5.5  PTOFusionRegionGen（区域封装）
+               │
+               ▼
+    5.6  Level 特定适配器（ExpandTileOp 之前）
+         level2: PlanMemory → ResolveReservedBuffers → 可选 InsertSync
+         level3: 跳过 PlanMemory → ResolveReservedBuffers
+               │
+               ▼
+    5.7  VPTO 后端分界
+         (ExpandTileOp → InlineLibCall → FoldTileBufIntrinsics →
+          SCCP → Canonicalizer)
+               │
+               ▼
+    5.8  PTOLowLevelLoopFusion
+               │
+               ▼
+    5.9  后融合规范化与谓词消除
+         (Canonicalizer → CSE → PTOFusionPredicateElision)
+               │
+               ▼
+    5.10 PTOFusionLoadStoreElision（区域内访存消除）
+               │
+               ▼
+    5.11 PTOFlattenFusionRegion → CSE（区域展平）
+               │
+               ▼
+    5.12 VPTO 发射准备
+         (ptr 归一化 / bridge 展开 / vecscope 推断 / 发射 IR 校验)
+               │
+               ▼
+    5.13 VPTO 后端发射
+         (VPTO 文本 / LLVM 发射)
+```
+
+### 5.1 PreFusionAnalysis（纯分析）
+
+**设计动机。** 为 `FusionPlan` 提供可复用的 block-local 分析结果，不修改 IR。将哪些 op 能参与 tile fusion、哪些值会跨越 local/hard boundary 逃逸、哪些 op 处于同一迭代域等所有决策前置到统一分析中，供规划、封装及后续 region-local 清理复用。
+
+**流水线位置。**
+- **前置条件**：IR 仍在 tile-native `tile_buf` 语义世界，尚未跨越 `ExpandTileOp` 分界。
+- **后置条件**：生成 `PreFusionAnalysis` 结果对象。此 pass 不在默认主线中单独插入；`FusionPlanPass` 通过 `getAnalysis<pto::PreFusionAnalysis>()` 直接消费。
+
+**输入/输出规格。**
+- **输入**：`func::FuncOp` 内的 PTO tile-level IR。
+- **输出**：每个 basic block 的 `FusionBlockAnalysis`，主要包含：
+  - `computeNodes`：可参与预融合建模的 compute node。
+  - `edges`：生产者/消费者依赖边。
+  - `valueLiveness` / `writeInstances`：值和写实例的生命周期类别与逃逸类别。
+  - `iterationDomainClasses`：按 `(v_row, v_col)` 证明结果划分的迭代域等价类。
+
+**核心逻辑与约束。**
+- **Op 语义分类**：`FusionOpSemantics` 将 op 分为 `Compute`、`LocalBoundary`、`HardBoundary`。
+  - `treshape` 被视为 `LocalBoundary`，会阻断穿越它的局部规划与调度。
+  - 无 `OpLibOpInterface`、带 region/call/未知副作用的 op，一律按 `HardBoundary` 处理。
+- **当前可识别的 compute family**：
+  - `Elementwise`：`tadd/tsub/tmul/tdiv/tmax/tmin` 及对应 scalar 版本、`texp`
+  - `ScalarExpand`：`texpands`
+  - `RowBroadcastBinary`：`trowexpandmul`、`trowexpanddiv`
+  - `ReduceRow/ReduceCol`：`trowsum/trowmax/trowmin`、`tcolsum/tcolmax/tcolmin`
+- **依赖与生命周期建模**：
+  - 通过 SSA use-def 链和 DPS 输出归一化收集 tile 输入/输出。
+  - 记录 block 内 consumer、local boundary user、hard boundary user、块外逃逸信息。
+  - 写实例进一步区分为 `Internal`、`LocalBoundaryExternal`、`HardExternal`，供 region output/frontier 计算使用。
+- **分析范围**：严格限制在单个 basic block 内，不做跨 block、跨 CFG 的全局规划。
+
+**不变性与副作用。**
+- 纯分析，不修改 IR。
+- 可通过 `pto-pre-fusion-analysis` / `pto-print-pre-fusion-analysis` 做调试或 lit 检查，但它们不是默认后端主线的一部分。
+
+### 5.2 迭代域证明
+
+**设计动机。** 当前代码中形状推导尚未落成独立 pass。真正被主线依赖的是 `FusionAnalysis.cpp` 中对迭代域的保守证明：只有当参与计算的 anchor tile 能在编译期证明为一致的 rank-2 有效形状时，规划阶段才会继续融合。
+
+**流水线位置。**
+- **前置条件**：依赖 §5.1 中的 op 语义分类和 tile 类型/`pto.bind_tile` 元数据。
+- **后置条件**：不修改 IR。分析结果中的 `IterationDomainInfo` 会被标注为 `Proven` 或 `Unproven` 并附带失败原因。
+
+**输入/输出规格。**
+- **输入**：compute op 的 tile 输入/输出及其有效形状信息。
+- **输出**：`IterationDomainInfo { vRow, vCol, proof, unprovenReason }`。
+
+**核心逻辑与约束。**
+- **当前证明来源**：
+  - 优先读取 `TileBufType::validShape`。
+  - 若值来自 `pto.bind_tile`，则用其常量 `validRow/validCol` 覆盖类型上的静态形状。
+  - `Elementwise` 聚合输入和输出；`ScalarExpand/RowBroadcastBinary` 用输出域；`ReduceRow/ReduceCol` 用输入域。
+- **失败情形**：
+  - 任一关键维度为动态值。
+  - 同一组 anchor 的 `(v_row, v_col)` 不一致。
+  - 缺少可恢复的 tile domain 信息。
+- **现实边界**：实现中明确不尝试证明动态符号等价。带动态 `v_row/v_col` 的链路保持 `Unproven`，并在 §5.3 的规划阶段被保守拒绝。
+
+**不变性与副作用。**
+- 不生成新 attribute，不重写类型，不引入新的 shape solver。
+
+### 5.3 FusionPlanPass
+
+**设计动机。** 消费 §5.1 和 §5.2 的分析结果，为 block 内 op 打上稳定的组元数据，形成后续调度和区域封装的唯一输入契约。当前实现优先保证保守可用，而非开放式策略插件框架。
+
+**流水线位置。**
+- **前置条件**：`PreFusionAnalysis` 有效，op 仍处于 tile-level PTO IR。
+- **后置条件**：被接受的组成员获得：
+  - `pto.fusion.group_id`
+  - `pto.fusion.order`
+
+**输入/输出规格。**
+- **输入**：`FusionBlockAnalysis`。
+- **输出**：带规划 metadata 的原始 PTO IR。仅组大小 ≥ 2 的 group 才会落盘。
+
+**核心逻辑与约束。**
+- **当前策略**：
+  - `ConservativeDAGGreedyStrategyEngine`
+  - `ConservativeDAGGreedyCostModel`
+- **可规划 op 子集**（比 §5.1 中可分析的 compute family 更窄）：
+  - `tadd/tsub/tmul/tdiv/tmax/tmin`
+  - `tadds/tsubs/tmuls/tdivs/tmaxs/tmins`
+  - `texp`
+  - `texpands`
+  - `trowexpandmul`
+  - `trowexpanddiv`
+- **Seed 条件**：
+  - op 必须属于上述可规划集合。
+  - 其迭代域类必须是 `Proven`。
+- **Append 条件**：
+  - candidate 与当前组首成员属于同一 `iterationDomainClass`。
+  - candidate 与当前组至少存在一条直接数据流连接。
+  - 成本模型评分：`dependencyBenefit + loopMergeBenefit - liveTilePenalty - vfParameterPenalty > 0`。
+- **当前成本模型参数**：
+  - `dependencyBenefit = 4 × connectionCount`
+  - `loopMergeBenefit = 4`
+  - 当 `liveTileCount > 10` 时开始罚分
+  - 当 `vfParameterCount > 12` 时开始罚分
+- **结果排序**：
+  - 组内顺序按 `blockOrder/id` 稳定排序。
+  - `group_id` 按组首成员的 block 顺序稳定分配。
+
+**不变性与副作用。**
+- 只打 metadata，不移动 op。
+- 当前未将策略接口暴露为可插拔配置点。ML/AI 决策接口仍属于未来方向。
+
+### 5.4 OpSchedulingPass
+
+**设计动机。** 将 §5.3 已规划好的 group 压缩成 block 内连续 span，为 `PTOFusionRegionGen` 提供"一组对应一个连续区间"的结构前提。
+
+**流水线位置。**
+- **前置条件**：op 已带有完整的 `pto.fusion.group_id/order`。
+- **后置条件**：每个 group 在 block 中形成一个连续 span，组成员关系不变。
+
+**输入/输出规格。**
+- **输入**：带规划 metadata 的 PTO IR。
+- **输出**：物理顺序重排后的 PTO IR。
+
+**核心逻辑与约束。**
+- **Barrier 分类**：
+  - `Movable`：普通可移动 compute op。
+  - `LocalBoundary`：例如 `treshape`，在无 tile 依赖冲突时可跨越。
+  - `HardBoundary`：call、region op、未知副作用 op、不可安全移动的边界。
+- **调度策略**：
+  - 按 `group_id` 收集成员，再按 `pto.fusion.order` 排序。
+  - 对组内后续成员，优先尝试前移到当前 `placement` 之后。
+  - 若前移受阻，则在不违反 later-crossing 约束时反向尝试将 `placement` 后推。
+- **合法性检查**：
+  - 不能跨越 operand 的定义点。
+  - 不能将 producer 移到某个 consumer 之后。
+  - 不能越过 hard boundary。
+  - 穿越 local boundary 时，需确认双方不共享 tile input/output 依赖。
+
+**不变性与副作用。**
+- 会改写 block 内 op 顺序。
+- 不改 group metadata，不改 CFG。
+
+### 5.5 PTOFusionRegionGenPass
+
+**设计动机。** 将连续 span 封装成显式 `pto.fusion_region`，为 VPTO post-lowering 的 region-local 循环融合、谓词清理和 load/store 消除提供容器边界。
+
+**流水线位置。**
+- **前置条件**：同一 `group_id` 在 block 中已是单一连续 span。
+- **后置条件**：每个 span 被包成一个 `pto.fusion_region`，并用 `pto.yield` 显式声明对外可见的 frontier。
+
+**输入/输出规格。**
+- **输入**：已调度好的 block-local group span。
+- **输出**：`pto.fusion_region` 包装后的 PTO IR。
+  - region 不显式建模输入 block argument。
+  - region body 直接隐式捕获父作用域 SSA 值。
+  - `pto.yield` 只返回真正对 region 外可见的 value。
+
+**核心逻辑与约束。**
+- **Span 识别约束**：
+  - 同一 `group_id` 在一个 block 里必须只出现一个连续 span，否则直接报错。
+  - 组内 `pto.fusion.order` 必须严格递增。
+- **Frontier 计算**：
+  - `PTOFusionRegionGen` 结合 use-def 分析和 `PreFusionAnalysis` 的写实例逃逸信息，找出必须在 region result 列表中保留的 escaping value。
+  - 仅 region 内使用、或虽有外用但不可被 region result 合法替换的值，不会盲目外提。
+- **结构约束**：
+  - 一组对应一个 region。
+  - 不额外生成 region 输入 operands。
+  - 允许空 result / 空 `pto.yield`。
+
+**不变性与副作用。**
+- 会引入嵌套 region，显著改变 IR 结构。
+- 这是当前主线中真正将"逻辑 fusion group"转成"后续 backend 可识别容器"的分界点。
+
+### 5.6 Level 特定适配器（`ExpandTileOp` 之前）
+
+**设计动机。** 不再为每个 level 维护独立融合实现，而是将差异收敛为适配器：共享融合核心固定在 `ExpandTileOp` 之前，`level2`/`level3` 仅在其前后的约束不同。
+
+**流水线位置。**
+- **前置条件**：`pto.fusion_region` 已建立，body 仍是 PTO tile op。
+- **后置条件**：
+  - `level2`：完成 `PlanMemory → PTOResolveReservedBuffers → 可选 PTOInsertSync`，同时保持 `pto.fusion_region` 不被破坏。
+  - `level3`：跳过 `PlanMemory`，仅做 `PTOResolveReservedBuffers`，保持 explicit-address / manual-sync 契约。
+
+**核心逻辑与约束。**
+- 共享适配器插入点固定在 `PlanMemory` 决策点之前。
+- `level2` 契约：
+  - 允许 `PlanMemory` 将 region 内外 `alloc_tile` 改写成 `pto.pointer_cast`。
+  - 允许 `PTOInsertSync` 在 region 之后追加 tail barrier。
+- `level3` 契约：
+  - 不会重新进入 `PlanMemory`。
+  - 若显式开启 `--enable-insert-sync`，会打印 warning 并忽略，以保留 manual sync contract。
+- `level1`：
+  - 架构上应同样遵循"共享融合核心在 PlanMemory 之前"。
+  - 当前分支无可用输入面，实现和测试均保持 N/A。
+
+### 5.7 VPTO 后端分界
+
+**设计动机。** `ExpandTileOp` 是当前 PTO tile IR 到 VPTO authoring IR 的硬边界。Tile fusion 必须在此之前完成 group 和 region 建模，同时确保 `pto.fusion_region` 能跨过这个 seam 供后续 post-lowering cleanup 使用。
+
+**流水线位置。**
+- **前置条件**：输入为 tile-native PTO IR；`pto.fusion_region` 可能已存在。
+- **后置条件**：
+  - Tile-level PTO op 被替换为 TileLang helper `call`/`func.call`。
+  - Helper body 被 inline 到主函数。
+  - `pto.tile_buf_addr` / `pto.tile_valid_rows` / `pto.tile_valid_cols` 等 intrinsic 被折叠为 VPTO 侧的 `memref`/`ptr`/常量。
+  - Fused 路径上 `pto.fusion_region` 继续保留。
+
+**核心逻辑与约束。**
+- 固定顺序：
+  1. `ExpandTileOp`
+  2. `PTOInlineLibCall`
+  3. `FoldTileBufIntrinsics`
+  4. `SCCP`
+  5. `Canonicalizer`
+- 现实边界：
+  - 原有的 `PTOViewToMemref` bridge 已移除，不再是有效 seam 前置条件。
+  - `FoldTileBufIntrinsics` 依赖 native tile metadata；非 native producer 的输入（如缺少地址/valid-shape 元数据的 block argument）会导致下游保守失败。
+
+### 5.8 PTOLowLevelLoopFusion
+
+**设计动机。** 真正的"循环融合"现在发生在 `ExpandTileOp` 之后，直接在 `pto.fusion_region` 内处理当前 VPTO post-lowering 的 `scf.for + memref/pto.v*` 结构。
+
+**流水线位置。**
+- **前置条件**：输入契约是保留在 `pto.fusion_region` 内的 VPTO post-lowering loop nest。
+- **后置条件**：可融合的相邻 loop stage 被聚合成共享 loop-header 的单一 carrier loop。
+
+**核心逻辑与约束。**
+- **Stage 识别方式**：
+  - 每个 stage 由 setup op、一层或多层同构 `scf.for`、以及叶子 `pto.vlds/vsts/vadd/...` 或相关纯 op 组成。
+  - 仅尝试融合彼此相邻、loop header 等价、且中间 prelude/setup 可安全重排的 stage。
+- **合法性条件**：
+  - `sameForHeader(lhs, rhs)`：下界、上界、步长和 loop attrs 必须完全等价。
+  - Prelude/setup 必须是 side-effect-free 或可分析的内存 prelude。
+  - 跨 stage 移动 prelude 时，不能与前一 stage 的内存根产生潜在 alias 冲突。
+- **现实边界**：
+  - 这是一个非常保守的 matcher，不做激进 loop normalization。
+  - 只融合"相邻 stage"，不做跨区域或跨复杂控制流的全局循环拼接。
+
+### 5.9 后融合规范化与谓词消除
+
+**设计动机。** 低层循环融合完成后，主线先做常规 `Canonicalizer + CSE`，再专门清理 fusion-region 内部冗余的 VPTO 谓词物化，减少后续 load/store 消除看到的噪声。
+
+**流水线位置。**
+- **前置条件**：`PTOLowLevelLoopFusion` 已完成。
+- **后置条件**：重复的 `pto.plt_*` 计算被压缩，后续访存消除看到的 VPTO loop body 更干净。
+
+**核心逻辑与约束。**
+- 历史上专门的 `PTOVPTOIfCanonicalize` / `A5VMIfCanonicalize` 已退役，仅使用共享 `Canonicalizer`。
+- `PTOFusionPredicateElision` 当前聚焦 `pto::PltB8/B16/B32Op`。
+- 在 fusion-region 内做保守 value 等价判断，包括：
+  - 纯 op 结果等价。
+  - Loop-carried `iter_arg` 与 `plt.scalar_out` 的直接递归等价。
+- 仅在能证明等价时复用已有谓词，避免错误跨越 side effect 或复杂循环递归。
+
+### 5.10 PTOFusionLoadStoreElision
+
+**设计动机。** 在已形成稳定 VPTO carrier loop 的前提下，消除 fusion-region 内部仅用于中转的本地 store/load 往返，将 region-local 数据通路收缩到更接近寄存器/向量值直传的形态。
+
+**流水线位置。**
+- **前置条件**：低层循环融合、全局规范化和谓词消除已完成。
+- **后置条件**：局部 `pto.vsts → pto.vlds` round-trip 被消除；非逃逸尾部 store 也可能被清理。
+
+**核心逻辑与约束。**
+- **输入契约**：处理对象是 `pto.fusion_region` 内的 VPTO post-lowering loop body，典型形态为 `scf.for + memref.subview + memref.cast + pto.vlds/vsts/vadd/...`。
+- **核心行为**：
+  - 归一化 tracked memref 根值，穿透 `bind_tile`、`memref.cast`、`reinterpret_cast`、`transpose` 等包装。
+  - 以 `pto.yield` / region result 作为"外部可见性 frontier"，避免误删需要向 region 外暴露的写回。
+  - 保守消除匹配的 store/load 对，并做 frontier-aware tail-store cleanup。
+- **现实边界**：
+  - 遇到无法做别名分析的内存 effect 会直接保守退出。
+  - 仅处理 fusion-region 局部模式，不替代通用 DSE。
+
+### 5.11 PTOFlattenFusionRegion
+
+**设计动机。** 一旦 region-local 后端优化全部结束，`pto.fusion_region` 这个结构化容器就不再需要，必须显式展平回父 block，恢复后端发射更容易消费的平面 VPTO IR。
+
+**流水线位置。**
+- **前置条件**：§5.10 之后 region 内剩余 op 已是最终 backend-ready 形式。
+- **后置条件**：`pto.fusion_region` 和 `pto.yield` 被删除，父 block 仅保留普通低层 VPTO op。
+
+**核心逻辑与约束。**
+- 将 region body 中除 terminator 外的 op 全部移到 wrapper 之前。
+- 用 `pto.yield` 的 operands 替换 `pto.fusion_region` 的结果。
+- 擦除 `pto.yield` 和 wrapper 本身。
+- 展平后再跑一轮 `CSE`，去掉 wrapper 生命周期结束后产生的冗余值。
+
+### 5.12 VPTO 发射准备
+
+**设计动机。** Post-lowering 融合生命周期结束后，IR 还需经过一段与发射器强相关的 VPTO emission preparation，才能成为真正可导出的 VPTO 文本或 LLVM 产物。
+
+**流水线位置。**
+- **前置条件**：IR 已是展平后的 backend-ready VPTO 形式。
+- **后置条件**：完成 ptr 归一化、bridge 展开、vecscope 推断和发射合法性校验。
+
+**核心逻辑与约束。**
+- 固定顺序：
+  1. `Canonicalizer + CSE`
+  2. `VPTOPtrNormalize`
+  3. `VPTOPtrCastCleanup`
+  4. `ReconcileUnrealizedCasts`
+  5. `PTOVPTOExpandBridgeOps`
+  6. `CSE`
+  7. `PTOInferVPTOVecScope`
+  8. `Canonicalizer + CSE`
+  9. `PTOValidateVPTOEmissionIR`
+- 此阶段已不属于 tile fusion 本身，但它决定了前面产出的 VPTO IR 能否成功发射。
+
+### 5.13 VPTO 后端发射
+
+**设计动机。** 当前 tile fusion 主线的最终目标是进入现有 VPTO 后端发射器：要么输出清理后的 VPTO 文本，要么继续走 LLVM emission 交给后续工具链。
+
+**流水线位置。**
+- **前置条件**：IR 已通过发射准备和合法性校验。
+- **后置条件**：生成 VPTO 文本输出或 LLVM 级后端产物。
+
+**核心逻辑与约束。**
+- `--emit-vpto` 直接输出准备完成后的 VPTO IR。
+- `--vpto-emit-hivm-llvm` / `--vpto-emit-hivm-bc` 继续走 LLVM/HIVM 导出。
+- 从 tile fusion 的角度，这里关注的是前置 pass 是否产出了结构正确的 VPTO IR，而非后端发射器本身的实现细节。
+
+---
+
+## 6. 关键算法
+
+- **预分析驱动的 block-local DFG 建模**：在 `tile_buf` 世界内提取 compute/local-boundary/hard-boundary 分类、value liveness 和 write escape class，作为所有后续决策的统一依据。
+- **保守 DAG 贪心规划**：当前默认策略是 `ConservativeDAGGreedyStrategyEngine + ConservativeDAGGreedyCostModel`，非开放式插件系统。
+- **Span 压缩调度**：通过 barrier 分类与双向移动规则，将离散 group 压成连续 span，同时维持 SSA 和 boundary 合法性。
+- **Post-lowering stage matcher**：`PTOLowLevelLoopFusion` 在 `scf.for + memref/pto.v*` VPTO 层匹配同头循环和可重排 prelude，执行保守的相邻 stage 融合。
+- **Frontier-aware cleanup**：`PTOFusionPredicateElision` 和 `PTOFusionLoadStoreElision` 都依赖 fusion-region frontier，避免把仍需对外可见的值错误消除。
+
+---
+
+## 7. 与系统其他模块的交互
+
+- **共享 pre-backend normalization**：Tile fusion 前半段与 VPTO backend 共用 `LoweringSyncToPipe`、`InferPTOLayout`、`PlanMemory`、`PTOResolveReservedBuffers`、可选 `PTOInsertSync` 等 pass；其中 `level3` 会显式跳过 `PlanMemory`。
+- **ExpandTileOp seam 契约**：`ExpandTileOp` 是当前 PTO → VPTO 的硬边界。Tile fusion 必须在 seam 之前形成 `pto.fusion_region`，并保证 wrapper 能跨过 `InlineLibCall` / `FoldTileBufIntrinsics`。
+- **Backend emitter 契约**：上游 pass 需将 IR 收敛到 `prepareVPTOForEmission()` 可接受的形态，否则后端发射会直接失败。
+- **测试与 OpenSpec**：当前主要行为约束已转移到 `test/lit/tile_fusion/*.pto`、`test/basic/expand_tile_op_tilelang_tadds.pto`、`test/vpto/auto_vecscope_infer_boundary.pto` 以及 `openspec/changes/reintroduce-vpto-tile-fusion/*`。原有的 LibCall/CCE 设计不再是 source of truth。
+
+---
+
+## 8. 验证与测试
+
+### 8.1 功能验证
+
+- 当前功能回归以 `test/lit/tile_fusion/*.pto` 为主。原有的 `test/tile_fusion/*.mlir` 和 test-only CLI 路径已废弃。
+- 查看 frontend group/schedule/region 结果时，使用：
+  - `--mlir-print-ir-after=pto-fusion-plan`
+  - `--mlir-print-ir-after=pto-op-scheduling`
+  - `--mlir-print-ir-after=pto-fusion-region-gen`
+- 验证 backend 主线 IR 形态时，使用：
+  - `--mlir-print-ir-after=pto-expand-tile-op`
+  - `--mlir-print-ir-after=pto-low-level-loop-fusion`
+  - `--mlir-print-ir-after=pto-fusion-predicate-elision`
+  - `--mlir-print-ir-after=pto-fusion-load-store-elision`
+  - `--mlir-print-ir-after=pto-flatten-fusion-region`
+- 负例应覆盖：动态 shape、local boundary、hard boundary、不可移动副作用 op。
+
+### 8.2 性能度量
+
+- **结构指标**：
+  - `pto.fusion.group_id/order` 是否正确。
+  - `pto.fusion_region` 是否仅包住一个连续 span。
+  - `pto.fusion_region` 是否能够跨过 `PlanMemory`、`ResolveReservedBuffers`、可选 `PTOInsertSync` 和 `ExpandTileOp` seam。
+- **低层指标**：
+  - 冗余 `pto.plt_*` 是否下降。
+  - Region 内 `vlds/vsts` round-trip 是否减少。
+- **端到端测试命令**：
+  - `llvm-lit -sv test/lit/tile_fusion`
+  - 代表性 fused A5 VPTO 样例：`test/lit/tile_fusion/op_fusion_adapter_placement_level2_tadd.pto` 和 `test/lit/tile_fusion/op_fusion_adapter_placement_level3_tadd.pto`
+  - 必要时用 `--mlir-print-ir-after=<pass>` 对照关键阶段 IR。
+
+---
+
+## 9. 当前边界与后续方向
+
+### 9.1 当前边界
+
+- 主线仅覆盖 A5 VPTO backend，不覆盖 EmitC。
+- 规划仅支持保守的 block-local group，不做跨 basic block 融合。
+- 动态迭代域当前无法证明，相关链路会被拒绝。
+- `PreFusionAnalysis` 可识别的 compute family 比 `FusionPlan` 当前允许规划的 op 范围更宽。
+- `level1` 在当前迁移范围内无可支持输入面，仅保留设计位置，无实现与回归覆盖。
+
+### 9.2 后续可扩展方向
+
+- 将动态 `v_row/v_col` 证明补成独立 shape inference 主线 pass。
+- 放宽 planner 对 reduce/broadcast 组合的实际落地支持。
+- 在保持 `pto.fusion_region` 契约稳定的前提下，继续增强 post-lowering loop fusion 和 load/store elimination 的覆盖面。

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1405,6 +1405,45 @@ def SectionCubeOp : PTO_SectionOp<"section.cube">;
 def SectionVectorOp : PTO_SectionOp<"section.vector">;
 
 //===----------------------------------------------------------------------===//
+// Tile Fusion Region Ops
+//===----------------------------------------------------------------------===//
+
+def FusionRegionOp : PTO_Op<"fusion_region", [SingleBlock]> {
+  let summary = "Structured region container for one scheduled tile fusion group";
+  let description = [{
+    `pto.fusion_region` wraps one already-scheduled fusion group inside the
+    current function and exposes explicit escaping values as results.
+    The body is a lightweight single-block container and may implicitly capture
+    surrounding SSA values from the parent scope.
+  }];
+
+  let results = (outs Variadic<AnyType>:$outputs);
+  let regions = (region SizedRegion<1>:$body);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $body attr-dict `:` type(results)
+  }];
+}
+
+def YieldOp : PTO_Op<"yield", [Terminator, ParentOneOf<["FusionRegionOp"]>]> {
+  let summary = "Terminate a pto.fusion_region and return its visible outputs";
+  let description = [{
+    `pto.yield` is the dedicated terminator for `pto.fusion_region`. Its
+    operands enumerate the tile/value set that remains externally visible after
+    encapsulation. They define the region outputs in the same order as the
+    parent `pto.fusion_region` results, giving downstream passes a compact
+    summary of which internal tiles still escape the region boundary.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$values);
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    `(` $values `)` attr-dict `:` functional-type($values, results)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Frontend TPUSH/TPOP Pipe Communication Ops
 //===----------------------------------------------------------------------===//
 

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -72,9 +72,19 @@ std::unique_ptr<Pass> createPTOViewToMemrefPass();
 std::unique_ptr<Pass> createPTOMaterializeTileHandlesPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 std::unique_ptr<Pass> createPTOA5NormalizeTMovPass();
+std::unique_ptr<Pass> createPreFusionAnalysisPass();
+std::unique_ptr<Pass> createPrintPreFusionAnalysisPass();
+std::unique_ptr<Pass> createFusionPlanPass();
+std::unique_ptr<Pass> createOpSchedulingPass();
+std::unique_ptr<Pass> createPTOFusionRegionGenPass();
 std::unique_ptr<Pass> createPTOInferVPTOVecScopePass();
 std::unique_ptr<Pass> createVPTOExpandWrapperOpsPass();
 std::unique_ptr<Pass> createPTOVPTOPtrBoundaryPass();
+std::unique_ptr<Pass>
+createPTOLowLevelLoopFusionPass(const PTOLowLevelLoopFusionOptions &options = {});
+std::unique_ptr<Pass> createPTOFusionPredicateElisionPass();
+std::unique_ptr<Pass> createPTOFusionLoadStoreElisionPass();
+std::unique_ptr<Pass> createPTOFlattenFusionRegionPass();
 std::unique_ptr<Pass> createVPTOPtrNormalizePass();
 std::unique_ptr<Pass> createVPTOPtrCastCleanupPass();
 std::unique_ptr<Pass> createPTOValidateVPTOIRPass();
@@ -83,6 +93,7 @@ std::unique_ptr<Pass> createMemrefToTileBufPass();
 std::unique_ptr<Pass> createExpandTileOpPass();
 std::unique_ptr<Pass> createExpandTileOpPass(const ExpandTileOpOptions &options);
 std::unique_ptr<Pass> createFoldTileBufIntrinsicsPass();
+std::unique_ptr<Pass> createFoldTileBufIntrinsicsPass(llvm::StringRef foldMode);
 std::unique_ptr<Pass>
 createPTOInlineLibCallPass(const PTOInlineLibCallOptions &options = {});
 void registerPTOViewToMemrefPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -170,6 +170,64 @@ def PTOLoweringSyncToPipe : Pass<"pto-lowering-sync-to-pipe", "func::FuncOp"> {
   ];
 }
 
+def PreFusionAnalysis : Pass<"pto-pre-fusion-analysis", "func::FuncOp"> {
+  let summary = "Analyze block-local tile-fusion candidates before planning";
+  let description = [{
+    Builds reusable pre-planning analysis state for tile fusion in tile-native
+    PTO IR. This pass is analysis-only and does not emit grouping or
+    scheduling decisions.
+  }];
+  let constructor = "mlir::pto::createPreFusionAnalysisPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
+def PrintPreFusionAnalysis
+    : Pass<"pto-print-pre-fusion-analysis", "func::FuncOp"> {
+  let summary = "Print pre-fusion analysis results for testing and debugging";
+  let description = [{
+    Computes the pre-fusion analysis result and prints a stable textual dump of
+    block-local compute nodes, edges, liveness, iteration-domain classes, and
+    local boundaries.
+  }];
+  let constructor = "mlir::pto::createPrintPreFusionAnalysisPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
+def FusionPlan : Pass<"pto-fusion-plan", "func::FuncOp"> {
+  let summary = "Build conservative tile-fusion planning groups from block-local analysis";
+  let description = [{
+    Consumes PreFusionAnalysis results, forms conservative block-local fusion
+    groups for currently supported tile-native compute ops, and annotates
+    accepted group members with:
+      - pto.fusion.group_id
+      - pto.fusion.order
+  }];
+  let constructor = "mlir::pto::createFusionPlanPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
+def OpScheduling : Pass<"pto-op-scheduling", "func::FuncOp"> {
+  let summary = "Compact planned fusion groups into block-local contiguous spans";
+  let description = [{
+    Consumes fusion planning metadata emitted by FusionPlanPass and performs
+    block-local instruction scheduling to make each accepted fusion group a
+    contiguous span without redefining group membership.
+  }];
+  let constructor = "mlir::pto::createOpSchedulingPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
+def PTOFusionRegionGen : Pass<"pto-fusion-region-gen", "func::FuncOp"> {
+  let summary = "Wrap one scheduled fusion span into one pto.fusion_region";
+  let description = [{
+    Consumes scheduled tile-fusion metadata and encapsulates one contiguous
+    fusion group span into one pto.fusion_region without redefining group
+    membership or physical order.
+  }];
+  let constructor = "mlir::pto::createPTOFusionRegionGenPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
 def PTOWrapFunctionsInSections : Pass<"pto-wrap-functions-in-sections", "func::FuncOp"> {
   let summary = "Wrap attributed single-core functions in PTO cube/vector sections";
   let description = [{
@@ -391,6 +449,11 @@ def FoldTileBufIntrinsics : Pass<"pto-fold-tile-buf-intrinsics", "mlir::func::Fu
     rewrite.
   }];
   let constructor = "mlir::pto::createFoldTileBufIntrinsicsPass()";
+  let options = [
+    Option<"foldMode", "fold-mode", "std::string",
+           /*default=*/"\"all\"",
+           "Select which intrinsic family to fold: all, shape-only, or addr-only">
+  ];
   let dependentDialects = [
     "mlir::pto::PTODialect",
     "mlir::memref::MemRefDialect",
@@ -559,6 +622,68 @@ def PTOVPTOPtrBoundary
   let dependentDialects = ["mlir::func::FuncDialect",
                            "mlir::pto::PTODialect",
                            "mlir::memref::MemRefDialect"];
+}
+
+def PTOLowLevelLoopFusion : Pass<"pto-low-level-loop-fusion", "ModuleOp"> {
+  let summary =
+      "Fuse adjacent VPTO post-lowering loop nests inside pto.fusion_region";
+  let description = [{
+    Conservatively fuses adjacent post-lowering loop stages for already-planned
+    fusion groups after the tile-native frontend fusion core. The formal input
+    contract for this pass is low-level `scf.for + pto.*` structure that
+    remains inside `pto.fusion_region` until explicit flatten.
+  }];
+  let constructor = "mlir::pto::createPTOLowLevelLoopFusionPass()";
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::pto::PTODialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::scf::SCFDialect",
+                           "mlir::vector::VectorDialect"];
+  let options = [Option<
+      "debug", "debug", "bool",
+      /*default=*/"false",
+      "Enable verbose debug logging for low-level loop fusion">];
+}
+
+def PTOFusionPredicateElision
+    : Pass<"pto-fusion-predicate-elision", "func::FuncOp"> {
+  let summary =
+      "Elide redundant fusion-local VPTO plt predicate materialization";
+  let description = [{
+    Scans `pto.fusion_region` bodies after VPTO post-lowering CSE and prepares
+    fusion-local redundant `pto.plt_*` predicate elimination before
+    load/store cleanup and explicit flatten.
+  }];
+  let constructor = "mlir::pto::createPTOFusionPredicateElisionPass()";
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::pto::PTODialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::scf::SCFDialect"];
+}
+
+def PTOFusionLoadStoreElision
+    : Pass<"pto-fusion-load-store-elision", "func::FuncOp"> {
+  let summary =
+      "Elide fusion-local VPTO load/store round trips before flattening";
+  let description = [{
+    Removes local store materialization inside canonical fused loop bodies
+    before explicit flatten. It also performs conservative frontier-aware
+    cleanup for non-escaping fusion-region internal buffers.
+  }];
+  let constructor = "mlir::pto::createPTOFusionLoadStoreElisionPass()";
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::pto::PTODialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::scf::SCFDialect"];
+}
+
+def PTOFlattenFusionRegion : Pass<"pto-flatten-fusion-region", "func::FuncOp"> {
+  let summary = "Flatten pto.fusion_region wrappers back into the parent block";
+  let description = [{
+    Eliminates residual `pto.fusion_region` wrappers after region-local
+    lowering is complete by moving body operations back to the parent block,
+    replacing region results with `pto.yield` operands, and erasing both
+    `pto.yield` and the wrapper op.
+  }];
+  let constructor = "mlir::pto::createPTOFlattenFusionRegionPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
 }
 
 def VPTOPtrNormalize

--- a/include/PTO/Transforms/TileFusion/FusionAnalysis.h
+++ b/include/PTO/Transforms/TileFusion/FusionAnalysis.h
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef PTO_TRANSFORMS_TILEFUSION_FUSIONANALYSIS_H
+#define PTO_TRANSFORMS_TILEFUSION_FUSIONANALYSIS_H
+
+#include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Support/LLVM.h"
+
+#include <cassert>
+#include <optional>
+
+namespace mlir {
+namespace pto {
+
+enum class IterationDomainProof {
+  Proven,
+  Unproven,
+};
+
+enum class IterationDomainUnprovenReason {
+  None,
+  MissingTileDomain,
+  DynamicShape,
+  InconsistentShape,
+};
+
+struct IterationDomainInfo {
+  int64_t vRow = ShapedType::kDynamic;
+  int64_t vCol = ShapedType::kDynamic;
+  IterationDomainProof proof = IterationDomainProof::Unproven;
+  IterationDomainUnprovenReason unprovenReason =
+      IterationDomainUnprovenReason::MissingTileDomain;
+};
+
+struct IterationDomainClass {
+  unsigned id = 0;
+  IterationDomainInfo info;
+  SmallVector<unsigned, 4> members;
+};
+
+struct FusionDFGEdge {
+  unsigned producerNode = 0;
+  unsigned consumerNode = 0;
+  Value value;
+};
+
+struct FusionValueLiveness {
+  Value value;
+  std::optional<unsigned> producerNode;
+  SmallVector<unsigned, 4> consumerNodes;
+  SmallVector<unsigned, 2> writeInstances;
+  std::optional<unsigned> lastLocalConsumer;
+  bool hasExternalUsers = false;
+  bool escapesBlock = false;
+  bool hasLocalBoundaryUsers = false;
+  bool hasLocalHardBoundaryUsers = false;
+};
+
+enum class FusionWriteInstanceEscapeClass {
+  Internal,
+  LocalBoundaryExternal,
+  HardExternal,
+};
+
+struct FusionWriteInstanceLiveness {
+  unsigned id = 0;
+  Value value;
+  Value storageValue;
+  std::optional<unsigned> producerNode;
+  SmallVector<unsigned, 4> consumerNodes;
+  std::optional<unsigned> lastLocalConsumer;
+  FusionWriteInstanceEscapeClass escapeClass =
+      FusionWriteInstanceEscapeClass::Internal;
+  bool hasExternalUsers = false;
+  bool escapesBlock = false;
+  bool hasLocalBoundaryUsers = false;
+  bool hasLocalHardBoundaryUsers = false;
+};
+
+struct FusionComputeNode {
+  unsigned id = 0;
+  unsigned blockOrder = 0;
+  Operation *op = nullptr;
+  FusionOpSemantics semantics;
+  unsigned iterationDomainClass = 0;
+  SmallVector<unsigned, 4> incomingEdges;
+  SmallVector<unsigned, 4> outgoingEdges;
+};
+
+struct FusionBlockAnalysis {
+  Block *block = nullptr;
+  SmallVector<FusionComputeNode, 8> computeNodes;
+  SmallVector<IterationDomainClass, 4> iterationDomainClasses;
+  SmallVector<FusionDFGEdge, 8> edges;
+  SmallVector<FusionValueLiveness, 8> liveness;
+  SmallVector<FusionWriteInstanceLiveness, 8> writeInstances;
+};
+
+struct PreFusionAnalysisResult {
+  SmallVector<FusionBlockAnalysis, 8> blocks;
+};
+
+FailureOr<PreFusionAnalysisResult> buildPreFusionAnalysis(func::FuncOp func);
+
+class PreFusionAnalysis {
+public:
+  explicit PreFusionAnalysis(func::FuncOp func) {
+    FailureOr<PreFusionAnalysisResult> resultOr = buildPreFusionAnalysis(func);
+    if (succeeded(resultOr))
+      result = std::move(*resultOr);
+  }
+
+  bool isValid() const { return result.has_value(); }
+
+  const PreFusionAnalysisResult &getResult() const {
+    assert(result && "expected valid pre-fusion analysis result");
+    return *result;
+  }
+
+private:
+  std::optional<PreFusionAnalysisResult> result;
+};
+
+} // namespace pto
+} // namespace mlir
+
+#endif // PTO_TRANSFORMS_TILEFUSION_FUSIONANALYSIS_H

--- a/include/PTO/Transforms/TileFusion/FusionOpSemantics.h
+++ b/include/PTO/Transforms/TileFusion/FusionOpSemantics.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef PTO_TRANSFORMS_TILEFUSION_FUSIONOPSEMANTICS_H
+#define PTO_TRANSFORMS_TILEFUSION_FUSIONOPSEMANTICS_H
+
+#include "PTO/IR/PTO.h"
+
+#include "mlir/Support/LLVM.h"
+
+#include <string>
+
+namespace mlir {
+namespace pto {
+
+enum class FusionOpKind {
+  Compute,
+  LocalBoundary,
+  HardBoundary,
+};
+
+enum class FusionComputeFamily {
+  Unknown,
+  Elementwise,
+  ScalarExpand,
+  RowBroadcastBinary,
+  ReduceRow,
+  ReduceCol,
+};
+
+struct FusionOpSemantics {
+  FusionOpKind kind = FusionOpKind::HardBoundary;
+  FusionComputeFamily computeFamily = FusionComputeFamily::Unknown;
+  Operation *op = nullptr;
+  std::string opName;
+  SmallVector<Value, 4> tileInputs;
+  SmallVector<Value, 2> tileOutputs;
+  SmallVector<Value, 2> scalarInputs;
+};
+
+bool isSupportedPreFusionComputeOp(StringRef opName);
+FailureOr<FusionOpSemantics> getFusionOpSemantics(Operation *op);
+
+} // namespace pto
+} // namespace mlir
+
+#endif // PTO_TRANSFORMS_TILEFUSION_FUSIONOPSEMANTICS_H

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1857,6 +1857,61 @@ static std::optional<int64_t> getConstantIntegerValue(Value value) {
   return std::nullopt;
 }
 
+LogicalResult mlir::pto::FusionRegionOp::verify() {
+  Region &bodyRegion = getBody();
+  if (bodyRegion.empty())
+    return emitOpError("expects a non-empty body region");
+
+  Block &body = bodyRegion.front();
+  if (body.getNumArguments() != 0)
+    return emitOpError() << "expects body block to have no arguments, got "
+                         << body.getNumArguments();
+
+  auto yield = dyn_cast_or_null<YieldOp>(body.getTerminator());
+  if (!yield)
+    return emitOpError("expects body to terminate with pto.yield");
+
+  if (yield.getValues().size() != getOutputs().size())
+    return emitOpError() << "expects pto.yield to return "
+                         << getOutputs().size() << " values, got "
+                         << yield.getValues().size();
+
+  for (auto [idx, pair] :
+       llvm::enumerate(llvm::zip(yield.getValues(), getOutputs()))) {
+    Value yielded = std::get<0>(pair);
+    Value output = std::get<1>(pair);
+    if (yielded.getType() != output.getType())
+      return emitOpError() << "expects yielded value #" << idx << " to have "
+                           << "type " << output.getType() << ", got "
+                           << yielded.getType();
+  }
+
+  return success();
+}
+
+LogicalResult mlir::pto::YieldOp::verify() {
+  auto parent = dyn_cast_or_null<FusionRegionOp>(getOperation()->getParentOp());
+  if (!parent)
+    return emitOpError("expects parent op to be pto.fusion_region");
+
+  if (getValues().size() != parent.getOutputs().size())
+    return emitOpError() << "expects " << parent.getOutputs().size()
+                         << " yielded values to match parent results, got "
+                         << getValues().size();
+
+  for (auto [idx, pair] :
+       llvm::enumerate(llvm::zip(getValues(), parent.getOutputs()))) {
+    Value yielded = std::get<0>(pair);
+    Value output = std::get<1>(pair);
+    if (yielded.getType() != output.getType())
+      return emitOpError() << "expects yielded value #" << idx << " to have "
+                           << "type " << output.getType() << ", got "
+                           << yielded.getType();
+  }
+
+  return success();
+}
+
 LogicalResult mlir::pto::MakeTensorViewOp::verify() {
   auto tvTy = dyn_cast<mlir::pto::TensorViewType>(getResult().getType());
   if (!tvTy)

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -12,6 +12,17 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 add_mlir_dialect_library(PTOTransforms
+  TileFusion/FusionAnalysis.cpp
+  TileFusion/FusionOpSemantics.cpp
+  TileFusion/PTOPreFusionAnalysis.cpp
+  TileFusion/PTOPrintPreFusionAnalysis.cpp
+  TileFusion/PTOFusionPlan.cpp
+  TileFusion/PTOOpScheduling.cpp
+  TileFusion/PTOFusionRegionGen.cpp
+  TileFusion/PTOLowLevelLoopFusion.cpp
+  TileFusion/PTOFusionPredicateElision.cpp
+  TileFusion/PTOFusionLoadStoreElision.cpp
+  TileFusion/PTOFlattenFusionRegion.cpp
   VPTOLLVMEmitter.cpp
   VPTOLLVMEmitterHelper.cpp
   VPTOPtrNormalize.cpp

--- a/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
+++ b/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
@@ -55,6 +55,30 @@ namespace pto {
 
 namespace {
 
+enum class FoldIntrinsicMode {
+  All,
+  ShapeOnly,
+  AddrOnly,
+};
+
+static FailureOr<FoldIntrinsicMode> parseFoldIntrinsicMode(StringRef mode) {
+  if (mode.empty() || mode == "all")
+    return FoldIntrinsicMode::All;
+  if (mode == "shape-only")
+    return FoldIntrinsicMode::ShapeOnly;
+  if (mode == "addr-only")
+    return FoldIntrinsicMode::AddrOnly;
+  return failure();
+}
+
+static bool shouldFoldShapeFamily(FoldIntrinsicMode mode) {
+  return mode == FoldIntrinsicMode::All || mode == FoldIntrinsicMode::ShapeOnly;
+}
+
+static bool shouldFoldAddrFamily(FoldIntrinsicMode mode) {
+  return mode == FoldIntrinsicMode::All || mode == FoldIntrinsicMode::AddrOnly;
+}
+
 static void eraseDeadAllocTileOps(func::FuncOp func) {
   SmallVector<pto::AllocTileOp> deadAllocs;
   func.walk([&](pto::AllocTileOp alloc) {
@@ -76,6 +100,26 @@ struct TileHandleInfo {
 
 static std::optional<TileHandleInfo> resolveTileHandle(Value tileBuf,
                                                        Operation *user) {
+  if (auto regionResult = dyn_cast<OpResult>(tileBuf)) {
+    if (auto fusionRegion =
+            dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp = dyn_cast<pto::YieldOp>(
+          fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp) {
+        user->emitError("FoldTileBufIntrinsics: pto.fusion_region must "
+                        "terminate with pto.yield");
+        return std::nullopt;
+      }
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands()) {
+        user->emitError("FoldTileBufIntrinsics: pto.fusion_region result/yield "
+                        "sizes are inconsistent");
+        return std::nullopt;
+      }
+      return resolveTileHandle(yieldOp.getOperand(resultIndex), user);
+    }
+  }
+
   if (auto alloc = tileBuf.getDefiningOp<pto::AllocTileOp>()) {
     auto tileTy = dyn_cast<pto::TileBufType>(alloc.getResult().getType());
     if (!tileTy) {
@@ -95,7 +139,8 @@ static std::optional<TileHandleInfo> resolveTileHandle(Value tileBuf,
 
   user->emitError("FoldTileBufIntrinsics: expected tile_buf to be defined by "
                   "the active materialized tile-handle bridge "
-                  "(pto.alloc_tile or pto.materialize_tile)");
+                  "(pto.alloc_tile, pto.materialize_tile, or a "
+                  "pto.fusion_region result that yields one of them)");
   return std::nullopt;
 }
 
@@ -267,6 +312,14 @@ struct FoldTileBufIntrinsicsPass
     MLIRContext *ctx = &getContext();
     OpBuilder builder(ctx);
 
+    FailureOr<FoldIntrinsicMode> mode = parseFoldIntrinsicMode(foldMode);
+    if (failed(mode)) {
+      func.emitError()
+          << "FoldTileBufIntrinsics: unsupported --fold-mode value '"
+          << foldMode << "' (expected all, shape-only, or addr-only)";
+      return signalPassFailure();
+    }
+
     // Leftover TileLang template instances (private, uncalled after
     // PTOInlineLibCall) still contain pto.tile_buf_addr / tile_valid_*
     // ops on tile_buf function arguments — they have no materialized tile
@@ -297,273 +350,280 @@ struct FoldTileBufIntrinsicsPass
         tvStrideOps.push_back(tvStride);
     });
 
-    // Fold pto.tile_buf_addr by recovering the active materialized tile
-    // handle contract:
-    //   - pto.materialize_tile → use the source memref directly
-    //   - pto.alloc_tile       → rebuild a memref from the explicit addr
-    // When the requested result type is already !pto.ptr<...>, cast from the
-    // recovered memref instead of leaving tile_buf_addr in the IR.
-    for (auto addrOp : addrOps) {
-      auto handleInfo = resolveTileHandle(addrOp.getSrc(), addrOp);
-      if (!handleInfo)
-        return signalPassFailure();
+    if (shouldFoldAddrFamily(*mode)) {
+      // Fold pto.tile_buf_addr by recovering the active materialized tile
+      // handle contract:
+      //   - pto.materialize_tile → use the source memref directly
+      //   - pto.alloc_tile       → rebuild a memref from the explicit addr
+      // When the requested result type is already !pto.ptr<...>, cast from the
+      // recovered memref instead of leaving tile_buf_addr in the IR.
+      for (auto addrOp : addrOps) {
+        auto handleInfo = resolveTileHandle(addrOp.getSrc(), addrOp);
+        if (!handleInfo)
+          return signalPassFailure();
 
-      auto tileTy = dyn_cast<pto::TileBufType>(addrOp.getSrc().getType());
-      if (!tileTy) {
-        addrOp.emitError("FoldTileBufIntrinsics: tile_buf_addr source must be "
-                         "!pto.tile_buf");
-        return signalPassFailure();
-      }
+        auto tileTy = dyn_cast<pto::TileBufType>(addrOp.getSrc().getType());
+        if (!tileTy) {
+          addrOp.emitError("FoldTileBufIntrinsics: tile_buf_addr source must be "
+                           "!pto.tile_buf");
+          return signalPassFailure();
+        }
 
-      if (auto resultMemrefType = dyn_cast<MemRefType>(addrOp.getDst().getType())) {
-        if (handleInfo->sourceMemref) {
-          Value srcMemref = handleInfo->sourceMemref;
-          if (!isa<MemRefType>(srcMemref.getType())) {
-            addrOp.emitError(
-                "FoldTileBufIntrinsics: pto.materialize_tile source is not a memref");
+        if (auto resultMemrefType =
+                dyn_cast<MemRefType>(addrOp.getDst().getType())) {
+          if (handleInfo->sourceMemref) {
+            Value srcMemref = handleInfo->sourceMemref;
+            if (!isa<MemRefType>(srcMemref.getType())) {
+              addrOp.emitError("FoldTileBufIntrinsics: pto.materialize_tile "
+                               "source is not a memref");
+              return signalPassFailure();
+            }
+
+            // The declared tile_buf_addr result type may differ from the actual
+            // materialized source layout (e.g. plain shape vs. strided layout).
+            if (srcMemref.getType() != resultMemrefType)
+              addrOp.getDst().setType(cast<MemRefType>(srcMemref.getType()));
+            addrOp.getDst().replaceAllUsesWith(srcMemref);
+            addrOp.erase();
+            continue;
+          }
+
+          if (!handleInfo->addr) {
+            addrOp.emitError("FoldTileBufIntrinsics: pto.alloc_tile used by "
+                             "tile_buf_addr must carry an addr operand on the "
+                             "VPTO path");
             return signalPassFailure();
           }
 
-          // The declared tile_buf_addr result type may differ from the actual
-          // materialized source layout (e.g. plain shape vs. strided layout).
-          if (srcMemref.getType() != resultMemrefType)
-            addrOp.getDst().setType(cast<MemRefType>(srcMemref.getType()));
-          addrOp.getDst().replaceAllUsesWith(srcMemref);
+          builder.setInsertionPoint(addrOp);
+          Value replacement = builder.create<pto::PointerCastOp>(
+              addrOp.getLoc(), resultMemrefType, ValueRange{handleInfo->addr},
+              handleInfo->validRow ? handleInfo->validRow : Value(),
+              handleInfo->validCol ? handleInfo->validCol : Value(),
+              handleInfo->config);
+          addrOp.getDst().replaceAllUsesWith(replacement);
           addrOp.erase();
           continue;
         }
 
-        if (!handleInfo->addr) {
-          addrOp.emitError("FoldTileBufIntrinsics: pto.alloc_tile used by "
-                           "tile_buf_addr must carry an addr operand on the "
-                           "VPTO path");
+        auto resultPtrType = dyn_cast<pto::PtrType>(addrOp.getDst().getType());
+        if (!resultPtrType) {
+          addrOp.emitError("FoldTileBufIntrinsics: tile_buf_addr result must "
+                           "be memref or !pto.ptr");
           return signalPassFailure();
         }
 
+        Value memrefValue;
+        if (handleInfo->sourceMemref) {
+          memrefValue = handleInfo->sourceMemref;
+          if (!isa<MemRefType>(memrefValue.getType())) {
+            addrOp.emitError("FoldTileBufIntrinsics: pto.materialize_tile "
+                             "source is not a memref");
+            return signalPassFailure();
+          }
+        } else {
+          if (!handleInfo->addr) {
+            addrOp.emitError("FoldTileBufIntrinsics: pto.alloc_tile used by "
+                             "tile_buf_addr must carry an addr operand on the "
+                             "VPTO path");
+            return signalPassFailure();
+          }
+
+          builder.setInsertionPoint(addrOp);
+          auto canonicalMemrefType = getCanonicalMemRefTypeForTileBuf(tileTy);
+          memrefValue = builder.create<pto::PointerCastOp>(
+              addrOp.getLoc(), canonicalMemrefType, ValueRange{handleInfo->addr},
+              handleInfo->validRow ? handleInfo->validRow : Value(),
+              handleInfo->validCol ? handleInfo->validCol : Value(),
+              handleInfo->config);
+        }
+
         builder.setInsertionPoint(addrOp);
-        Value replacement = builder.create<pto::PointerCastOp>(
-            addrOp.getLoc(), resultMemrefType, ValueRange{handleInfo->addr},
-            handleInfo->validRow ? handleInfo->validRow : Value(),
-            handleInfo->validCol ? handleInfo->validCol : Value(),
-            handleInfo->config);
+        Value replacement =
+            builder.create<pto::CastPtrOp>(addrOp.getLoc(), resultPtrType,
+                                           memrefValue);
         addrOp.getDst().replaceAllUsesWith(replacement);
         addrOp.erase();
-        continue;
       }
+    }
 
-      auto resultPtrType = dyn_cast<pto::PtrType>(addrOp.getDst().getType());
-      if (!resultPtrType) {
-        addrOp.emitError(
-            "FoldTileBufIntrinsics: tile_buf_addr result must be memref or !pto.ptr");
-        return signalPassFailure();
-      }
-
-      Value memrefValue;
-      if (handleInfo->sourceMemref) {
-        memrefValue = handleInfo->sourceMemref;
-        if (!isa<MemRefType>(memrefValue.getType())) {
-          addrOp.emitError(
-              "FoldTileBufIntrinsics: pto.materialize_tile source is not a memref");
+    if (shouldFoldShapeFamily(*mode)) {
+      // Fold pto.tile_valid_rows → arith.constant (static) or the dynamic
+      // valid_row operand carried by the new tile handle bridge.
+      for (auto rowsOp : rowsOps) {
+        builder.setInsertionPoint(rowsOp);
+        auto tbTy = dyn_cast<pto::TileBufType>(rowsOp.getSrc().getType());
+        if (!tbTy || tbTy.getValidShape().empty()) {
+          rowsOp.emitError("tile_valid_rows: invalid tile_buf type");
           return signalPassFailure();
         }
-      } else {
-        if (!handleInfo->addr) {
-          addrOp.emitError("FoldTileBufIntrinsics: pto.alloc_tile used by "
-                           "tile_buf_addr must carry an addr operand on the "
-                           "VPTO path");
+
+        int64_t vRow = tbTy.getValidShape()[0];
+        Value replacement;
+        if (vRow != ShapedType::kDynamic) {
+          replacement =
+              builder.create<arith::ConstantIndexOp>(rowsOp.getLoc(), vRow);
+        } else {
+          auto handleInfo = resolveTileHandle(rowsOp.getSrc(), rowsOp);
+          if (!handleInfo)
+            return signalPassFailure();
+          replacement = handleInfo->validRow;
+          if (!replacement) {
+            rowsOp.emitError(
+                "tile_valid_rows: dynamic v_row but the materialized tile "
+                "handle has no valid_row operand");
+            return signalPassFailure();
+          }
+          assert(replacement.getType() == rowsOp.getResult().getType() &&
+                 "tile_valid_rows fold: type mismatch with handle valid_row");
+        }
+        rowsOp.getResult().replaceAllUsesWith(replacement);
+        rowsOp.erase();
+      }
+
+      // Fold pto.tile_valid_cols → arith.constant (static) or the dynamic
+      // valid_col operand carried by the new tile handle bridge.
+      for (auto colsOp : colsOps) {
+        builder.setInsertionPoint(colsOp);
+        auto tbTy = dyn_cast<pto::TileBufType>(colsOp.getSrc().getType());
+        if (!tbTy || tbTy.getValidShape().size() < 2) {
+          colsOp.emitError("tile_valid_cols: invalid tile_buf type");
           return signalPassFailure();
         }
+
+        int64_t vCol = tbTy.getValidShape()[1];
+        Value replacement;
+        if (vCol != ShapedType::kDynamic) {
+          replacement =
+              builder.create<arith::ConstantIndexOp>(colsOp.getLoc(), vCol);
+        } else {
+          auto handleInfo = resolveTileHandle(colsOp.getSrc(), colsOp);
+          if (!handleInfo)
+            return signalPassFailure();
+          replacement = handleInfo->validCol;
+          if (!replacement) {
+            colsOp.emitError(
+                "tile_valid_cols: dynamic v_col but the materialized tile "
+                "handle has no valid_col operand");
+            return signalPassFailure();
+          }
+          assert(replacement.getType() == colsOp.getResult().getType() &&
+                 "tile_valid_cols fold: type mismatch with handle valid_col");
+        }
+        colsOp.getResult().replaceAllUsesWith(replacement);
+        colsOp.erase();
+      }
+
+      for (auto dimOp : tvDimOps) {
+        auto chain = traceViewChain(dimOp.getTensorView(), dimOp);
+        if (!chain)
+          return signalPassFailure();
+
+        int64_t dimIdx = 0;
+        if (!getConstIndexValue(dimOp.getDimIndex(), dimIdx)) {
+          dimOp.emitError(
+              "FoldTileBufIntrinsics: get_tensor_view_dim requires a constant "
+              "dim index");
+          return signalPassFailure();
+        }
+
+        auto svTy = cast<MemRefType>(chain->subview.getType());
+        if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
+          dimOp.emitError(
+              "FoldTileBufIntrinsics: get_tensor_view_dim dim index out of "
+              "bounds");
+          return signalPassFailure();
+        }
+
+        builder.setInsertionPoint(dimOp);
+        Value replacement;
+        if (!svTy.isDynamicDim(dimIdx)) {
+          replacement =
+              builder.create<arith::ConstantIndexOp>(dimOp.getLoc(),
+                                                     svTy.getDimSize(dimIdx));
+        } else {
+          replacement = getValueOrCreateConstant(
+              builder, dimOp.getLoc(), chain->subview.getMixedSizes()[dimIdx]);
+        }
+
+        dimOp.getResult().replaceAllUsesWith(replacement);
+        dimOp.erase();
+      }
+
+      for (auto strideOp : tvStrideOps) {
+        auto chain = traceViewChain(strideOp.getTensorView(), strideOp);
+        if (!chain)
+          return signalPassFailure();
+
+        int64_t dimIdx = 0;
+        if (!getConstIndexValue(strideOp.getDimIndex(), dimIdx)) {
+          strideOp.emitError(
+              "FoldTileBufIntrinsics: get_tensor_view_stride requires a "
+              "constant dim index");
+          return signalPassFailure();
+        }
+
+        auto svTy = cast<MemRefType>(chain->subview.getType());
+        if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
+          strideOp.emitError(
+              "FoldTileBufIntrinsics: get_tensor_view_stride dim index out of "
+              "bounds");
+          return signalPassFailure();
+        }
+
+        builder.setInsertionPoint(strideOp);
+        Value replacement = computeResultStride(
+            builder, strideOp.getLoc(),
+            chain->reinterpretCast.getMixedStrides()[dimIdx],
+            chain->subview.getMixedStrides()[dimIdx]);
+
+        strideOp.getResult().replaceAllUsesWith(replacement);
+        strideOp.erase();
+      }
+    }
+
+    if (shouldFoldAddrFamily(*mode)) {
+      for (auto addrOp : tvAddrOps) {
+        auto chain = traceViewChain(addrOp.getSrc(), addrOp);
+        if (!chain)
+          return signalPassFailure();
 
         builder.setInsertionPoint(addrOp);
-        auto canonicalMemrefType = getCanonicalMemRefTypeForTileBuf(tileTy);
-        memrefValue = builder.create<pto::PointerCastOp>(
-            addrOp.getLoc(), canonicalMemrefType, ValueRange{handleInfo->addr},
-            handleInfo->validRow ? handleInfo->validRow : Value(),
-            handleInfo->validCol ? handleInfo->validCol : Value(),
-            handleInfo->config);
-      }
 
-      builder.setInsertionPoint(addrOp);
-      Value replacement =
-          builder.create<pto::CastPtrOp>(addrOp.getLoc(), resultPtrType,
-                                         memrefValue);
-      addrOp.getDst().replaceAllUsesWith(replacement);
-      addrOp.erase();
-    }
-
-    // Fold pto.tile_valid_rows → arith.constant (static) or the dynamic
-    // valid_row operand carried by the new tile handle bridge.
-    for (auto rowsOp : rowsOps) {
-      builder.setInsertionPoint(rowsOp);
-      auto tbTy = dyn_cast<pto::TileBufType>(rowsOp.getSrc().getType());
-      if (!tbTy || tbTy.getValidShape().empty()) {
-        rowsOp.emitError("tile_valid_rows: invalid tile_buf type");
-        return signalPassFailure();
-      }
-
-      int64_t vRow = tbTy.getValidShape()[0];
-      Value replacement;
-      if (vRow != ShapedType::kDynamic) {
-        replacement =
-            builder.create<arith::ConstantIndexOp>(rowsOp.getLoc(), vRow);
-      } else {
-        auto handleInfo = resolveTileHandle(rowsOp.getSrc(), rowsOp);
-        if (!handleInfo)
-          return signalPassFailure();
-        replacement = handleInfo->validRow;
-        if (!replacement) {
-          rowsOp.emitError(
-              "tile_valid_rows: dynamic v_row but the materialized tile "
-              "handle has no valid_row operand");
+        auto resultPtrType = dyn_cast<pto::PtrType>(addrOp.getDst().getType());
+        if (!resultPtrType) {
+          if (auto resultMemrefType =
+                  dyn_cast<MemRefType>(addrOp.getDst().getType())) {
+            Value base = chain->baseMemref;
+            if (base.getType() != resultMemrefType)
+              addrOp.getDst().setType(cast<MemRefType>(base.getType()));
+            addrOp.getDst().replaceAllUsesWith(base);
+            addrOp.erase();
+            continue;
+          }
+          addrOp.emitError(
+              "FoldTileBufIntrinsics: tensor_view_addr result must be memref or "
+              "!pto.ptr");
           return signalPassFailure();
         }
-        assert(replacement.getType() == rowsOp.getResult().getType() &&
-               "tile_valid_rows fold: type mismatch with handle valid_row");
+
+        Value linearOffset =
+            computeLinearOffset(builder, addrOp.getLoc(),
+                                chain->reinterpretCast.getMixedOffsets(),
+                                chain->subview.getMixedOffsets(),
+                                chain->reinterpretCast.getMixedStrides());
+
+        Value basePtr = builder.create<pto::CastPtrOp>(
+            addrOp.getLoc(), resultPtrType, chain->baseMemref);
+        Value replacement =
+            linearOffset
+                ? builder.create<pto::AddPtrOp>(addrOp.getLoc(), resultPtrType,
+                                                basePtr, linearOffset)
+                : basePtr;
+
+        addrOp.getDst().replaceAllUsesWith(replacement);
+        addrOp.erase();
       }
-      rowsOp.getResult().replaceAllUsesWith(replacement);
-      rowsOp.erase();
-    }
-
-    // Fold pto.tile_valid_cols → arith.constant (static) or the dynamic
-    // valid_col operand carried by the new tile handle bridge.
-    for (auto colsOp : colsOps) {
-      builder.setInsertionPoint(colsOp);
-      auto tbTy = dyn_cast<pto::TileBufType>(colsOp.getSrc().getType());
-      if (!tbTy || tbTy.getValidShape().size() < 2) {
-        colsOp.emitError("tile_valid_cols: invalid tile_buf type");
-        return signalPassFailure();
-      }
-
-      int64_t vCol = tbTy.getValidShape()[1];
-      Value replacement;
-      if (vCol != ShapedType::kDynamic) {
-        replacement =
-            builder.create<arith::ConstantIndexOp>(colsOp.getLoc(), vCol);
-      } else {
-        auto handleInfo = resolveTileHandle(colsOp.getSrc(), colsOp);
-        if (!handleInfo)
-          return signalPassFailure();
-        replacement = handleInfo->validCol;
-        if (!replacement) {
-          colsOp.emitError(
-              "tile_valid_cols: dynamic v_col but the materialized tile "
-              "handle has no valid_col operand");
-          return signalPassFailure();
-        }
-        assert(replacement.getType() == colsOp.getResult().getType() &&
-               "tile_valid_cols fold: type mismatch with handle valid_col");
-      }
-      colsOp.getResult().replaceAllUsesWith(replacement);
-      colsOp.erase();
-    }
-
-    for (auto addrOp : tvAddrOps) {
-      auto chain = traceViewChain(addrOp.getSrc(), addrOp);
-      if (!chain)
-        return signalPassFailure();
-
-      builder.setInsertionPoint(addrOp);
-
-      auto resultPtrType = dyn_cast<pto::PtrType>(addrOp.getDst().getType());
-      if (!resultPtrType) {
-        if (auto resultMemrefType =
-                dyn_cast<MemRefType>(addrOp.getDst().getType())) {
-          Value base = chain->baseMemref;
-          if (base.getType() != resultMemrefType)
-            addrOp.getDst().setType(cast<MemRefType>(base.getType()));
-          addrOp.getDst().replaceAllUsesWith(base);
-          addrOp.erase();
-          continue;
-        }
-        addrOp.emitError(
-            "FoldTileBufIntrinsics: tensor_view_addr result must be memref or "
-            "!pto.ptr");
-        return signalPassFailure();
-      }
-
-      Value linearOffset =
-          computeLinearOffset(builder, addrOp.getLoc(),
-                              chain->reinterpretCast.getMixedOffsets(),
-                              chain->subview.getMixedOffsets(),
-                              chain->reinterpretCast.getMixedStrides());
-
-      Value basePtr = builder.create<pto::CastPtrOp>(
-          addrOp.getLoc(), resultPtrType, chain->baseMemref);
-      Value replacement =
-          linearOffset
-              ? builder.create<pto::AddPtrOp>(addrOp.getLoc(), resultPtrType,
-                                              basePtr, linearOffset)
-              : basePtr;
-
-      addrOp.getDst().replaceAllUsesWith(replacement);
-      addrOp.erase();
-    }
-
-    for (auto dimOp : tvDimOps) {
-      auto chain = traceViewChain(dimOp.getTensorView(), dimOp);
-      if (!chain)
-        return signalPassFailure();
-
-      int64_t dimIdx = 0;
-      if (!getConstIndexValue(dimOp.getDimIndex(), dimIdx)) {
-        dimOp.emitError(
-            "FoldTileBufIntrinsics: get_tensor_view_dim requires a constant "
-            "dim index");
-        return signalPassFailure();
-      }
-
-      auto svTy = cast<MemRefType>(chain->subview.getType());
-      if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
-        dimOp.emitError(
-            "FoldTileBufIntrinsics: get_tensor_view_dim dim index out of "
-            "bounds");
-        return signalPassFailure();
-      }
-
-      builder.setInsertionPoint(dimOp);
-      Value replacement;
-      if (!svTy.isDynamicDim(dimIdx)) {
-        replacement =
-            builder.create<arith::ConstantIndexOp>(dimOp.getLoc(),
-                                                   svTy.getDimSize(dimIdx));
-      } else {
-        replacement = getValueOrCreateConstant(
-            builder, dimOp.getLoc(), chain->subview.getMixedSizes()[dimIdx]);
-      }
-
-      dimOp.getResult().replaceAllUsesWith(replacement);
-      dimOp.erase();
-    }
-
-    for (auto strideOp : tvStrideOps) {
-      auto chain = traceViewChain(strideOp.getTensorView(), strideOp);
-      if (!chain)
-        return signalPassFailure();
-
-      int64_t dimIdx = 0;
-      if (!getConstIndexValue(strideOp.getDimIndex(), dimIdx)) {
-        strideOp.emitError(
-            "FoldTileBufIntrinsics: get_tensor_view_stride requires a "
-            "constant dim index");
-        return signalPassFailure();
-      }
-
-      auto svTy = cast<MemRefType>(chain->subview.getType());
-      if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
-        strideOp.emitError(
-            "FoldTileBufIntrinsics: get_tensor_view_stride dim index out of "
-            "bounds");
-        return signalPassFailure();
-      }
-
-      builder.setInsertionPoint(strideOp);
-      Value replacement = computeResultStride(
-          builder, strideOp.getLoc(),
-          chain->reinterpretCast.getMixedStrides()[dimIdx],
-          chain->subview.getMixedStrides()[dimIdx]);
-
-      strideOp.getResult().replaceAllUsesWith(replacement);
-      strideOp.erase();
     }
 
     // Clean up dead unrealized_conversion_cast ops that bridged
@@ -605,6 +665,12 @@ namespace pto {
 
 std::unique_ptr<Pass> createFoldTileBufIntrinsicsPass() {
   return std::make_unique<FoldTileBufIntrinsicsPass>();
+}
+
+std::unique_ptr<Pass> createFoldTileBufIntrinsicsPass(llvm::StringRef foldMode) {
+  FoldTileBufIntrinsicsOptions options;
+  options.foldMode = foldMode.str();
+  return std::make_unique<FoldTileBufIntrinsicsPass>(options);
 }
 
 } // namespace pto

--- a/lib/PTO/Transforms/PTOMaterializeTileHandles.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeTileHandles.cpp
@@ -101,7 +101,7 @@ static bool shouldMaterializeOperand(Operation *owner) {
 }
 
 static bool shouldMaterializeYieldOperand(Operation *owner) {
-  return isa<scf::YieldOp>(owner);
+  return isa<scf::YieldOp, pto::YieldOp>(owner);
 }
 
 static bool hasStringAttr(ArrayRef<NamedAttribute> attrs, StringRef name,
@@ -703,6 +703,55 @@ materializeSCFForResults(ModuleOp module, DenseMap<Value, Value> &tileHandles) {
   return changed;
 }
 
+static FailureOr<bool>
+materializeFusionRegionResults(ModuleOp module,
+                               DenseMap<Value, Value> &tileHandles) {
+  bool changed = false;
+
+  SmallVector<pto::FusionRegionOp, 8> fusionRegions;
+  module.walk([&](pto::FusionRegionOp fusionRegion) {
+    fusionRegions.push_back(fusionRegion);
+  });
+
+  for (pto::FusionRegionOp fusionRegion : llvm::reverse(fusionRegions)) {
+    if (fusionRegion.getNumResults() == 0)
+      continue;
+
+    auto yield =
+        dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+    if (!yield) {
+      fusionRegion.emitOpError(
+          "result-bearing pto.fusion_region must terminate with pto.yield");
+      return failure();
+    }
+    if (yield.getNumOperands() != fusionRegion.getNumResults()) {
+      fusionRegion.emitOpError()
+          << "cannot materialize tile results because yield/result arity "
+             "mismatch: "
+          << yield.getNumOperands() << " vs " << fusionRegion.getNumResults();
+      return failure();
+    }
+
+    for (auto [idx, result] : llvm::enumerate(fusionRegion.getResults())) {
+      if (!isLocalTileMemRef(result.getType()))
+        continue;
+
+      Value yieldTile =
+          lookupMaterializedTileHandle(yield.getOperand(idx), tileHandles);
+      if (!yieldTile)
+        continue;
+
+      Type tileTy = yieldTile.getType();
+      yield->setOperand(idx, yieldTile);
+      result.setType(tileTy);
+      tileHandles[result] = result;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
 static LogicalResult
 materializeControlFlowTileResults(ModuleOp module,
                                   DenseMap<Value, Value> &tileHandles) {
@@ -721,6 +770,12 @@ materializeControlFlowTileResults(ModuleOp module,
     if (failed(forChanged))
       return failure();
     changed |= *forChanged;
+
+    FailureOr<bool> fusionChanged =
+        materializeFusionRegionResults(module, tileHandles);
+    if (failed(fusionChanged))
+      return failure();
+    changed |= *fusionChanged;
   } while (changed);
 
   return success();

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -386,6 +386,9 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       RecursiveForOp(forOp, live);
       return WalkResult::skip();
+    } else if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(op)) {
+      RecursiveFusionRegionOp(fusionRegion, live);
+      return WalkResult::skip();
     }
 
     // process operation
@@ -590,6 +593,34 @@ void MemLivenessAnalysis::RecursiveIfOp(scf::IfOp ifOp, Liveness live) {
   OpKillHandle(curIfEnd, live, ifOp->getBlock());
 }
 
+void MemLivenessAnalysis::UpdateFusionRegionBufferAlias(
+    pto::FusionRegionOp fusionRegion, pto::YieldOp yieldOp) {
+  if (fusionRegion.getResults().empty())
+    return;
+  if (fusionRegion->getResults().size() != yieldOp->getOperands().size()) {
+    llvm::report_fatal_error(
+        "pto.fusion_region result/yield sizes are inconsistent");
+  }
+  for (auto [i, yielded] : llvm::enumerate(yieldOp->getOperands())) {
+    UpdateBufferAlias(fusionRegion->getResult(i), yielded);
+  }
+}
+
+void MemLivenessAnalysis::RecursiveFusionRegionOp(pto::FusionRegionOp fusionRegion,
+                                                  Liveness live) {
+  UpdateLinearOperation(fusionRegion.getOperation());
+  RecursionIR(&fusionRegion.getBody(), live);
+
+  auto yieldOp =
+      dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+  if (!yieldOp)
+    llvm::report_fatal_error("pto.fusion_region must terminate with pto.yield");
+  UpdateFusionRegionBufferAlias(fusionRegion, yieldOp);
+
+  auto regionEnd = UpdateLinearOperation(fusionRegion.getOperation());
+  OpKillHandle(regionEnd, live, fusionRegion->getBlock());
+}
+
 SmallVector<Value> MemLivenessAnalysis::GetLiveBuffersInLoop(scf::ForOp forOp,
                                                              Liveness live) {
   SmallVector<Value> allocBeforeLoopBuffers;
@@ -633,7 +664,7 @@ MemLivenessAnalysis::CheckLocalBufferAllocOp(Operation *op) const {
 bool MemLivenessAnalysis::isSkippableOp(Operation *op) const {
   // Call-like ops are still modeled explicitly. Only pure terminators and
   // dim queries are skipped here.
-  return isa<func::ReturnOp, scf::YieldOp, memref::DimOp>(op);
+  return isa<func::ReturnOp, scf::YieldOp, pto::YieldOp, memref::DimOp>(op);
 }
 
 LogicalResult

--- a/lib/PTO/Transforms/PTOPlanMemory.h
+++ b/lib/PTO/Transforms/PTOPlanMemory.h
@@ -321,6 +321,13 @@ private:
   /// Update buffer alias information for ifop.
   void UpdateIfOpBufferAlias(scf::IfOp ifOp, scf::YieldOp yieldOp);
 
+  /// Recursive operation for pto.fusion_region.
+  void RecursiveFusionRegionOp(pto::FusionRegionOp fusionRegion, Liveness live);
+
+  /// Update buffer alias information for pto.fusion_region results.
+  void UpdateFusionRegionBufferAlias(pto::FusionRegionOp fusionRegion,
+                                     pto::YieldOp yieldOp);
+
   /// Update and obtain op info information.
   OpInfo *UpdateLinearOperation(Operation *op);
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -92,6 +92,22 @@ static mlir::pto::TileBufConfigAttr lookupConfig(Value v) {
   if (auto cast = v.getDefiningOp<memref::CastOp>()) {
     return lookupConfig(cast.getSource());
   }
+
+  // 3. pto.fusion_region result 本身不携带 config；作为兜底情况，沿着
+  //    pto.yield 回溯到 region 内真正的 tile handle/memref 定义链继续查找。
+  if (auto regionResult = dyn_cast<OpResult>(v)) {
+    if (auto fusionRegion =
+            dyn_cast<mlir::pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp = dyn_cast<mlir::pto::YieldOp>(
+          fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return {};
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return {};
+      return lookupConfig(yieldOp.getOperand(resultIndex));
+    }
+  }
   
   // 如果追溯到 BlockArgument (函数参数) 或其他无法穿透的 Op，则返回空
   return {}; 
@@ -123,8 +139,53 @@ static void lookupValidDims(Value v, Value &vRow, Value &vCol) {
     lookupValidDims(cast.getSource(), vRow, vCol);
     return;
   }
+
+  // pto.fusion_region result 不直接携带 valid dims；作为兜底情况，沿着
+  // pto.yield 回溯到 region 内真正的 tile handle/memref 定义链继续查找。
+  if (auto regionResult = dyn_cast<OpResult>(v)) {
+    if (auto fusionRegion =
+            dyn_cast<mlir::pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp = dyn_cast<mlir::pto::YieldOp>(
+          fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp) {
+        vRow = Value();
+        vCol = Value();
+        return;
+      }
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands()) {
+        vRow = Value();
+        vCol = Value();
+        return;
+      }
+      lookupValidDims(yieldOp.getOperand(resultIndex), vRow, vCol);
+      return;
+    }
+  }
+
   vRow = Value();
   vCol = Value();
+}
+
+static Value resolveTileBufViewLikeSource(Value src) {
+  if (isa<MemRefType>(src.getType()))
+    return src;
+
+  if (auto regionResult = dyn_cast<OpResult>(src)) {
+    if (auto fusionRegion =
+            dyn_cast<mlir::pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp = dyn_cast<mlir::pto::YieldOp>(
+          fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return Value();
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return Value();
+      return resolveTileBufViewLikeSource(yieldOp.getOperand(resultIndex));
+    }
+  }
+
+  return Value();
 }
 
 // =============================================================================
@@ -627,6 +688,43 @@ static LogicalResult reconcileSCFForResultTypes(func::FuncOp func) {
   return success();
 }
 
+// Ensure pto.fusion_region result types follow the rewritten pto.yield operand
+// types. PTOViewToMemref rewrites region-local tile values to memref, but the
+// region result types are not auto-updated by those op-local rewrites.
+static LogicalResult reconcileFusionRegionResultTypes(func::FuncOp func) {
+  SmallVector<pto::FusionRegionOp, 8> fusionRegions;
+  func.walk([&](pto::FusionRegionOp fusionRegion) {
+    fusionRegions.push_back(fusionRegion);
+  });
+
+  for (pto::FusionRegionOp fusionRegion : fusionRegions) {
+    if (fusionRegion.getNumResults() == 0)
+      continue;
+
+    auto yieldOp =
+        dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+    if (!yieldOp) {
+      fusionRegion.emitError("result-bearing pto.fusion_region must end with "
+                             "pto.yield");
+      return failure();
+    }
+
+    if (yieldOp.getNumOperands() != fusionRegion.getNumResults()) {
+      fusionRegion.emitError(
+          "pto.fusion_region result count does not match yielded values");
+      return failure();
+    }
+
+    for (unsigned i = 0; i < fusionRegion.getNumResults(); ++i) {
+      Type yieldedTy = yieldOp.getOperand(i).getType();
+      if (fusionRegion.getResult(i).getType() != yieldedTy)
+        fusionRegion.getResult(i).setType(yieldedTy);
+    }
+  }
+
+  return success();
+}
+
 static LogicalResult markLoweredSetValidShapeOps(func::FuncOp func,
                                                  MLIRContext *ctx) {
   WalkResult result = func.walk([&](mlir::pto::SetValidShapeOp op) {
@@ -1088,7 +1186,8 @@ static Value buildTileBufViewLikeValue(Operation *anchorOp, Value src,
   IRRewriter rewriter(ctx);
   rewriter.setInsertionPoint(anchorOp);
 
-  auto srcMrTy = dyn_cast<MemRefType>(src.getType());
+  src = resolveTileBufViewLikeSource(src);
+  auto srcMrTy = dyn_cast_or_null<MemRefType>(src.getType());
   if (!srcMrTy) {
     anchorOp->emitError("tile_buf view op src must be lowered to memref first");
     return Value();
@@ -1533,6 +1632,10 @@ struct PTOViewToMemrefPass
       // Stage 1.4: Lower tile_buf view-like ops (treshape/bitcast)
       // ------------------------------------------------------------------
       if (failed(lowerTileBufViewLikeOps(func, ctx))) {
+        signalPassFailure();
+        return;
+      }
+      if (failed(reconcileFusionRegionResultTypes(func))) {
         signalPassFailure();
         return;
       }
@@ -3482,7 +3585,6 @@ struct PTOViewToMemrefPass
         signalPassFailure();
         return;
       }
-
       // Mark memref-form set_validshape only after control-flow result-type
       // reconciliation. Values such as scf.if results can stay tile_buf until
       // this late stage.

--- a/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
@@ -1,0 +1,497 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/TileFusion/FusionAnalysis.h"
+
+#include "PTO/IR/PTO.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir {
+namespace pto {
+
+namespace {
+
+static int64_t getConstantIndexOrDynamic(Value value) {
+  if (!value)
+    return ShapedType::kDynamic;
+  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>())
+    return cst.value();
+  if (auto cst = value.getDefiningOp<arith::ConstantIntOp>())
+    return cst.value();
+  return ShapedType::kDynamic;
+}
+
+static SmallVector<int64_t, 4> getValidShapeVec(Type type) {
+  if (auto tileType = dyn_cast<pto::TileBufType>(type)) {
+    return SmallVector<int64_t, 4>(tileType.getValidShape().begin(),
+                                   tileType.getValidShape().end());
+  }
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
+    return SmallVector<int64_t, 4>(shapedType.getShape().begin(),
+                                   shapedType.getShape().end());
+  }
+  return {};
+}
+
+static SmallVector<int64_t, 4> getValidShapeVec(Value value) {
+  SmallVector<int64_t, 4> validShape = getValidShapeVec(value.getType());
+  if (auto bind = value.getDefiningOp<pto::BindTileOp>()) {
+    if (validShape.size() >= 1 && bind.getValidRow())
+      validShape[0] = getConstantIndexOrDynamic(bind.getValidRow());
+    if (validShape.size() >= 2 && bind.getValidCol())
+      validShape[1] = getConstantIndexOrDynamic(bind.getValidCol());
+  }
+  return validShape;
+}
+
+struct Rank2IterationSpace {
+  int64_t rows = ShapedType::kDynamic;
+  int64_t cols = ShapedType::kDynamic;
+};
+
+static std::optional<Rank2IterationSpace> getRank2IterationSpace(Value value) {
+  SmallVector<int64_t, 4> validShape = getValidShapeVec(value);
+  if (validShape.size() < 2)
+    return std::nullopt;
+  return Rank2IterationSpace{validShape[0], validShape[1]};
+}
+
+static void mergeIterationDim(int64_t &mergedDim, int64_t dim,
+                              IterationDomainInfo &info) {
+  if (mergedDim == ShapedType::kDynamic || dim == ShapedType::kDynamic) {
+    mergedDim = ShapedType::kDynamic;
+    if (info.unprovenReason == IterationDomainUnprovenReason::None)
+      info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+    return;
+  }
+
+  if (mergedDim != dim) {
+    mergedDim = ShapedType::kDynamic;
+    info.unprovenReason = IterationDomainUnprovenReason::InconsistentShape;
+  }
+}
+
+static IterationDomainInfo
+inferConsensusIterationDomain(ArrayRef<Value> anchorValues) {
+  IterationDomainInfo info;
+  info.unprovenReason = IterationDomainUnprovenReason::None;
+
+  if (anchorValues.empty())
+    return info;
+
+  std::optional<Rank2IterationSpace> firstSpace =
+      getRank2IterationSpace(anchorValues.front());
+  if (!firstSpace)
+    return info;
+
+  info.vRow = firstSpace->rows;
+  info.vCol = firstSpace->cols;
+
+  if (info.vRow == ShapedType::kDynamic || info.vCol == ShapedType::kDynamic)
+    info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+
+  for (Value value : ArrayRef<Value>(anchorValues).drop_front()) {
+    std::optional<Rank2IterationSpace> space = getRank2IterationSpace(value);
+    if (!space) {
+      info.vRow = ShapedType::kDynamic;
+      info.vCol = ShapedType::kDynamic;
+      info.unprovenReason = IterationDomainUnprovenReason::MissingTileDomain;
+      return info;
+    }
+    mergeIterationDim(info.vRow, space->rows, info);
+    mergeIterationDim(info.vCol, space->cols, info);
+  }
+
+  if (info.unprovenReason == IterationDomainUnprovenReason::None &&
+      info.vRow != ShapedType::kDynamic && info.vCol != ShapedType::kDynamic) {
+    info.proof = IterationDomainProof::Proven;
+    return info;
+  }
+
+  if (info.unprovenReason == IterationDomainUnprovenReason::None)
+    info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+  return info;
+}
+
+static IterationDomainInfo
+inferIterationDomainInfo(const FusionOpSemantics &semantics) {
+  switch (semantics.computeFamily) {
+  case FusionComputeFamily::Elementwise: {
+    SmallVector<Value, 6> anchors;
+    anchors.append(semantics.tileInputs.begin(), semantics.tileInputs.end());
+    anchors.append(semantics.tileOutputs.begin(), semantics.tileOutputs.end());
+    return inferConsensusIterationDomain(anchors);
+  }
+  case FusionComputeFamily::ScalarExpand:
+  case FusionComputeFamily::RowBroadcastBinary:
+    return inferConsensusIterationDomain(semantics.tileOutputs);
+  case FusionComputeFamily::ReduceRow:
+  case FusionComputeFamily::ReduceCol:
+    return inferConsensusIterationDomain(semantics.tileInputs);
+  case FusionComputeFamily::Unknown:
+    return IterationDomainInfo();
+  }
+  return IterationDomainInfo();
+}
+
+static unsigned assignIterationDomainClass(
+    SmallVectorImpl<IterationDomainClass> &classes,
+    DenseMap<std::pair<int64_t, int64_t>, unsigned> &provenClassByKey,
+    const IterationDomainInfo &info, unsigned nodeId) {
+  if (info.proof == IterationDomainProof::Proven) {
+    std::pair<int64_t, int64_t> key{info.vRow, info.vCol};
+    auto it = provenClassByKey.find(key);
+    if (it != provenClassByKey.end()) {
+      classes[it->second].members.push_back(nodeId);
+      return it->second;
+    }
+
+    unsigned classId = classes.size();
+    IterationDomainClass klass;
+    klass.id = classId;
+    klass.info = info;
+    klass.members.push_back(nodeId);
+    classes.push_back(std::move(klass));
+    provenClassByKey.try_emplace(key, classId);
+    return classId;
+  }
+
+  unsigned classId = classes.size();
+  IterationDomainClass klass;
+  klass.id = classId;
+  klass.info = info;
+  klass.members.push_back(nodeId);
+  classes.push_back(std::move(klass));
+  return classId;
+}
+
+struct MutableLiveness {
+  FusionValueLiveness live;
+};
+
+struct MutableWriteInstance {
+  FusionWriteInstanceLiveness live;
+  unsigned producerBlockOrder = 0;
+};
+
+static FusionWriteInstanceEscapeClass classifyEscapeClass(
+    const FusionWriteInstanceLiveness &live) {
+  if (live.hasExternalUsers || live.escapesBlock ||
+      live.hasLocalHardBoundaryUsers) {
+    return FusionWriteInstanceEscapeClass::HardExternal;
+  }
+  if (live.hasLocalBoundaryUsers)
+    return FusionWriteInstanceEscapeClass::LocalBoundaryExternal;
+  return FusionWriteInstanceEscapeClass::Internal;
+}
+
+static Value getWriteInstanceStorageValue(Operation *op, unsigned outputIndex,
+                                          Value output) {
+  if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
+    unsigned tileOutputIndex = 0;
+    for (Value init : dpsIface.getDpsInits()) {
+      if (!isa<pto::TileBufType>(init.getType()))
+        continue;
+      if (tileOutputIndex == outputIndex)
+        return init;
+      ++tileOutputIndex;
+    }
+  }
+  return output;
+}
+
+static unsigned getOrCreateLivenessSlot(DenseMap<Value, unsigned> &slotByValue,
+                                        SmallVectorImpl<MutableLiveness> &slots,
+                                        Value value) {
+  auto [it, inserted] = slotByValue.try_emplace(value, slots.size());
+  if (inserted) {
+    MutableLiveness state;
+    state.live.value = value;
+    slots.push_back(std::move(state));
+  }
+  return it->second;
+}
+
+static void appendUniqueNode(SmallVectorImpl<unsigned> &nodes, unsigned nodeId) {
+  if (!llvm::is_contained(nodes, nodeId))
+    nodes.push_back(nodeId);
+}
+
+static void finalizeBlockLiveness(
+    Block &block, DenseMap<Operation *, FusionOpKind> &kindByOp,
+    DenseMap<Operation *, unsigned> &computeNodeByOp,
+    SmallVectorImpl<MutableLiveness> &mutableLiveness) {
+  for (MutableLiveness &state : mutableLiveness) {
+    for (OpOperand &use : state.live.value.getUses()) {
+      Operation *user = use.getOwner();
+      if (user->getBlock() != &block) {
+        state.live.hasExternalUsers = true;
+        state.live.escapesBlock = true;
+        continue;
+      }
+
+      auto kindIt = kindByOp.find(user);
+      if (kindIt == kindByOp.end())
+        continue;
+
+      if (user->hasTrait<OpTrait::IsTerminator>())
+        state.live.escapesBlock = true;
+
+      switch (kindIt->second) {
+      case FusionOpKind::Compute: {
+        auto nodeIt = computeNodeByOp.find(user);
+        if (nodeIt == computeNodeByOp.end())
+          continue;
+        appendUniqueNode(state.live.consumerNodes, nodeIt->second);
+        state.live.lastLocalConsumer = nodeIt->second;
+        break;
+      }
+      case FusionOpKind::LocalBoundary:
+        state.live.hasLocalBoundaryUsers = true;
+        break;
+      case FusionOpKind::HardBoundary:
+        state.live.hasLocalHardBoundaryUsers = true;
+        break;
+      }
+    }
+  }
+}
+
+static std::optional<unsigned> findReachingWriteInstance(
+    ArrayRef<unsigned> writeInstanceIds,
+    ArrayRef<MutableWriteInstance> mutableWriteInstances,
+    std::optional<unsigned> userBlockOrder) {
+  if (writeInstanceIds.empty())
+    return std::nullopt;
+
+  if (!userBlockOrder)
+    return writeInstanceIds.back();
+
+  for (unsigned writeInstanceId : llvm::reverse(writeInstanceIds)) {
+    if (mutableWriteInstances[writeInstanceId].producerBlockOrder <
+        *userBlockOrder)
+      return writeInstanceId;
+  }
+  return std::nullopt;
+}
+
+static bool isDpsInitOperandUse(OpOperand &use) {
+  auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(use.getOwner());
+  if (!dpsIface)
+    return false;
+
+  for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable())
+    if (&dpsInit == &use)
+      return true;
+  return false;
+}
+
+static void finalizeWriteInstances(
+    Block &block, DenseMap<Operation *, FusionOpKind> &kindByOp,
+    DenseMap<Operation *, unsigned> &computeNodeByOp,
+    DenseMap<Operation *, unsigned> &blockOrderByOp,
+    ArrayRef<MutableLiveness> mutableLiveness,
+    SmallVectorImpl<MutableWriteInstance> &mutableWriteInstances) {
+  for (const MutableLiveness &storageState : mutableLiveness) {
+    if (storageState.live.writeInstances.empty())
+      continue;
+
+    for (OpOperand &use : storageState.live.value.getUses()) {
+      if (isDpsInitOperandUse(use))
+        continue;
+
+      Operation *user = use.getOwner();
+      bool isInBlock = user->getBlock() == &block;
+      std::optional<unsigned> userBlockOrder;
+      if (isInBlock) {
+        auto orderIt = blockOrderByOp.find(user);
+        if (orderIt != blockOrderByOp.end())
+          userBlockOrder = orderIt->second;
+      }
+
+      std::optional<unsigned> writeInstanceId = findReachingWriteInstance(
+          storageState.live.writeInstances, mutableWriteInstances,
+          userBlockOrder);
+      if (!writeInstanceId)
+        continue;
+
+      FusionWriteInstanceLiveness &writeLive =
+          mutableWriteInstances[*writeInstanceId].live;
+
+      if (!isInBlock) {
+        writeLive.hasExternalUsers = true;
+        writeLive.escapesBlock = true;
+        continue;
+      }
+
+      auto kindIt = kindByOp.find(user);
+      if (kindIt == kindByOp.end())
+        continue;
+
+      if (user->hasTrait<OpTrait::IsTerminator>())
+        writeLive.escapesBlock = true;
+
+      switch (kindIt->second) {
+      case FusionOpKind::Compute: {
+        auto nodeIt = computeNodeByOp.find(user);
+        if (nodeIt == computeNodeByOp.end())
+          continue;
+        appendUniqueNode(writeLive.consumerNodes, nodeIt->second);
+        writeLive.lastLocalConsumer = nodeIt->second;
+        break;
+      }
+      case FusionOpKind::LocalBoundary:
+        writeLive.hasLocalBoundaryUsers = true;
+        break;
+      case FusionOpKind::HardBoundary:
+        writeLive.hasLocalHardBoundaryUsers = true;
+        break;
+      }
+    }
+  }
+
+  for (MutableWriteInstance &state : mutableWriteInstances)
+    state.live.escapeClass = classifyEscapeClass(state.live);
+}
+
+static FailureOr<FusionBlockAnalysis> analyzeBlock(Block &block) {
+  FusionBlockAnalysis analysis;
+  analysis.block = &block;
+
+  DenseMap<Value, unsigned> producerByValue;
+  DenseMap<Value, unsigned> livenessSlotByValue;
+  SmallVector<MutableLiveness, 8> mutableLiveness;
+  SmallVector<MutableWriteInstance, 8> mutableWriteInstances;
+  DenseMap<Operation *, FusionOpKind> kindByOp;
+  DenseMap<Operation *, unsigned> computeNodeByOp;
+  DenseMap<Operation *, unsigned> blockOrderByOp;
+  DenseMap<std::pair<int64_t, int64_t>, unsigned> provenClassByKey;
+
+  unsigned blockOrder = 0;
+  for (Operation &op : block) {
+    FailureOr<FusionOpSemantics> semanticsOr = getFusionOpSemantics(&op);
+    if (failed(semanticsOr)) {
+      op.emitError("failed to normalize fusion op semantics");
+      return failure();
+    }
+    blockOrderByOp[&op] = blockOrder;
+    kindByOp[&op] = semanticsOr->kind;
+
+    if (semanticsOr->kind == FusionOpKind::LocalBoundary) {
+      for (Value input : semanticsOr->tileInputs)
+        getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, input);
+      for (Value output : semanticsOr->tileOutputs)
+        getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, output);
+      ++blockOrder;
+      continue;
+    }
+
+    if (semanticsOr->kind != FusionOpKind::Compute) {
+      ++blockOrder;
+      continue;
+    }
+
+    FusionComputeNode node;
+    node.id = analysis.computeNodes.size();
+    node.blockOrder = blockOrder;
+    node.op = &op;
+    node.semantics = *semanticsOr;
+    computeNodeByOp[&op] = node.id;
+
+    IterationDomainInfo domainInfo = inferIterationDomainInfo(node.semantics);
+    node.iterationDomainClass = assignIterationDomainClass(
+        analysis.iterationDomainClasses, provenClassByKey, domainInfo, node.id);
+
+    for (auto [outputIdx, output] : llvm::enumerate(node.semantics.tileOutputs)) {
+      producerByValue[output] = node.id;
+      unsigned liveSlot =
+          getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, output);
+      mutableLiveness[liveSlot].live.producerNode = node.id;
+
+      MutableWriteInstance writeInstance;
+      writeInstance.live.id = mutableWriteInstances.size();
+      writeInstance.live.value = output;
+      writeInstance.live.storageValue =
+          getWriteInstanceStorageValue(&op, outputIdx, output);
+      writeInstance.live.producerNode = node.id;
+      writeInstance.producerBlockOrder = blockOrder;
+      mutableLiveness[liveSlot].live.writeInstances.push_back(
+          writeInstance.live.id);
+      mutableWriteInstances.push_back(std::move(writeInstance));
+    }
+
+    for (Value input : node.semantics.tileInputs) {
+      unsigned liveSlot =
+          getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, input);
+      appendUniqueNode(mutableLiveness[liveSlot].live.consumerNodes, node.id);
+      mutableLiveness[liveSlot].live.lastLocalConsumer = node.id;
+
+      auto producerIt = producerByValue.find(input);
+      if (producerIt == producerByValue.end())
+        continue;
+
+      FusionDFGEdge edge;
+      edge.producerNode = producerIt->second;
+      edge.consumerNode = node.id;
+      edge.value = input;
+
+      unsigned edgeId = analysis.edges.size();
+      analysis.edges.push_back(edge);
+      node.incomingEdges.push_back(edgeId);
+      if (edge.producerNode < analysis.computeNodes.size())
+        analysis.computeNodes[edge.producerNode].outgoingEdges.push_back(edgeId);
+    }
+
+    analysis.computeNodes.push_back(std::move(node));
+    ++blockOrder;
+  }
+
+  finalizeBlockLiveness(block, kindByOp, computeNodeByOp, mutableLiveness);
+  finalizeWriteInstances(block, kindByOp, computeNodeByOp, blockOrderByOp,
+                         mutableLiveness, mutableWriteInstances);
+
+  analysis.liveness.reserve(mutableLiveness.size());
+  for (MutableLiveness &state : mutableLiveness)
+    analysis.liveness.push_back(std::move(state.live));
+  analysis.writeInstances.reserve(mutableWriteInstances.size());
+  for (MutableWriteInstance &state : mutableWriteInstances)
+    analysis.writeInstances.push_back(std::move(state.live));
+
+  return std::move(analysis);
+}
+
+static LogicalResult analyzeRegion(Region &region,
+                                   SmallVectorImpl<FusionBlockAnalysis> &blocks) {
+  for (Block &block : region.getBlocks()) {
+    FailureOr<FusionBlockAnalysis> blockAnalysis = analyzeBlock(block);
+    if (failed(blockAnalysis))
+      return failure();
+    blocks.push_back(std::move(*blockAnalysis));
+    for (Operation &op : block)
+      for (Region &nested : op.getRegions())
+        if (failed(analyzeRegion(nested, blocks)))
+          return failure();
+  }
+  return success();
+}
+
+} // namespace
+
+FailureOr<PreFusionAnalysisResult> buildPreFusionAnalysis(func::FuncOp func) {
+  PreFusionAnalysisResult result;
+  if (failed(analyzeRegion(func.getRegion(), result.blocks)))
+    return failure();
+  return std::move(result);
+}
+
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+
+namespace mlir {
+namespace pto {
+
+static FusionComputeFamily getFusionComputeFamily(StringRef opName) {
+  return llvm::StringSwitch<FusionComputeFamily>(opName)
+      .Cases("tadd", "tsub", "tmul", "tdiv", "tmax", "tmin",
+             FusionComputeFamily::Elementwise)
+      .Cases("tadds", "tsubs", "tmuls", "tdivs", "tmaxs", "tmins",
+             FusionComputeFamily::Elementwise)
+      .Case("texp", FusionComputeFamily::Elementwise)
+      .Case("texpands", FusionComputeFamily::ScalarExpand)
+      .Cases("trowexpandmul", "trowexpanddiv",
+             FusionComputeFamily::RowBroadcastBinary)
+      .Cases("trowsum", "trowmax", "trowmin", FusionComputeFamily::ReduceRow)
+      .Cases("tcolsum", "tcolmax", "tcolmin", FusionComputeFamily::ReduceCol)
+      .Default(FusionComputeFamily::Unknown);
+}
+
+bool isSupportedPreFusionComputeOp(StringRef opName) {
+  return getFusionComputeFamily(opName) != FusionComputeFamily::Unknown;
+}
+
+static bool isTileFusionTileValue(Value value) {
+  return isa<pto::TileBufType>(value.getType());
+}
+
+static SmallVector<Value, 2> collectNormalizedTileOutputs(Operation *op) {
+  SmallVector<Value, 2> outputs;
+
+  if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
+    for (Value init : dpsIface.getDpsInits()) {
+      if (isTileFusionTileValue(init))
+        outputs.push_back(init);
+    }
+    if (!outputs.empty())
+      return outputs;
+  }
+
+  for (Value result : op->getResults()) {
+    if (isTileFusionTileValue(result))
+      outputs.push_back(result);
+  }
+  return outputs;
+}
+
+static StringRef getTileFusionOpName(Operation *op) {
+  StringRef opName = op->getName().getStringRef();
+  opName.consume_front("pto.");
+  return opName;
+}
+
+FailureOr<FusionOpSemantics> getFusionOpSemantics(Operation *op) {
+  FusionOpSemantics semantics;
+  semantics.op = op;
+  semantics.opName = getTileFusionOpName(op).str();
+
+  if (auto reshape = dyn_cast<pto::TReshapeOp>(op)) {
+    semantics.kind = FusionOpKind::LocalBoundary;
+    semantics.opName = "treshape";
+    semantics.tileInputs.push_back(reshape.getSrc());
+    semantics.tileOutputs.push_back(reshape.getResult());
+    return semantics;
+  }
+
+  semantics.computeFamily = getFusionComputeFamily(semantics.opName);
+  if (semantics.computeFamily == FusionComputeFamily::Unknown) {
+    semantics.kind = FusionOpKind::HardBoundary;
+    return semantics;
+  }
+
+  auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op);
+  if (!dpsIface && op->getNumResults() == 0) {
+    semantics.kind = FusionOpKind::HardBoundary;
+    return semantics;
+  }
+
+  semantics.kind = FusionOpKind::Compute;
+  semantics.tileOutputs = collectNormalizedTileOutputs(op);
+  if (semantics.tileOutputs.empty())
+    return failure();
+
+  SmallVector<unsigned, 4> dpsInitOperandNumbers;
+  if (dpsIface) {
+    for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable())
+      dpsInitOperandNumbers.push_back(dpsInit.getOperandNumber());
+  }
+
+  for (OpOperand &operand : op->getOpOperands()) {
+    if (llvm::is_contained(dpsInitOperandNumbers, operand.getOperandNumber()))
+      continue;
+
+    Value value = operand.get();
+    if (isTileFusionTileValue(value))
+      semantics.tileInputs.push_back(value);
+    else
+      semantics.scalarInputs.push_back(value);
+  }
+
+  if (semantics.tileInputs.empty()) {
+    for (Value output : semantics.tileOutputs) {
+      if (!isa<pto::TileBufType>(output.getType()))
+        return failure();
+    }
+  }
+
+  return semantics;
+}
+
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOFLATTENFUSIONREGION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static LogicalResult flattenFusionRegion(pto::FusionRegionOp fusionRegion) {
+  Block &body = fusionRegion.getBody().front();
+  auto yieldOp = dyn_cast<pto::YieldOp>(body.getTerminator());
+  if (!yieldOp)
+    return fusionRegion.emitOpError("expects body to terminate with pto.yield");
+
+  SmallVector<Value, 8> yieldedValues(yieldOp.getValues().begin(),
+                                      yieldOp.getValues().end());
+
+  Operation *anchor = fusionRegion.getOperation();
+  SmallVector<Operation *, 16> opsToMove;
+  opsToMove.reserve(body.getOperations().size());
+  for (Operation &op : body.without_terminator())
+    opsToMove.push_back(&op);
+
+  for (Operation *op : opsToMove)
+    op->moveBefore(anchor);
+
+  for (auto [result, replacement] :
+       llvm::zip(anchor->getResults(), yieldedValues))
+    result.replaceAllUsesWith(replacement);
+
+  yieldOp.erase();
+  anchor->erase();
+  return success();
+}
+
+struct PTOFlattenFusionRegionPass
+    : public pto::impl::PTOFlattenFusionRegionBase<
+          PTOFlattenFusionRegionPass> {
+  using pto::impl::PTOFlattenFusionRegionBase<
+      PTOFlattenFusionRegionPass>::PTOFlattenFusionRegionBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    SmallVector<pto::FusionRegionOp, 8> fusionRegions;
+    func.walk<WalkOrder::PostOrder>([&](pto::FusionRegionOp fusionRegion) {
+      fusionRegions.push_back(fusionRegion);
+    });
+
+    if (fusionRegions.empty()) {
+      markAllAnalysesPreserved();
+      return;
+    }
+
+    for (pto::FusionRegionOp fusionRegion : fusionRegions) {
+      if (failed(flattenFusionRegion(fusionRegion))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOFlattenFusionRegionPass() {
+  return std::make_unique<PTOFlattenFusionRegionPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
@@ -1,0 +1,624 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOFUSIONLOADSTOREELISION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct TrackedStore {
+  Operation *op = nullptr;
+  Value base;
+  SmallVector<Value, 2> indices;
+  Value mask;
+  Value value;
+};
+
+struct FusionRegionStoreContext {
+  Block *body = nullptr;
+  Block *parentBlock = nullptr;
+  Operation *regionOp = nullptr;
+  llvm::DenseSet<Value> yieldedValues;
+};
+
+static bool areEquivalentValues(Value lhs, Value rhs);
+static bool areEquivalentValueRanges(ArrayRef<Value> lhs, ArrayRef<Value> rhs) {
+  return lhs.size() == rhs.size() &&
+         llvm::all_of(llvm::zip(lhs, rhs), [](auto pair) {
+           return areEquivalentValues(std::get<0>(pair), std::get<1>(pair));
+         });
+}
+
+static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
+  if (!lhs || !rhs)
+    return false;
+  if (lhs->getName() != rhs->getName())
+    return false;
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+    return false;
+  if (lhs->getNumResults() != rhs->getNumResults())
+    return false;
+  if (lhs->getNumOperands() != rhs->getNumOperands())
+    return false;
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+    return false;
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+    return false;
+
+  if (auto lhsDim = dyn_cast<memref::DimOp>(lhs)) {
+    auto rhsDim = cast<memref::DimOp>(rhs);
+    return lhsDim.getSource().getType() == rhsDim.getSource().getType() &&
+           areEquivalentValues(lhsDim.getIndex(), rhsDim.getIndex());
+  }
+
+  for (auto [lhsOperand, rhsOperand] :
+       llvm::zip(lhs->getOperands(), rhs->getOperands())) {
+    if (!areEquivalentValues(lhsOperand, rhsOperand))
+      return false;
+  }
+  return true;
+}
+
+static bool areEquivalentValues(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return true;
+  if (!lhs || !rhs)
+    return false;
+  if (lhs.getType() != rhs.getType())
+    return false;
+
+  auto lhsArg = dyn_cast<BlockArgument>(lhs);
+  auto rhsArg = dyn_cast<BlockArgument>(rhs);
+  if (lhsArg || rhsArg) {
+    return lhsArg && rhsArg && lhsArg.getOwner() == rhsArg.getOwner() &&
+           lhsArg.getArgNumber() == rhsArg.getArgNumber();
+  }
+
+  return areEquivalentOperations(lhs.getDefiningOp(), rhs.getDefiningOp());
+}
+
+static bool areEquivalentMaskValues(Value lhs, Value rhs) {
+  return areEquivalentValues(lhs, rhs);
+}
+
+static bool isPureNoRegionOp(Operation *op) {
+  return op->getNumRegions() == 0 && isMemoryEffectFree(op);
+}
+
+static bool isSupportedLoopPreludeOp(Operation *op) {
+  if (isa<pto::UvldOp>(op))
+    return true;
+  return isPureNoRegionOp(op);
+}
+
+static bool isSupportedLeafOp(Operation *op) {
+  if (isa<pto::VldsOp, pto::VstsOp>(op))
+    return true;
+  return isPureNoRegionOp(op);
+}
+
+static Value getCanonicalTrackedValue(Value value) {
+  while (value) {
+    Operation *def = value.getDefiningOp();
+    if (!def)
+      break;
+
+    if (auto bind = dyn_cast<pto::BindTileOp>(def)) {
+      value = bind.getSource();
+      continue;
+    }
+    if (auto tileBufAddr = dyn_cast<pto::TileBufAddrOp>(def)) {
+      value = tileBufAddr.getSrc();
+      continue;
+    }
+    if (auto subview = dyn_cast<pto::SubViewOp>(def)) {
+      value = subview.getSource();
+      continue;
+    }
+    if (auto bitcast = dyn_cast<pto::BitcastOp>(def)) {
+      value = bitcast.getSrc();
+      continue;
+    }
+    if (auto reshape = dyn_cast<pto::TReshapeOp>(def)) {
+      value = reshape.getSrc();
+      continue;
+    }
+    if (auto subview = dyn_cast<memref::SubViewOp>(def)) {
+      value = subview.getSource();
+      continue;
+    }
+    if (auto cast = dyn_cast<memref::CastOp>(def)) {
+      value = cast.getSource();
+      continue;
+    }
+    if (auto reshape = dyn_cast<memref::ReshapeOp>(def)) {
+      value = reshape.getSource();
+      continue;
+    }
+    if (auto reinterpretCast = dyn_cast<memref::ReinterpretCastOp>(def)) {
+      value = reinterpretCast.getSource();
+      continue;
+    }
+    if (auto collapse = dyn_cast<memref::CollapseShapeOp>(def)) {
+      value = collapse.getSrc();
+      continue;
+    }
+    if (auto expand = dyn_cast<memref::ExpandShapeOp>(def)) {
+      value = expand.getSrc();
+      continue;
+    }
+    if (auto memorySpaceCast = dyn_cast<memref::MemorySpaceCastOp>(def)) {
+      value = memorySpaceCast.getSource();
+      continue;
+    }
+    if (auto transpose = dyn_cast<memref::TransposeOp>(def)) {
+      value = transpose.getIn();
+      continue;
+    }
+    if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
+      if (cast.getInputs().empty())
+        break;
+      if (auto result = dyn_cast<OpResult>(value)) {
+        unsigned resultNumber = result.getResultNumber();
+        if (resultNumber < cast.getInputs().size()) {
+          value = cast.getInputs()[resultNumber];
+          continue;
+        }
+      }
+      if (cast.getInputs().size() == 1) {
+        value = cast.getInputs().front();
+        continue;
+      }
+    }
+    break;
+  }
+  return value;
+}
+
+static bool normalizeFusionRegionYieldFrontier(pto::FusionRegionOp fusionRegion) {
+  Block &body = fusionRegion.getBody().front();
+  auto yieldOp = dyn_cast<pto::YieldOp>(body.getTerminator());
+  if (!yieldOp)
+    return false;
+
+  bool changed = false;
+  for (auto [index, yielded] : llvm::enumerate(yieldOp.getValues())) {
+    auto bind = yielded.getDefiningOp<pto::BindTileOp>();
+    if (!bind)
+      continue;
+
+    Value normalized = bind.getSource();
+    if (!normalized || normalized == yielded)
+      continue;
+
+    Value regionResult = fusionRegion.getResult(index);
+    Type originalResultType = regionResult.getType();
+
+    yieldOp->setOperand(index, normalized);
+    if (regionResult.getType() != normalized.getType())
+      regionResult.setType(normalized.getType());
+
+    if (originalResultType != normalized.getType() && !regionResult.use_empty()) {
+      OpBuilder builder(fusionRegion);
+      builder.setInsertionPointAfter(fusionRegion);
+      auto rebound = builder.create<pto::BindTileOp>(
+          bind.getLoc(), originalResultType, regionResult, bind.getValidRow(),
+          bind.getValidCol(), bind.getConfig());
+      rebound->setAttrs(bind->getAttrDictionary());
+      regionResult.replaceAllUsesExcept(rebound.getResult(), rebound);
+    }
+    changed = true;
+  }
+  return changed;
+}
+
+static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp())
+    if (cur->getBlock() == block)
+      return cur;
+  return nullptr;
+}
+
+static Region *getDirectRegionUnderAncestor(Operation *op, Operation *ancestor) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    Operation *parent = cur->getParentOp();
+    if (parent == ancestor)
+      return cur->getBlock() ? cur->getBlock()->getParent() : nullptr;
+  }
+  return nullptr;
+}
+
+static bool areMutuallyExclusiveByIfRegion(Operation *lhs, Operation *rhs) {
+  if (!lhs || !rhs)
+    return false;
+
+  for (Operation *ancestor = lhs; ancestor; ancestor = ancestor->getParentOp()) {
+    auto ifOp = dyn_cast<scf::IfOp>(ancestor);
+    if (!ifOp)
+      continue;
+
+    Region *lhsRegion = getDirectRegionUnderAncestor(lhs, ifOp);
+    Region *rhsRegion = getDirectRegionUnderAncestor(rhs, ifOp);
+    if (!lhsRegion || !rhsRegion)
+      continue;
+    if (lhsRegion != rhsRegion)
+      return true;
+  }
+
+  return false;
+}
+
+static std::optional<FusionRegionStoreContext>
+buildFusionRegionStoreContext(pto::FusionRegionOp fusionRegion) {
+  Block &body = fusionRegion.getBody().front();
+  auto yieldOp = dyn_cast<pto::YieldOp>(body.getTerminator());
+  if (!yieldOp)
+    return std::nullopt;
+
+  FusionRegionStoreContext context;
+  context.body = &body;
+  context.parentBlock = fusionRegion->getBlock();
+  context.regionOp = fusionRegion.getOperation();
+
+  for (Value yielded : yieldOp.getValues()) {
+    Value canonical = getCanonicalTrackedValue(yielded);
+    if (canonical)
+      context.yieldedValues.insert(canonical);
+  }
+
+  return context;
+}
+
+static bool isSupportedLoopRoot(scf::ForOp loop) {
+  if (!loop)
+    return false;
+  return isa<pto::FusionRegionOp, pto::VecScopeOp, pto::StrictVecScopeOp>(
+      loop->getParentOp());
+}
+
+static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
+  if (!carrierLoop)
+    return nullptr;
+
+  scf::ForOp currentLoop = carrierLoop;
+  while (currentLoop) {
+    SmallVector<Operation *, 8> bodyOps;
+    scf::ForOp innerLoop;
+    for (Operation &op : currentLoop.getBody()->without_terminator()) {
+      bodyOps.push_back(&op);
+      if (auto loop = dyn_cast<scf::ForOp>(op)) {
+        if (innerLoop)
+          return nullptr;
+        innerLoop = loop;
+      }
+    }
+
+    if (!innerLoop) {
+      Block *leafBody = currentLoop.getBody();
+      if (!leafBody)
+        return nullptr;
+      for (Operation &op : leafBody->without_terminator())
+        if (!isSupportedLeafOp(&op))
+          return nullptr;
+      return leafBody;
+    }
+
+    bool seenInnerLoop = false;
+    for (Operation *op : bodyOps) {
+      if (op == innerLoop.getOperation()) {
+        seenInnerLoop = true;
+        continue;
+      }
+      if (seenInnerLoop || !isSupportedLoopPreludeOp(op))
+        return nullptr;
+    }
+
+    currentLoop = innerLoop;
+  }
+
+  return nullptr;
+}
+
+static bool isSupportedStraightLineBlock(Block &body) {
+  for (Operation &op : body.without_terminator())
+    if (!isSupportedLeafOp(&op))
+      return false;
+  return true;
+}
+
+static Value inferVPTOLoadUserMask(pto::VldsOp load) {
+  Value inferredMask;
+  for (OpOperand &use : load.getResult().getUses()) {
+    Operation *owner = use.getOwner();
+    if (!owner || owner->getNumRegions() != 0)
+      return Value();
+
+    Value ownerMask;
+    for (Value operand : owner->getOperands()) {
+      if (!isa<pto::MaskType>(operand.getType()))
+        continue;
+      if (!ownerMask)
+        ownerMask = operand;
+      else if (!areEquivalentMaskValues(ownerMask, operand))
+        return Value();
+    }
+
+    if (!ownerMask)
+      return Value();
+
+    if (!inferredMask)
+      inferredMask = ownerMask;
+    else if (!areEquivalentMaskValues(inferredMask, ownerMask))
+      return Value();
+  }
+  return inferredMask;
+}
+
+static int findTrackedStoreIndex(ArrayRef<TrackedStore> stores, Value base,
+                                 ArrayRef<Value> indices, Value mask) {
+  for (int index = static_cast<int>(stores.size()) - 1; index >= 0; --index) {
+    const TrackedStore &store = stores[index];
+    if (areEquivalentValues(store.base, base) &&
+        areEquivalentValueRanges(store.indices, indices) &&
+        areEquivalentMaskValues(store.mask, mask)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+static void pruneTrackedStoresForLoadBase(SmallVectorImpl<TrackedStore> &stores,
+                                          Value base) {
+  if (!base) {
+    stores.clear();
+    return;
+  }
+  llvm::erase_if(stores, [&](const TrackedStore &store) {
+    return areEquivalentValues(store.base, base);
+  });
+}
+
+static bool shouldElideTailStore(
+    const TrackedStore &store, const FusionRegionStoreContext &context,
+    Operation *scopeOp,
+    const llvm::SmallPtrSetImpl<Operation *> &scheduledForErase) {
+  Value canonicalBase = getCanonicalTrackedValue(store.base);
+  if (!canonicalBase)
+    return false;
+  Operation *localScopeOp = scopeOp ? scopeOp : store.op;
+  if (!localScopeOp)
+    return false;
+  // Yielded frontier is still region-observable in v1, so its final
+  // materializing store must be preserved even if there is no reload.
+  if (context.yieldedValues.contains(canonicalBase))
+    return false;
+
+  for (OpOperand &use : canonicalBase.getUses()) {
+    Operation *owner = use.getOwner();
+    if (!owner || scheduledForErase.contains(owner))
+      continue;
+    if (context.regionOp->isProperAncestor(owner)) {
+      // Uses nested under the current carrier loop are fine: erasing the tail
+      // store only affects memory materialization, while SSA users still
+      // observe the forwarded vector value. A later top-level op in the same
+      // fusion region may still require the buffer to stay materialized, so
+      // keep the store.
+      Operation *topLevelUser = getTopLevelAncestorInBlock(owner, context.body);
+      if (!topLevelUser)
+        return false;
+      if (scheduledForErase.contains(topLevelUser))
+        continue;
+      if (topLevelUser == localScopeOp)
+        continue;
+      if (localScopeOp->getBlock() == topLevelUser->getBlock() &&
+          localScopeOp->isBeforeInBlock(topLevelUser))
+        return false;
+      continue;
+    }
+
+    // Any observable use after the fusion_region means the buffer escapes the
+    // region boundary, so the final store must remain.
+    Operation *topLevelUser =
+        getTopLevelAncestorInBlock(owner, context.parentBlock);
+    if (!topLevelUser) {
+      if (areMutuallyExclusiveByIfRegion(localScopeOp, owner))
+        continue;
+      return false;
+    }
+    if (scheduledForErase.contains(topLevelUser))
+      continue;
+    if (topLevelUser == context.regionOp)
+      continue;
+    if (context.regionOp->isBeforeInBlock(topLevelUser))
+      return false;
+  }
+  return true;
+}
+
+static bool elideLoadStoreRoundTripsInLeafBody(
+    Block &body, const FusionRegionStoreContext *context, Operation *scopeOp) {
+  SmallVector<Operation *, 8> eraseOrder;
+  llvm::SmallPtrSet<Operation *, 8> scheduledForErase;
+  SmallVector<TrackedStore, 8> trackedStores;
+  bool changed = false;
+
+  auto scheduleErase = [&](Operation *op) {
+    if (scheduledForErase.insert(op).second)
+      eraseOrder.push_back(op);
+  };
+
+  for (Operation &op : body.without_terminator()) {
+    if (auto load = dyn_cast<pto::VldsOp>(op)) {
+      Value inferredMask = inferVPTOLoadUserMask(load);
+      if (!inferredMask) {
+        // VPTO vlds does not carry an explicit predicate operand. If use-side
+        // mask information is not uniquely recoverable, keep behavior
+        // conservative by dropping only potentially aliasing tracked stores.
+        pruneTrackedStoresForLoadBase(trackedStores, load.getSource());
+        continue;
+      }
+
+      Value base = load.getSource();
+      Value offset = load.getOffset();
+      SmallVector<Value, 4> loadIndices{offset};
+      int matchIndex =
+          findTrackedStoreIndex(trackedStores, base, loadIndices, inferredMask);
+      if (matchIndex >= 0) {
+        load.getResult().replaceAllUsesWith(trackedStores[matchIndex].value);
+        scheduleErase(load);
+        changed = true;
+      } else {
+        pruneTrackedStoresForLoadBase(trackedStores, base);
+      }
+      continue;
+    }
+
+    if (auto store = dyn_cast<pto::VstsOp>(op)) {
+      Value base = store.getDestination();
+      Value offset = store.getOffset();
+      Value mask = store.getMask();
+      SmallVector<Value, 4> storeIndices{offset};
+      int matchIndex =
+          findTrackedStoreIndex(trackedStores, base, storeIndices, mask);
+      if (matchIndex >= 0) {
+        scheduleErase(trackedStores[matchIndex].op);
+        trackedStores.erase(trackedStores.begin() + matchIndex);
+        changed = true;
+      }
+
+      trackedStores.push_back(TrackedStore{
+          store.getOperation(),
+          base,
+          SmallVector<Value, 2>{offset},
+          mask,
+          store.getValue(),
+      });
+      continue;
+    }
+
+    if (!isPureNoRegionOp(&op))
+      trackedStores.clear();
+  }
+
+  if (context) {
+    for (const TrackedStore &store : trackedStores) {
+      if (!shouldElideTailStore(store, *context, scopeOp, scheduledForErase))
+        continue;
+      scheduleErase(store.op);
+      changed = true;
+    }
+  }
+
+  for (Operation *op : eraseOrder)
+    op->erase();
+  return changed;
+}
+
+struct PTOFusionLoadStoreElisionPass
+    : public pto::impl::PTOFusionLoadStoreElisionBase<
+          PTOFusionLoadStoreElisionPass> {
+  using pto::impl::PTOFusionLoadStoreElisionBase<
+      PTOFusionLoadStoreElisionPass>::PTOFusionLoadStoreElisionBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    bool changed = false;
+    func.walk([&](pto::FusionRegionOp fusionRegion) {
+      changed |= normalizeFusionRegionYieldFrontier(fusionRegion);
+    });
+
+    llvm::DenseMap<Operation *, FusionRegionStoreContext> regionContexts;
+    func.walk([&](pto::FusionRegionOp fusionRegion) {
+      std::optional<FusionRegionStoreContext> context =
+          buildFusionRegionStoreContext(fusionRegion);
+      if (!context)
+        return;
+      regionContexts.try_emplace(fusionRegion.getOperation(),
+                                 std::move(*context));
+    });
+
+    func.walk([&](pto::FusionRegionOp fusionRegion) {
+      auto it = regionContexts.find(fusionRegion.getOperation());
+      if (it == regionContexts.end())
+        return;
+
+      Block &body = fusionRegion.getBody().front();
+      if (!isSupportedStraightLineBlock(body))
+        return;
+
+      changed |= elideLoadStoreRoundTripsInLeafBody(body, &it->second, nullptr);
+    });
+
+    auto runElisionForLeafBody = [&](Block *leafBody, Operation *scopeOp,
+                                     pto::FusionRegionOp fusionRegion) {
+      if (!leafBody || !fusionRegion)
+        return;
+
+      auto it = regionContexts.find(fusionRegion.getOperation());
+      if (it == regionContexts.end())
+        return;
+
+      changed |=
+          elideLoadStoreRoundTripsInLeafBody(*leafBody, &it->second, scopeOp);
+    };
+
+    func.walk([&](pto::VecScopeOp vecscope) {
+      if (auto fusionRegion = vecscope->getParentOfType<pto::FusionRegionOp>()) {
+        if (isSupportedStraightLineBlock(vecscope.getBody().front()))
+          runElisionForLeafBody(&vecscope.getBody().front(), vecscope,
+                                fusionRegion);
+      }
+    });
+    func.walk([&](pto::StrictVecScopeOp vecscope) {
+      if (auto fusionRegion = vecscope->getParentOfType<pto::FusionRegionOp>()) {
+        if (isSupportedStraightLineBlock(vecscope.getBody().front()))
+          runElisionForLeafBody(&vecscope.getBody().front(), vecscope,
+                                fusionRegion);
+      }
+    });
+
+    func.walk([&](scf::ForOp loop) {
+      if (!isSupportedLoopRoot(loop))
+        return;
+      runElisionForLeafBody(getLeafLoopBody(loop), loop.getOperation(),
+                            loop->getParentOfType<pto::FusionRegionOp>());
+    });
+
+    if (!changed)
+      markAllAnalysesPreserved();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOFusionLoadStoreElisionPass() {
+  return std::make_unique<PTOFusionLoadStoreElisionPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -1,0 +1,526 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/TileFusion/FusionAnalysis.h"
+#include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <algorithm>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_FUSIONPLAN
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static constexpr llvm::StringLiteral kFusionGroupIdAttr =
+    "pto.fusion.group_id";
+static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+
+struct PlannedFusionGroup {
+  SmallVector<const pto::FusionComputeNode *, 8> members;
+};
+
+struct PlanningContext {
+  const pto::FusionBlockAnalysis &blockAnalysis;
+};
+
+struct PlanningCost {
+  int64_t dependencyBenefit = 0;
+  int64_t loopMergeBenefit = 0;
+  int64_t liveTilePenalty = 0;
+  int64_t vfParameterPenalty = 0;
+  bool rejectedForDynamicShape = false;
+
+  int64_t total() const {
+    return dependencyBenefit + loopMergeBenefit - liveTilePenalty -
+           vfParameterPenalty;
+  }
+};
+
+struct PlanningDecision {
+  bool accept = false;
+  PlanningCost cost;
+};
+
+static bool isCurrentlyPlannableOp(StringRef opName) {
+  return llvm::StringSwitch<bool>(opName)
+      .Cases("tmul", "tdiv", "tadd", "tsub", "tmax", "tmin", true)
+      .Cases("tmuls", "tdivs", "tadds", "tsubs", "tmaxs", "tmins", true)
+      .Case("texp", true)
+      .Case("texpands", true)
+      .Cases("trowexpandmul", "trowexpanddiv", true)
+      .Default(false);
+}
+
+static bool isProvenIterationDomain(
+    const pto::FusionBlockAnalysis &blockAnalysis,
+    const pto::FusionComputeNode &node) {
+  if (node.iterationDomainClass >= blockAnalysis.iterationDomainClasses.size())
+    return false;
+  return blockAnalysis.iterationDomainClasses[node.iterationDomainClass]
+             .info.proof == pto::IterationDomainProof::Proven;
+}
+
+static bool dependsOnPreviousNode(
+    const pto::FusionBlockAnalysis &blockAnalysis,
+    const pto::FusionComputeNode &previous,
+    const pto::FusionComputeNode &current) {
+  for (unsigned edgeId : current.incomingEdges) {
+    if (edgeId >= blockAnalysis.edges.size())
+      continue;
+    if (blockAnalysis.edges[edgeId].producerNode == previous.id)
+      return true;
+  }
+
+  for (Value output : previous.semantics.tileOutputs)
+    if (llvm::is_contained(current.semantics.tileInputs, output))
+      return true;
+
+  return false;
+}
+
+static SmallVector<const pto::FusionComputeNode *, 8>
+buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
+  SmallVector<const pto::FusionComputeNode *, 8> ordered(members.begin(),
+                                                         members.end());
+  llvm::stable_sort(ordered, [](const pto::FusionComputeNode *lhs,
+                                const pto::FusionComputeNode *rhs) {
+    if (lhs->blockOrder != rhs->blockOrder)
+      return lhs->blockOrder < rhs->blockOrder;
+    return lhs->id < rhs->id;
+  });
+  return ordered;
+}
+
+static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
+                                      MLIRContext *ctx,
+                                      int64_t &nextGroupId) {
+  SmallVector<const PlannedFusionGroup *, 8> orderedGroups;
+  orderedGroups.reserve(groups.size());
+  for (const PlannedFusionGroup &group : groups)
+    orderedGroups.push_back(&group);
+
+  llvm::stable_sort(orderedGroups, [](const PlannedFusionGroup *lhs,
+                                      const PlannedFusionGroup *rhs) {
+    const pto::FusionComputeNode *lhsFirst = lhs->members.front();
+    const pto::FusionComputeNode *rhsFirst = rhs->members.front();
+    if (lhsFirst->blockOrder != rhsFirst->blockOrder)
+      return lhsFirst->blockOrder < rhsFirst->blockOrder;
+    return lhsFirst->id < rhsFirst->id;
+  });
+
+  for (const PlannedFusionGroup *group : orderedGroups) {
+    const int64_t groupId = nextGroupId++;
+    SmallVector<const pto::FusionComputeNode *, 8> stableOrder =
+        buildStableInGroupOrder(group->members);
+    for (auto [order, node] : llvm::enumerate(stableOrder)) {
+      node->op->setAttr(kFusionGroupIdAttr,
+                        IntegerAttr::get(IntegerType::get(ctx, 64), groupId));
+      node->op->setAttr(
+          kFusionOrderAttr,
+          IntegerAttr::get(IntegerType::get(ctx, 64),
+                           static_cast<int64_t>(order)));
+    }
+  }
+}
+
+static bool isSupportedPlanningNode(const pto::FusionComputeNode &node) {
+  return node.semantics.kind == pto::FusionOpKind::Compute &&
+         isCurrentlyPlannableOp(node.semantics.opName);
+}
+
+static unsigned
+countEdgesFromGroup(const pto::FusionBlockAnalysis &blockAnalysis,
+                    ArrayRef<const pto::FusionComputeNode *> group,
+                    const pto::FusionComputeNode &candidate) {
+  DenseSet<unsigned> producerIds;
+  for (const pto::FusionComputeNode *member : group)
+    producerIds.insert(member->id);
+
+  unsigned count = 0;
+  for (unsigned edgeId : candidate.incomingEdges) {
+    if (edgeId >= blockAnalysis.edges.size())
+      continue;
+    if (producerIds.contains(blockAnalysis.edges[edgeId].producerNode))
+      ++count;
+  }
+  return count;
+}
+
+struct GroupFootprint {
+  unsigned liveTileCount = 0;
+  unsigned vfParameterCount = 0;
+};
+
+static bool nodesHaveDirectDataFlowConnection(
+    const pto::FusionBlockAnalysis &blockAnalysis,
+    const pto::FusionComputeNode &lhs, const pto::FusionComputeNode &rhs) {
+  for (unsigned edgeId : lhs.outgoingEdges) {
+    if (edgeId >= blockAnalysis.edges.size())
+      continue;
+    if (blockAnalysis.edges[edgeId].consumerNode == rhs.id)
+      return true;
+  }
+
+  for (unsigned edgeId : lhs.incomingEdges) {
+    if (edgeId >= blockAnalysis.edges.size())
+      continue;
+    if (blockAnalysis.edges[edgeId].producerNode == rhs.id)
+      return true;
+  }
+
+  for (Value output : lhs.semantics.tileOutputs)
+    if (llvm::is_contained(rhs.semantics.tileInputs, output))
+      return true;
+
+  for (Value output : rhs.semantics.tileOutputs)
+    if (llvm::is_contained(lhs.semantics.tileInputs, output))
+      return true;
+
+  return false;
+}
+
+static unsigned
+countConnectionsToGroup(const pto::FusionBlockAnalysis &blockAnalysis,
+                        ArrayRef<const pto::FusionComputeNode *> group,
+                        const pto::FusionComputeNode &candidate) {
+  unsigned connections = 0;
+  for (const pto::FusionComputeNode *member : group)
+    if (nodesHaveDirectDataFlowConnection(blockAnalysis, *member, candidate))
+      ++connections;
+  return connections;
+}
+
+static GroupFootprint
+computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
+  DenseSet<Value> producedTiles;
+  DenseSet<Value> touchedTiles;
+  DenseSet<Value> externalInputs;
+
+  for (const pto::FusionComputeNode *member : members) {
+    for (Value output : member->semantics.tileOutputs) {
+      producedTiles.insert(output);
+      touchedTiles.insert(output);
+    }
+  }
+
+  for (const pto::FusionComputeNode *member : members) {
+    for (Value input : member->semantics.tileInputs) {
+      touchedTiles.insert(input);
+      if (!producedTiles.contains(input))
+        externalInputs.insert(input);
+    }
+  }
+
+  GroupFootprint footprint;
+  footprint.liveTileCount = touchedTiles.size();
+  footprint.vfParameterCount = externalInputs.size() + producedTiles.size();
+  return footprint;
+}
+
+class CostModel {
+public:
+  virtual ~CostModel() = default;
+
+  virtual PlanningDecision evaluateSeed(const PlanningContext &ctx,
+                                        const pto::FusionComputeNode &candidate)
+      const = 0;
+
+  virtual PlanningDecision
+  evaluateAppend(const PlanningContext &ctx,
+                 ArrayRef<const pto::FusionComputeNode *> currentGroup,
+                 const pto::FusionComputeNode &candidate) const = 0;
+};
+
+class ConservativeGreedyCostModel final : public CostModel {
+public:
+  PlanningDecision
+  evaluateSeed(const PlanningContext &ctx,
+               const pto::FusionComputeNode &candidate) const override {
+    PlanningDecision decision;
+    if (!isSupportedPlanningNode(candidate))
+      return decision;
+
+    if (!isProvenIterationDomain(ctx.blockAnalysis, candidate)) {
+      decision.cost.rejectedForDynamicShape = true;
+      return decision;
+    }
+
+    decision.accept = true;
+    return decision;
+  }
+
+  PlanningDecision
+  evaluateAppend(const PlanningContext &ctx,
+                 ArrayRef<const pto::FusionComputeNode *> currentGroup,
+                 const pto::FusionComputeNode &candidate) const override {
+    PlanningDecision seedDecision = evaluateSeed(ctx, candidate);
+    if (!seedDecision.accept)
+      return seedDecision;
+
+    PlanningDecision decision;
+    if (currentGroup.empty()) {
+      decision.accept = true;
+      return decision;
+    }
+
+    const pto::FusionComputeNode &previous = *currentGroup.back();
+    const bool sameDomainClass =
+        previous.iterationDomainClass == candidate.iterationDomainClass;
+    const bool contiguousInBlock =
+        candidate.blockOrder == previous.blockOrder + 1;
+    const bool directlyDependent =
+        dependsOnPreviousNode(ctx.blockAnalysis, previous, candidate);
+    if (!sameDomainClass || !contiguousInBlock || !directlyDependent)
+      return decision;
+
+    SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
+        currentGroup.begin(), currentGroup.end());
+    proposedGroup.push_back(&candidate);
+    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
+
+    decision.cost.dependencyBenefit =
+        4 * static_cast<int64_t>(
+                countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate));
+    decision.cost.loopMergeBenefit = 2;
+    decision.cost.liveTilePenalty =
+        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - 4);
+    decision.cost.vfParameterPenalty = std::max<int64_t>(
+        0, static_cast<int64_t>(footprint.vfParameterCount) - 6);
+    decision.accept = decision.cost.total() > 0;
+    return decision;
+  }
+};
+
+class ConservativeDAGGreedyCostModel final : public CostModel {
+public:
+  PlanningDecision
+  evaluateSeed(const PlanningContext &ctx,
+               const pto::FusionComputeNode &candidate) const override {
+    PlanningDecision decision;
+    if (!isSupportedPlanningNode(candidate))
+      return decision;
+
+    if (!isProvenIterationDomain(ctx.blockAnalysis, candidate)) {
+      decision.cost.rejectedForDynamicShape = true;
+      return decision;
+    }
+
+    decision.accept = true;
+    return decision;
+  }
+
+  PlanningDecision
+  evaluateAppend(const PlanningContext &ctx,
+                 ArrayRef<const pto::FusionComputeNode *> currentGroup,
+                 const pto::FusionComputeNode &candidate) const override {
+    PlanningDecision seedDecision = evaluateSeed(ctx, candidate);
+    if (!seedDecision.accept)
+      return seedDecision;
+
+    PlanningDecision decision;
+    if (currentGroup.empty()) {
+      decision.accept = true;
+      return decision;
+    }
+
+    if (currentGroup.front()->iterationDomainClass !=
+        candidate.iterationDomainClass)
+      return decision;
+
+    const unsigned connectionCount =
+        countConnectionsToGroup(ctx.blockAnalysis, currentGroup, candidate);
+    if (connectionCount == 0)
+      return decision;
+
+    SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
+        currentGroup.begin(), currentGroup.end());
+    proposedGroup.push_back(&candidate);
+    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
+
+    decision.cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
+    decision.cost.loopMergeBenefit = 4;
+    decision.cost.liveTilePenalty = std::max<int64_t>(
+        0, static_cast<int64_t>(footprint.liveTileCount) - 10);
+    decision.cost.vfParameterPenalty = std::max<int64_t>(
+        0, static_cast<int64_t>(footprint.vfParameterCount) - 12);
+    decision.accept = decision.cost.total() > 0;
+    return decision;
+  }
+};
+
+class StrategyEngine {
+public:
+  virtual ~StrategyEngine() = default;
+
+  virtual SmallVector<PlannedFusionGroup, 8>
+  planBlock(const PlanningContext &ctx, const CostModel &costModel) const = 0;
+};
+
+class ConservativeGreedyStrategyEngine final : public StrategyEngine {
+public:
+  SmallVector<PlannedFusionGroup, 8>
+  planBlock(const PlanningContext &ctx,
+            const CostModel &costModel) const override {
+    SmallVector<PlannedFusionGroup, 8> groups;
+    SmallVector<const pto::FusionComputeNode *, 8> chain;
+
+    auto flushChain = [&]() {
+      if (chain.size() < 2) {
+        chain.clear();
+        return;
+      }
+
+      PlannedFusionGroup group;
+      group.members = chain;
+      groups.push_back(std::move(group));
+      chain.clear();
+    };
+
+    for (const pto::FusionComputeNode &node : ctx.blockAnalysis.computeNodes) {
+      PlanningDecision seedDecision = costModel.evaluateSeed(ctx, node);
+      if (!seedDecision.accept) {
+        flushChain();
+        continue;
+      }
+
+      if (chain.empty()) {
+        chain.push_back(&node);
+        continue;
+      }
+
+      PlanningDecision appendDecision =
+          costModel.evaluateAppend(ctx, chain, node);
+      if (!appendDecision.accept) {
+        flushChain();
+        chain.push_back(&node);
+        continue;
+      }
+
+      chain.push_back(&node);
+    }
+
+    flushChain();
+    return groups;
+  }
+};
+
+class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
+public:
+  SmallVector<PlannedFusionGroup, 8>
+  planBlock(const PlanningContext &ctx,
+            const CostModel &costModel) const override {
+    SmallVector<PlannedFusionGroup, 8> groups;
+    DenseSet<unsigned> assignedNodes;
+
+    for (const pto::FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
+      if (assignedNodes.contains(seed.id))
+        continue;
+
+      PlanningDecision seedDecision = costModel.evaluateSeed(ctx, seed);
+      if (!seedDecision.accept)
+        continue;
+
+      SmallVector<const pto::FusionComputeNode *, 8> groupMembers;
+      DenseSet<unsigned> groupNodeIds;
+      groupMembers.push_back(&seed);
+      groupNodeIds.insert(seed.id);
+
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (const pto::FusionComputeNode &candidate :
+             ctx.blockAnalysis.computeNodes) {
+          if (assignedNodes.contains(candidate.id) ||
+              groupNodeIds.contains(candidate.id))
+            continue;
+
+          PlanningDecision appendDecision =
+              costModel.evaluateAppend(ctx, groupMembers, candidate);
+          if (!appendDecision.accept)
+            continue;
+
+          groupMembers.push_back(&candidate);
+          groupNodeIds.insert(candidate.id);
+          changed = true;
+        }
+      }
+
+      if (groupMembers.size() < 2)
+        continue;
+
+      PlannedFusionGroup group;
+      group.members = buildStableInGroupOrder(groupMembers);
+      groups.push_back(group);
+      for (const pto::FusionComputeNode *member : group.members)
+        assignedNodes.insert(member->id);
+    }
+
+    return groups;
+  }
+};
+
+static void clearPlanningAttrs(func::FuncOp func) {
+  func.walk([](Operation *op) {
+    op->removeAttr(kFusionGroupIdAttr);
+    op->removeAttr(kFusionOrderAttr);
+  });
+}
+
+struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
+  using pto::impl::FusionPlanBase<FusionPlanPass>::FusionPlanBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    clearPlanningAttrs(func);
+
+    const auto &analysis = getAnalysis<pto::PreFusionAnalysis>();
+    if (!analysis.isValid()) {
+      signalPassFailure();
+      return;
+    }
+
+    MLIRContext *ctx = &getContext();
+    int64_t nextGroupId = 0;
+    ConservativeDAGGreedyCostModel costModel;
+    ConservativeDAGGreedyStrategyEngine strategyEngine;
+
+    for (const pto::FusionBlockAnalysis &blockAnalysis :
+         analysis.getResult().blocks) {
+      PlanningContext planningCtx{blockAnalysis};
+      SmallVector<PlannedFusionGroup, 8> groups =
+          strategyEngine.planBlock(planningCtx, costModel);
+      assignStableGroupMetadata(groups, ctx, nextGroupId);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createFusionPlanPass() {
+  return std::make_unique<FusionPlanPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOFUSIONPREDICATEELISION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct PltCandidate {
+  Operation *op = nullptr;
+  Value scalar;
+  Value mask;
+  Value scalarOut;
+  unsigned bitWidth = 0;
+  SmallVector<unsigned, 4> dominatingCandidates;
+};
+
+struct FusionRegionPredicateContext {
+  pto::FusionRegionOp fusionRegion;
+  SmallVector<PltCandidate, 8> pltCandidates;
+};
+
+enum class EquivalenceState : uint8_t {
+  InProgress,
+  Equivalent,
+  NotEquivalent,
+};
+
+struct ValueEquivalenceContext {
+  // Cache pairwise equivalence inside one fusion-region rewrite walk. This
+  // keeps recursive loop-carried checks bounded and deterministic.
+  llvm::DenseMap<Value, llvm::SmallDenseMap<Value, EquivalenceState, 4>>
+      states;
+};
+
+struct ForIterArgInfo {
+  scf::ForOp forOp;
+  unsigned iterArgIndex = 0;
+};
+
+struct PltScalarOutInfo {
+  Value scalar;
+  unsigned bitWidth = 0;
+};
+
+static bool areEquivalentValues(Value lhs, Value rhs,
+                                ValueEquivalenceContext &context);
+
+static void normalizeValuePair(Value &lhs, Value &rhs) {
+  if (lhs.getAsOpaquePointer() > rhs.getAsOpaquePointer()) {
+    Value tmp = lhs;
+    lhs = rhs;
+    rhs = tmp;
+  }
+}
+
+static bool areSameValuePair(Value lhs, Value rhs, Value expectedLhs,
+                             Value expectedRhs) {
+  normalizeValuePair(lhs, rhs);
+  normalizeValuePair(expectedLhs, expectedRhs);
+  return lhs == expectedLhs && rhs == expectedRhs;
+}
+
+static std::optional<EquivalenceState>
+lookupEquivalenceState(ValueEquivalenceContext &context, Value lhs, Value rhs) {
+  normalizeValuePair(lhs, rhs);
+  auto outerIt = context.states.find(lhs);
+  if (outerIt == context.states.end())
+    return std::nullopt;
+  auto innerIt = outerIt->second.find(rhs);
+  if (innerIt == outerIt->second.end())
+    return std::nullopt;
+  return innerIt->second;
+}
+
+static void setEquivalenceState(ValueEquivalenceContext &context, Value lhs,
+                                Value rhs, EquivalenceState state) {
+  normalizeValuePair(lhs, rhs);
+  context.states[lhs][rhs] = state;
+}
+
+static std::optional<PltCandidate> buildPltCandidate(Operation *op) {
+  if (auto plt = dyn_cast<pto::PltB8Op>(op)) {
+    return PltCandidate{
+        op, plt.getScalar(), plt.getMask(), plt.getScalarOut(), 8, {}};
+  }
+  if (auto plt = dyn_cast<pto::PltB16Op>(op)) {
+    return PltCandidate{
+        op, plt.getScalar(), plt.getMask(), plt.getScalarOut(), 16, {}};
+  }
+  if (auto plt = dyn_cast<pto::PltB32Op>(op)) {
+    return PltCandidate{
+        op, plt.getScalar(), plt.getMask(), plt.getScalarOut(), 32, {}};
+  }
+  return std::nullopt;
+}
+
+static std::optional<ForIterArgInfo> getForIterArgInfo(Value value) {
+  auto arg = dyn_cast<BlockArgument>(value);
+  if (!arg || arg.getArgNumber() == 0)
+    return std::nullopt;
+
+  auto forOp =
+      dyn_cast_or_null<scf::ForOp>(arg.getParentRegion()->getParentOp());
+  if (!forOp || arg.getOwner() != forOp.getBody())
+    return std::nullopt;
+
+  unsigned iterArgIndex = arg.getArgNumber() - 1;
+  if (iterArgIndex >= forOp.getInitArgs().size())
+    return std::nullopt;
+  return ForIterArgInfo{forOp, iterArgIndex};
+}
+
+static std::optional<PltScalarOutInfo> getPltScalarOutInfo(Value value) {
+  auto result = dyn_cast<OpResult>(value);
+  if (!result || result.getResultNumber() != 1)
+    return std::nullopt;
+
+  if (auto plt = dyn_cast<pto::PltB8Op>(result.getOwner()))
+    return PltScalarOutInfo{plt.getScalar(), 8};
+  if (auto plt = dyn_cast<pto::PltB16Op>(result.getOwner()))
+    return PltScalarOutInfo{plt.getScalar(), 16};
+  if (auto plt = dyn_cast<pto::PltB32Op>(result.getOwner()))
+    return PltScalarOutInfo{plt.getScalar(), 32};
+  return std::nullopt;
+}
+
+static bool areEquivalentLoopCarriedValues(Value lhs, Value rhs,
+                                           ValueEquivalenceContext &context) {
+  std::optional<ForIterArgInfo> lhsInfo = getForIterArgInfo(lhs);
+  std::optional<ForIterArgInfo> rhsInfo = getForIterArgInfo(rhs);
+  if (!lhsInfo || !rhsInfo)
+    return false;
+  if (lhsInfo->forOp != rhsInfo->forOp)
+    return false;
+
+  if (lhsInfo->forOp.getRegionIterArgs().size() !=
+      lhsInfo->forOp.getInitArgs().size())
+    return false;
+  if (lhsInfo->forOp.getRegionIterArgs().size() !=
+      lhsInfo->forOp.getYieldedValues().size())
+    return false;
+
+  ValueRange initArgs = lhsInfo->forOp.getInitArgs();
+  if (!areEquivalentValues(initArgs[lhsInfo->iterArgIndex],
+                           initArgs[rhsInfo->iterArgIndex], context))
+    return false;
+
+  ValueRange yieldedValues = lhsInfo->forOp.getYieldedValues();
+  std::optional<PltScalarOutInfo> lhsYieldInfo =
+      getPltScalarOutInfo(yieldedValues[lhsInfo->iterArgIndex]);
+  std::optional<PltScalarOutInfo> rhsYieldInfo =
+      getPltScalarOutInfo(yieldedValues[rhsInfo->iterArgIndex]);
+  if (!lhsYieldInfo || !rhsYieldInfo)
+    return false;
+  if (lhsYieldInfo->bitWidth != rhsYieldInfo->bitWidth)
+    return false;
+
+  // Stay conservative on unsupported cyclic proofs. The only accepted
+  // recurrence cycle is the direct iter_arg -> plt.scalar_out self recursion
+  // for the same value pair; more complex cycles remain unsupported.
+  if (areSameValuePair(lhs, rhs, lhsYieldInfo->scalar, rhsYieldInfo->scalar))
+    return true;
+
+  return areEquivalentValues(lhsYieldInfo->scalar, rhsYieldInfo->scalar,
+                             context);
+}
+
+static bool areEquivalentOperations(Operation *lhs, Operation *rhs,
+                                    ValueEquivalenceContext &context) {
+  if (!lhs || !rhs)
+    return false;
+  if (lhs->getName() != rhs->getName())
+    return false;
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+    return false;
+  if (lhs->getNumResults() != rhs->getNumResults())
+    return false;
+  if (lhs->getNumOperands() != rhs->getNumOperands())
+    return false;
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+    return false;
+  if (!isMemoryEffectFree(lhs) || !isMemoryEffectFree(rhs))
+    return false;
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+    return false;
+
+  for (auto [lhsOperand, rhsOperand] :
+       llvm::zip(lhs->getOperands(), rhs->getOperands())) {
+    if (!areEquivalentValues(lhsOperand, rhsOperand, context))
+      return false;
+  }
+  return true;
+}
+
+static bool areEquivalentValues(Value lhs, Value rhs,
+                                ValueEquivalenceContext &context) {
+  if (lhs == rhs)
+    return true;
+  if (!lhs || !rhs)
+    return false;
+  if (lhs.getType() != rhs.getType())
+    return false;
+
+  if (std::optional<EquivalenceState> state =
+          lookupEquivalenceState(context, lhs, rhs)) {
+    return *state == EquivalenceState::Equivalent;
+  }
+  setEquivalenceState(context, lhs, rhs, EquivalenceState::InProgress);
+
+  auto lhsArg = dyn_cast<BlockArgument>(lhs);
+  auto rhsArg = dyn_cast<BlockArgument>(rhs);
+  if (lhsArg || rhsArg) {
+    bool equivalent =
+        lhsArg && rhsArg &&
+        ((lhsArg.getOwner() == rhsArg.getOwner() &&
+          lhsArg.getArgNumber() == rhsArg.getArgNumber()) ||
+         areEquivalentLoopCarriedValues(lhs, rhs, context));
+    setEquivalenceState(context, lhs, rhs,
+                        equivalent ? EquivalenceState::Equivalent
+                                   : EquivalenceState::NotEquivalent);
+    return equivalent;
+  }
+
+  bool equivalent =
+      areEquivalentOperations(lhs.getDefiningOp(), rhs.getDefiningOp(), context);
+  setEquivalenceState(context, lhs, rhs,
+                      equivalent ? EquivalenceState::Equivalent
+                                 : EquivalenceState::NotEquivalent);
+  return equivalent;
+}
+
+static void populateDominatingCandidateIndices(
+    MutableArrayRef<PltCandidate> candidates, DominanceInfo &dominanceInfo) {
+  for (unsigned current = 0; current < candidates.size(); ++current) {
+    for (unsigned previous = 0; previous < current; ++previous) {
+      if (candidates[previous].bitWidth != candidates[current].bitWidth)
+        continue;
+      // Only reuse an earlier plt when its whole result pair dominates the
+      // later one. This keeps replacement local and SSA-safe.
+      if (!dominanceInfo.properlyDominates(candidates[previous].op,
+                                           candidates[current].op))
+        continue;
+      candidates[current].dominatingCandidates.push_back(previous);
+    }
+  }
+}
+
+static FusionRegionPredicateContext
+buildFusionRegionPredicateContext(pto::FusionRegionOp fusionRegion,
+                                  DominanceInfo &dominanceInfo) {
+  FusionRegionPredicateContext context;
+  context.fusionRegion = fusionRegion;
+
+  fusionRegion.walk([&](Operation *op) -> WalkResult {
+    if (op != fusionRegion.getOperation() && isa<pto::FusionRegionOp>(op))
+      return WalkResult::skip();
+
+    if (std::optional<PltCandidate> candidate = buildPltCandidate(op))
+      context.pltCandidates.push_back(std::move(*candidate));
+    return WalkResult::advance();
+  });
+
+  populateDominatingCandidateIndices(context.pltCandidates, dominanceInfo);
+  return context;
+}
+
+static Value getCurrentScalarOperand(const PltCandidate &candidate) {
+  return candidate.op ? candidate.op->getOperand(0) : Value();
+}
+
+static std::optional<unsigned>
+findEquivalentDominatingCandidate(FusionRegionPredicateContext &context,
+                                  ValueEquivalenceContext &valueContext,
+                                  unsigned currentIndex,
+                                  const llvm::DenseSet<unsigned> &erased) {
+  const PltCandidate &current = context.pltCandidates[currentIndex];
+  Value currentScalar = getCurrentScalarOperand(current);
+  for (unsigned previousIndex : current.dominatingCandidates) {
+    if (erased.contains(previousIndex))
+      continue;
+    const PltCandidate &previous = context.pltCandidates[previousIndex];
+    // Equivalence is checked on the scalar input; when it holds, both plt
+    // results are reused as a pair.
+    if (areEquivalentValues(getCurrentScalarOperand(previous), currentScalar,
+                            valueContext))
+      return previousIndex;
+  }
+  return std::nullopt;
+}
+
+static bool
+elideEquivalentPltCandidates(FusionRegionPredicateContext &context) {
+  bool changed = false;
+  llvm::DenseSet<unsigned> erased;
+  SmallVector<Operation *, 8> opsToErase;
+  ValueEquivalenceContext valueContext;
+
+  for (unsigned currentIndex = 0; currentIndex < context.pltCandidates.size();
+       ++currentIndex) {
+    if (erased.contains(currentIndex))
+      continue;
+
+    std::optional<unsigned> previousIndex =
+        findEquivalentDominatingCandidate(context, valueContext, currentIndex,
+                                          erased);
+    if (!previousIndex)
+      continue;
+
+    PltCandidate &current = context.pltCandidates[currentIndex];
+    PltCandidate &previous = context.pltCandidates[*previousIndex];
+    current.mask.replaceAllUsesWith(previous.mask);
+    current.scalarOut.replaceAllUsesWith(previous.scalarOut);
+    opsToErase.push_back(current.op);
+    erased.insert(currentIndex);
+    changed = true;
+  }
+
+  for (Operation *op : opsToErase)
+    op->erase();
+
+  return changed;
+}
+
+struct PTOFusionPredicateElisionPass
+    : public pto::impl::PTOFusionPredicateElisionBase<
+          PTOFusionPredicateElisionPass> {
+  using pto::impl::PTOFusionPredicateElisionBase<
+      PTOFusionPredicateElisionPass>::PTOFusionPredicateElisionBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    DominanceInfo &dominanceInfo = getAnalysis<DominanceInfo>();
+    SmallVector<FusionRegionPredicateContext, 4> fusionContexts;
+    func.walk([&](pto::FusionRegionOp fusionRegion) {
+      FusionRegionPredicateContext context =
+          buildFusionRegionPredicateContext(fusionRegion, dominanceInfo);
+      if (!context.pltCandidates.empty())
+        fusionContexts.push_back(std::move(context));
+    });
+
+    bool changed = false;
+    for (FusionRegionPredicateContext &context : fusionContexts)
+      changed |= elideEquivalentPltCandidates(context);
+
+    if (!changed)
+      markAllAnalysesPreserved();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOFusionPredicateElisionPass() {
+  return std::make_unique<PTOFusionPredicateElisionPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
@@ -1,0 +1,464 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+#include "PTO/Transforms/TileFusion/FusionAnalysis.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOFUSIONREGIONGEN
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static constexpr llvm::StringLiteral kFusionGroupIdAttr =
+    "pto.fusion.group_id";
+static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+
+struct GroupSpanMember {
+  Operation *op = nullptr;
+  int64_t order = 0;
+};
+
+struct GroupSpan {
+  Block *block = nullptr;
+  int64_t groupId = -1;
+  SmallVector<GroupSpanMember, 8> members;
+};
+
+struct GroupSpanInterface {
+  SmallVector<Value, 8> externallyVisibleValues;
+  SmallVector<Operation *, 8> localDefs;
+};
+
+struct FusionBlockAnalysisIndex {
+  DenseMap<Operation *, unsigned> nodeIdByOp;
+  DenseMap<unsigned, SmallVector<const pto::FusionWriteInstanceLiveness *, 2>>
+      writeInstancesByProducerNode;
+};
+
+struct PreFusionAnalysisIndex {
+  DenseMap<Block *, FusionBlockAnalysisIndex> blocks;
+};
+
+static std::optional<int64_t> getRequiredI64Attr(Operation *op,
+                                                 StringRef attrName) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName))
+    return attr.getInt();
+  return std::nullopt;
+}
+
+static bool hasIncompleteFusionMetadata(Operation *op) {
+  const bool hasGroupId = op->hasAttr(kFusionGroupIdAttr);
+  const bool hasOrder = op->hasAttr(kFusionOrderAttr);
+  return hasGroupId != hasOrder;
+}
+
+static LogicalResult
+collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
+  DenseMap<int64_t, unsigned> spanIndexByGroupId;
+
+  GroupSpan current;
+
+  auto flush = [&]() -> LogicalResult {
+    if (current.members.empty())
+      return success();
+
+    current.block = &block;
+    auto [it, inserted] =
+        spanIndexByGroupId.try_emplace(current.groupId, spans.size());
+    if (!inserted) {
+      current.members.front().op->emitError(
+          "expected one contiguous span per pto.fusion.group_id within a basic "
+          "block");
+      return failure();
+    }
+
+    spans.push_back(std::move(current));
+    current = GroupSpan();
+    return success();
+  };
+
+  for (Operation &op : block) {
+    if (hasIncompleteFusionMetadata(&op)) {
+      op.emitError("expected pto.fusion.group_id and pto.fusion.order to "
+                   "either both exist or both be absent");
+      return failure();
+    }
+
+    std::optional<int64_t> groupId =
+        getRequiredI64Attr(&op, kFusionGroupIdAttr);
+    if (!groupId) {
+      if (failed(flush()))
+        return failure();
+      continue;
+    }
+
+    std::optional<int64_t> order = getRequiredI64Attr(&op, kFusionOrderAttr);
+    if (!order) {
+      op.emitError("missing required pto.fusion.order attribute");
+      return failure();
+    }
+
+    if (current.members.empty()) {
+      current.groupId = *groupId;
+      current.members.push_back(GroupSpanMember{&op, *order});
+      continue;
+    }
+
+    if (current.groupId != *groupId) {
+      if (failed(flush()))
+        return failure();
+      current.groupId = *groupId;
+    }
+
+    if (!current.members.empty() && current.members.back().order >= *order) {
+      op.emitError("expected contiguous fusion span to follow increasing "
+                   "pto.fusion.order");
+      return failure();
+    }
+
+    current.members.push_back(GroupSpanMember{&op, *order});
+  }
+
+  return flush();
+}
+
+static bool isNestedInOp(Operation *op, Operation *ancestor) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp())
+    if (cur == ancestor)
+      return true;
+  return false;
+}
+
+static bool isNestedInSpan(Operation *op, const DenseSet<Operation *> &spanOps) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp())
+    if (spanOps.contains(cur))
+      return true;
+  return false;
+}
+
+static void appendUniqueValue(SmallVectorImpl<Value> &values,
+                              DenseSet<Value> &seen, Value value) {
+  if (seen.insert(value).second)
+    values.push_back(value);
+}
+
+static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp())
+    if (cur->getBlock() == block)
+      return cur;
+  return nullptr;
+}
+
+static bool canReplaceUseWithRegionResult(OpOperand &use, Operation *boundary) {
+  Operation *topLevel =
+      getTopLevelAncestorInBlock(use.getOwner(), boundary->getBlock());
+  if (!topLevel || topLevel == boundary)
+    return false;
+  return boundary->isBeforeInBlock(topLevel);
+}
+
+static bool hasReplaceableUseOutsideSpan(Value value,
+                                         const DenseSet<Operation *> &spanOps,
+                                         Operation *boundary) {
+  for (OpOperand &use : value.getUses()) {
+    if (isNestedInSpan(use.getOwner(), spanOps))
+      continue;
+    if (canReplaceUseWithRegionResult(use, boundary))
+      return true;
+  }
+  return false;
+}
+
+static bool hasAnyUseOutsideSpan(Value value,
+                                 const DenseSet<Operation *> &spanOps) {
+  for (OpOperand &use : value.getUses())
+    if (!isNestedInSpan(use.getOwner(), spanOps))
+      return true;
+  return false;
+}
+
+static const FusionBlockAnalysisIndex *
+getBlockAnalysisIndex(const PreFusionAnalysisIndex *analysisIndex, Block *block) {
+  if (!analysisIndex)
+    return nullptr;
+  auto it = analysisIndex->blocks.find(block);
+  if (it == analysisIndex->blocks.end())
+    return nullptr;
+  return &it->second;
+}
+
+static const pto::FusionWriteInstanceLiveness *
+getProducedWriteInstance(const FusionBlockAnalysisIndex *blockAnalysis,
+                         Operation *op, unsigned tileOutputIndex) {
+  if (!blockAnalysis)
+    return nullptr;
+
+  auto nodeIt = blockAnalysis->nodeIdByOp.find(op);
+  if (nodeIt == blockAnalysis->nodeIdByOp.end())
+    return nullptr;
+
+  auto writeIt =
+      blockAnalysis->writeInstancesByProducerNode.find(nodeIt->second);
+  if (writeIt == blockAnalysis->writeInstancesByProducerNode.end())
+    return nullptr;
+  if (tileOutputIndex >= writeIt->second.size())
+    return nullptr;
+  return writeIt->second[tileOutputIndex];
+}
+
+static bool
+writeInstanceEscapesSpan(const pto::FusionWriteInstanceLiveness &writeInstance,
+                         const DenseSet<unsigned> &spanNodeIds) {
+  if (writeInstance.hasExternalUsers || writeInstance.escapesBlock ||
+      writeInstance.hasLocalBoundaryUsers ||
+      writeInstance.hasLocalHardBoundaryUsers)
+    return true;
+
+  for (unsigned consumerNode : writeInstance.consumerNodes)
+    if (!spanNodeIds.contains(consumerNode))
+      return true;
+  return false;
+}
+
+static bool canSinkAllocTileDefToRegion(Value value, const GroupSpan &span,
+                                        const DenseSet<Operation *> &spanOps) {
+  auto alloc = dyn_cast_or_null<pto::AllocTileOp>(value.getDefiningOp());
+  if (!alloc || alloc->getBlock() != span.block)
+    return false;
+
+  Operation *firstOp = span.members.front().op;
+  if (!alloc->isBeforeInBlock(firstOp))
+    return false;
+
+  for (OpOperand &use : value.getUses()) {
+    if (isNestedInSpan(use.getOwner(), spanOps))
+      continue;
+    if (!canReplaceUseWithRegionResult(use, firstOp))
+      return false;
+  }
+
+  return true;
+}
+
+static GroupSpanInterface
+buildGroupSpanInterface(const GroupSpan &span,
+                        const PreFusionAnalysisIndex *analysisIndex) {
+  GroupSpanInterface iface;
+  DenseSet<Value> seenOutputs;
+  DenseSet<Operation *> spanOps;
+  Operation *boundary = span.members.front().op;
+  const FusionBlockAnalysisIndex *blockAnalysis =
+      getBlockAnalysisIndex(analysisIndex, span.block);
+  DenseSet<unsigned> spanNodeIds;
+
+  for (const GroupSpanMember &member : span.members) {
+    spanOps.insert(member.op);
+    if (!blockAnalysis)
+      continue;
+    auto nodeIt = blockAnalysis->nodeIdByOp.find(member.op);
+    if (nodeIt != blockAnalysis->nodeIdByOp.end())
+      spanNodeIds.insert(nodeIt->second);
+  }
+
+  for (const GroupSpanMember &member : span.members) {
+    for (Value result : member.op->getResults())
+      if (hasReplaceableUseOutsideSpan(result, spanOps, boundary))
+        appendUniqueValue(iface.externallyVisibleValues, seenOutputs, result);
+
+    if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(member.op)) {
+      unsigned tileOutputIndex = 0;
+      for (Value init : dpsIface.getDpsInits()) {
+        if (!isa<pto::TileBufType>(init.getType()))
+          continue;
+
+        const pto::FusionWriteInstanceLiveness *writeInstance =
+            getProducedWriteInstance(blockAnalysis, member.op, tileOutputIndex);
+        ++tileOutputIndex;
+
+        bool escapesSpan =
+            hasReplaceableUseOutsideSpan(init, spanOps, boundary);
+        if (writeInstance)
+          escapesSpan =
+              escapesSpan && writeInstanceEscapesSpan(*writeInstance, spanNodeIds);
+
+        if (escapesSpan)
+          appendUniqueValue(iface.externallyVisibleValues, seenOutputs, init);
+      }
+    }
+  }
+
+  DenseSet<Value> visibleValues(iface.externallyVisibleValues.begin(),
+                                iface.externallyVisibleValues.end());
+  DenseSet<Operation *> seenLocalDefs;
+  for (const GroupSpanMember &member : span.members) {
+    if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(member.op)) {
+      for (Value init : dpsIface.getDpsInits()) {
+        if (!isa<pto::TileBufType>(init.getType()))
+          continue;
+        if (!canSinkAllocTileDefToRegion(init, span, spanOps))
+          continue;
+        if (hasAnyUseOutsideSpan(init, spanOps) && !visibleValues.contains(init))
+          continue;
+        Operation *defOp = init.getDefiningOp();
+        if (seenLocalDefs.insert(defOp).second)
+          iface.localDefs.push_back(defOp);
+      }
+    }
+  }
+
+  return iface;
+}
+
+static void replaceEscapingUsesOutsideRegion(pto::FusionRegionOp fusionRegion,
+                                             ArrayRef<Value> oldValues) {
+  for (auto [oldValueRef, newValue] :
+       llvm::zip(oldValues, fusionRegion.getOutputs())) {
+    Value oldValue = oldValueRef;
+    oldValue.replaceUsesWithIf(newValue, [&](OpOperand &use) {
+      return !isNestedInOp(use.getOwner(), fusionRegion.getOperation()) &&
+             canReplaceUseWithRegionResult(use, fusionRegion.getOperation());
+    });
+  }
+}
+
+static void clearSpanFusionMetadata(const GroupSpan &span) {
+  for (const GroupSpanMember &member : span.members) {
+    member.op->removeAttr(kFusionGroupIdAttr);
+    member.op->removeAttr(kFusionOrderAttr);
+  }
+}
+
+static LogicalResult
+encapsulateGroupSpan(const GroupSpan &span,
+                     const PreFusionAnalysisIndex *analysisIndex) {
+  if (span.members.empty())
+    return success();
+
+  GroupSpanInterface iface = buildGroupSpanInterface(span, analysisIndex);
+
+  SmallVector<Type, 8> outputTypes;
+  outputTypes.reserve(iface.externallyVisibleValues.size());
+  for (Value output : iface.externallyVisibleValues)
+    outputTypes.push_back(output.getType());
+
+  Operation *firstOp = span.members.front().op;
+  Location loc = firstOp->getLoc();
+  OpBuilder builder(firstOp);
+  auto fusionRegion =
+      builder.create<pto::FusionRegionOp>(loc, TypeRange(outputTypes));
+  fusionRegion->setAttr(kFusionGroupIdAttr,
+                        builder.getI64IntegerAttr(span.groupId));
+
+  Block *body = new Block();
+  fusionRegion.getBody().push_back(body);
+
+  for (Operation *localDef : iface.localDefs)
+    localDef->moveBefore(body, body->end());
+  for (const GroupSpanMember &member : span.members)
+    member.op->moveBefore(body, body->end());
+
+  clearSpanFusionMetadata(span);
+
+  SmallVector<Value, 8> yieldValues;
+  yieldValues.reserve(iface.externallyVisibleValues.size());
+  for (Value output : iface.externallyVisibleValues)
+    yieldValues.push_back(output);
+
+  OpBuilder bodyBuilder = OpBuilder::atBlockEnd(body);
+  bodyBuilder.create<pto::YieldOp>(loc, ValueRange(yieldValues));
+
+  if (failed(verify(fusionRegion.getOperation())))
+    return failure();
+
+  replaceEscapingUsesOutsideRegion(fusionRegion, iface.externallyVisibleValues);
+  return success();
+}
+
+static LogicalResult processRegion(Region &region,
+                                   const PreFusionAnalysisIndex *analysisIndex) {
+  for (Block &block : region.getBlocks()) {
+    SmallVector<Region *, 4> nestedRegions;
+    for (Operation &op : block)
+      for (Region &nestedRegion : op.getRegions())
+        nestedRegions.push_back(&nestedRegion);
+
+    for (Region *nestedRegion : nestedRegions)
+      if (failed(processRegion(*nestedRegion, analysisIndex)))
+        return failure();
+
+    SmallVector<GroupSpan, 8> spans;
+    if (failed(collectGroupSpansInBlock(block, spans)))
+      return failure();
+
+    for (const GroupSpan &span : spans)
+      if (failed(encapsulateGroupSpan(span, analysisIndex)))
+        return failure();
+  }
+  return success();
+}
+
+struct PTOFusionRegionGenPass
+    : public pto::impl::PTOFusionRegionGenBase<PTOFusionRegionGenPass> {
+  using pto::impl::PTOFusionRegionGenBase<
+      PTOFusionRegionGenPass>::PTOFusionRegionGenBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    FailureOr<pto::PreFusionAnalysisResult> analysisOr =
+        pto::buildPreFusionAnalysis(func);
+    if (failed(analysisOr)) {
+      signalPassFailure();
+      return;
+    }
+
+    PreFusionAnalysisIndex analysisIndex;
+    for (const pto::FusionBlockAnalysis &blockAnalysis : analysisOr->blocks) {
+      FusionBlockAnalysisIndex &index = analysisIndex.blocks[blockAnalysis.block];
+      for (const pto::FusionComputeNode &node : blockAnalysis.computeNodes)
+        index.nodeIdByOp.try_emplace(node.op, node.id);
+      for (const pto::FusionWriteInstanceLiveness &writeInstance :
+           blockAnalysis.writeInstances) {
+        if (!writeInstance.producerNode)
+          continue;
+        index.writeInstancesByProducerNode[*writeInstance.producerNode]
+            .push_back(&writeInstance);
+      }
+    }
+
+    if (failed(processRegion(func.getRegion(), &analysisIndex)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOFusionRegionGenPass() {
+  return std::make_unique<PTOFusionRegionGenPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
@@ -1,0 +1,571 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <cstdlib>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOLOWLEVELLOOPFUSION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct LoopLevelInfo {
+  scf::ForOp loop;
+  SmallVector<Operation *, 4> preludeOps;
+};
+
+struct StageInfo {
+  SmallVector<Operation *, 4> setupOps;
+  SmallVector<LoopLevelInfo, 4> levels;
+  SmallVector<Operation *, 8> leafOps;
+
+  scf::ForOp getOuterLoop() const { return levels.front().loop; }
+  unsigned getDepth() const { return levels.size(); }
+};
+
+static bool areEquivalentValues(Value lhs, Value rhs);
+
+static Value mapValueOrSelf(Value value, IRMapping &mapping) {
+  return mapping.lookupOrDefault(value);
+}
+
+static bool sameForHeader(scf::ForOp lhs, scf::ForOp rhs) {
+  return areEquivalentValues(lhs.getLowerBound(), rhs.getLowerBound()) &&
+         areEquivalentValues(lhs.getUpperBound(), rhs.getUpperBound()) &&
+         areEquivalentValues(lhs.getStep(), rhs.getStep()) &&
+         lhs->getAttrs() == rhs->getAttrs();
+}
+
+static bool isPureNoRegionOp(Operation *op) {
+  return op->getNumRegions() == 0 && isMemoryEffectFree(op);
+}
+
+static bool isMovableMemoryPreludeOp(Operation *op) {
+  return op->getNumRegions() == 0 && isa<MemoryEffectOpInterface>(op);
+}
+
+static bool isSupportedPreludeOp(Operation *op) {
+  return isPureNoRegionOp(op) || isMovableMemoryPreludeOp(op);
+}
+
+static bool isSupportedLeafOp(Operation *op) { return op->getNumRegions() == 0; }
+
+static bool isInterstageSetupOp(Operation *op) {
+  if (isPureNoRegionOp(op))
+    return true;
+
+  // Tile-native buffers lower to backend memrefs through pto.pointer_cast
+  // between adjacent stage loops. Treat these address materializations as
+  // stage-boundary-transparent so loop-run collection can keep walking.
+  return isa<pto::PointerCastOp>(op);
+}
+
+static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
+  if (!lhs || !rhs)
+    return false;
+  if (lhs->getName() != rhs->getName())
+    return false;
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+    return false;
+  if (lhs->getNumResults() != rhs->getNumResults())
+    return false;
+  if (lhs->getNumOperands() != rhs->getNumOperands())
+    return false;
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+    return false;
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+    return false;
+
+  if (auto lhsDim = dyn_cast<memref::DimOp>(lhs)) {
+    auto rhsDim = cast<memref::DimOp>(rhs);
+    return lhsDim.getSource().getType() == rhsDim.getSource().getType() &&
+           areEquivalentValues(lhsDim.getIndex(), rhsDim.getIndex());
+  }
+
+  for (auto [lhsOperand, rhsOperand] :
+       llvm::zip(lhs->getOperands(), rhs->getOperands())) {
+    if (!areEquivalentValues(lhsOperand, rhsOperand))
+      return false;
+  }
+  return true;
+}
+
+static bool areEquivalentValues(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return true;
+  if (!lhs || !rhs)
+    return false;
+  if (lhs.getType() != rhs.getType())
+    return false;
+
+  auto lhsArg = dyn_cast<BlockArgument>(lhs);
+  auto rhsArg = dyn_cast<BlockArgument>(rhs);
+  if (lhsArg || rhsArg) {
+    return lhsArg && rhsArg && lhsArg.getOwner() == rhsArg.getOwner() &&
+           lhsArg.getArgNumber() == rhsArg.getArgNumber();
+  }
+
+  return areEquivalentOperations(lhs.getDefiningOp(), rhs.getDefiningOp());
+}
+
+static Value traceAliasRootOneStep(Value value) {
+  if (auto arg = dyn_cast<BlockArgument>(value)) {
+    auto *parentOp = arg.getOwner()->getParentOp();
+    if (auto forOp = dyn_cast_or_null<scf::ForOp>(parentOp)) {
+      if (arg.getArgNumber() > 0 &&
+          forOp.getInitArgs().size() >= arg.getArgNumber())
+        return forOp.getInitArgs()[arg.getArgNumber() - 1];
+    }
+  }
+
+  Operation *def = value.getDefiningOp();
+  if (!def)
+    return {};
+
+  if (auto subview = dyn_cast<memref::SubViewOp>(def))
+    return subview.getSource();
+  if (auto cast = dyn_cast<memref::CastOp>(def))
+    return cast.getSource();
+  if (auto cast = dyn_cast<memref::ReinterpretCastOp>(def))
+    return cast.getSource();
+  if (auto cast = dyn_cast<memref::MemorySpaceCastOp>(def))
+    return cast.getSource();
+  if (auto transpose = dyn_cast<memref::TransposeOp>(def))
+    return transpose.getIn();
+  if (auto bind = dyn_cast<pto::BindTileOp>(def))
+    return bind.getSource();
+  if (auto subview = dyn_cast<pto::SubViewOp>(def))
+    return subview.getSource();
+  if (auto bitcast = dyn_cast<pto::BitcastOp>(def))
+    return bitcast.getSrc();
+  if (auto reshape = dyn_cast<pto::TReshapeOp>(def))
+    return reshape.getSrc();
+  if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
+    if (cast.getInputs().empty())
+      return {};
+    if (auto result = dyn_cast<OpResult>(value)) {
+      unsigned resultNumber = result.getResultNumber();
+      if (resultNumber < cast.getInputs().size())
+        return cast.getInputs()[resultNumber];
+    }
+    if (cast.getInputs().size() == 1)
+      return cast.getInputs().front();
+    return {};
+  }
+  if (auto forOp = dyn_cast<scf::ForOp>(def)) {
+    if (auto result = dyn_cast<OpResult>(value)) {
+      unsigned resultNumber = result.getResultNumber();
+      if (resultNumber < forOp.getInitArgs().size())
+        return forOp.getInitArgs()[resultNumber];
+    }
+  }
+
+  return {};
+}
+
+static Value traceAliasRoot(Value value) {
+  int loopBound = 256;
+  while (value) {
+    Value upward = traceAliasRootOneStep(value);
+    if (!upward)
+      break;
+    value = upward;
+    if (loopBound-- <= 0)
+      break;
+  }
+  return value;
+}
+
+static LogicalResult collectAliasRelevantRoots(
+    Operation *op, SmallVectorImpl<Value> &roots) {
+  if (isMemoryEffectFree(op))
+    return success();
+
+  auto effectsOp = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectsOp)
+    return failure();
+
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 4> effects;
+  effectsOp.getEffects(effects);
+  for (const auto &effect : effects) {
+    Value effectValue = effect.getValue();
+    if (!effectValue)
+      return failure();
+
+    Type effectType = effectValue.getType();
+    if (!isa<BaseMemRefType, pto::PtrType>(effectType)) {
+      if (isa<MemoryEffects::Write>(effect.getEffect()))
+        return failure();
+      continue;
+    }
+
+    Value root = traceAliasRoot(effectValue);
+    if (!root)
+      return failure();
+    roots.push_back(root);
+  }
+  return success();
+}
+
+static bool containsEquivalentRoot(ArrayRef<Value> roots, Value candidate) {
+  return llvm::any_of(roots, [&](Value root) {
+    return areEquivalentValues(root, candidate);
+  });
+}
+
+static bool canMovePreludeAcrossPriorStages(Operation *preludeOp,
+                                            ArrayRef<StageInfo> priorStages,
+                                            llvm::raw_ostream *debugOS) {
+  SmallVector<Value, 4> preludeRoots;
+  if (failed(collectAliasRelevantRoots(preludeOp, preludeRoots))) {
+    if (debugOS)
+      *debugOS << "[op-fusion] reject prelude op " << preludeOp->getName()
+               << " at " << preludeOp->getLoc()
+               << ": touched roots are not alias-analyzable\n";
+    return false;
+  }
+  for (const StageInfo &priorStage : priorStages) {
+    for (Operation *leafOp : priorStage.leafOps) {
+      SmallVector<Value, 4> leafRoots;
+      if (failed(collectAliasRelevantRoots(leafOp, leafRoots))) {
+        if (debugOS)
+          *debugOS << "[op-fusion] reject prelude op " << preludeOp->getName()
+                   << " at " << preludeOp->getLoc()
+                   << ": crossed effects of " << leafOp->getName()
+                   << " are not alias-analyzable\n";
+        return false;
+      }
+      for (Value preludeRoot : preludeRoots) {
+        if (containsEquivalentRoot(leafRoots, preludeRoot)) {
+          if (debugOS)
+            *debugOS << "[op-fusion] reject prelude op "
+                     << preludeOp->getName() << " at " << preludeOp->getLoc()
+                     << ": touched root may alias a prior stage memory op\n";
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+static bool arePreludeReordersLegal(ArrayRef<StageInfo> stages,
+                                    llvm::raw_ostream *debugOS) {
+  for (size_t stageIndex = 1; stageIndex < stages.size(); ++stageIndex) {
+    ArrayRef<StageInfo> priorStages(stages.data(), stageIndex);
+    for (const LoopLevelInfo &level : stages[stageIndex].levels) {
+      for (Operation *op : level.preludeOps) {
+        if (!canMovePreludeAcrossPriorStages(op, priorStages, debugOS))
+          return false;
+      }
+    }
+  }
+  return true;
+}
+
+static LogicalResult analyzeStage(scf::ForOp outerLoop, StageInfo &stage) {
+  scf::ForOp currentLoop = outerLoop;
+  while (currentLoop) {
+    stage.levels.push_back(LoopLevelInfo{currentLoop, {}});
+    LoopLevelInfo &currentLevel = stage.levels.back();
+
+    SmallVector<Operation *, 8> bodyOps;
+    scf::ForOp childLoop;
+    for (Operation &op : currentLoop.getBody()->without_terminator()) {
+      bodyOps.push_back(&op);
+      if (auto nestedLoop = dyn_cast<scf::ForOp>(op)) {
+        if (childLoop)
+          return failure();
+        childLoop = nestedLoop;
+      }
+    }
+
+    if (!childLoop) {
+      for (Operation *op : bodyOps) {
+        if (!isSupportedLeafOp(op))
+          return failure();
+        stage.leafOps.push_back(op);
+      }
+      return failure(stage.leafOps.empty());
+    }
+
+    bool seenChildLoop = false;
+    for (Operation *op : bodyOps) {
+      if (op == childLoop.getOperation()) {
+        seenChildLoop = true;
+        continue;
+      }
+      if (seenChildLoop || !isSupportedPreludeOp(op))
+        return failure();
+      currentLevel.preludeOps.push_back(op);
+    }
+
+    currentLoop = childLoop;
+  }
+
+  return failure();
+}
+
+static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
+                                                     llvm::raw_ostream *debugOS) {
+  SmallVector<StageInfo, 8> stages;
+
+  StageInfo firstStage;
+  if (failed(analyzeStage(firstLoop, firstStage))) {
+    if (debugOS)
+      *debugOS << "[op-fusion] reject loop stage at " << firstLoop.getLoc()
+               << ": stage analysis failed\n";
+    return stages;
+  }
+  stages.push_back(std::move(firstStage));
+
+  SmallVector<Operation *, 4> pendingSetup;
+  for (Operation *op = firstLoop->getNextNode(); op; op = op->getNextNode()) {
+    if (auto nextLoop = dyn_cast<scf::ForOp>(op)) {
+      StageInfo nextStage;
+      nextStage.setupOps = pendingSetup;
+      pendingSetup.clear();
+      if (failed(analyzeStage(nextLoop, nextStage))) {
+        if (debugOS)
+          *debugOS << "[op-fusion] stop stage run before " << nextLoop.getLoc()
+                   << ": next stage analysis failed\n";
+        break;
+      }
+      stages.push_back(std::move(nextStage));
+      continue;
+    }
+
+    if (!isInterstageSetupOp(op)) {
+      if (debugOS)
+        *debugOS << "[op-fusion] stop stage run at op " << op->getName()
+                 << "\n";
+      break;
+    }
+    pendingSetup.push_back(op);
+  }
+
+  return stages;
+}
+
+static bool sameLoopNestShape(const StageInfo &lhs, const StageInfo &rhs) {
+  if (lhs.getDepth() != rhs.getDepth())
+    return false;
+  return llvm::all_of(llvm::zip(lhs.levels, rhs.levels), [](auto pair) {
+    return sameForHeader(std::get<0>(pair).loop, std::get<1>(pair).loop);
+  });
+}
+
+static void cloneOpAndMapResults(OpBuilder &builder, Operation *op,
+                                 IRMapping &mapping) {
+  Operation *cloned = builder.clone(*op, mapping);
+  for (auto [oldRes, newRes] :
+       llvm::zip(op->getResults(), cloned->getResults()))
+    mapping.map(oldRes, newRes);
+}
+
+static void appendMappedValues(ValueRange values, IRMapping &mapping,
+                               SmallVectorImpl<Value> &mappedValues) {
+  for (Value value : values)
+    mappedValues.push_back(mapValueOrSelf(value, mapping));
+}
+
+static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
+                                            MutableArrayRef<StageInfo> stages,
+                                            MutableArrayRef<IRMapping> mappings,
+                                            unsigned levelIndex) {
+  scf::ForOp firstLoop = stages.front().levels[levelIndex].loop;
+
+  SmallVector<Value, 8> fusedInitArgs;
+  for (auto [stageIndex, stage] : llvm::enumerate(stages))
+    appendMappedValues(ValueRange(stage.levels[levelIndex].loop.getInitArgs()),
+                       mappings[stageIndex], fusedInitArgs);
+
+  auto fusedLoop = builder.create<scf::ForOp>(
+      firstLoop.getLoc(),
+      mapValueOrSelf(firstLoop.getLowerBound(), mappings.front()),
+      mapValueOrSelf(firstLoop.getUpperBound(), mappings.front()),
+      mapValueOrSelf(firstLoop.getStep(), mappings.front()), fusedInitArgs);
+  fusedLoop->setAttrs(firstLoop->getAttrs());
+
+  unsigned iterArgOffset = 0;
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+    scf::ForOp originalLoop = stage.levels[levelIndex].loop;
+    mappings[stageIndex].map(originalLoop.getInductionVar(),
+                             fusedLoop.getInductionVar());
+    for (auto [argIndex, originalArg] :
+         llvm::enumerate(originalLoop.getRegionIterArgs()))
+      mappings[stageIndex].map(
+          originalArg, fusedLoop.getRegionIterArgs()[iterArgOffset + argIndex]);
+    iterArgOffset += originalLoop.getRegionIterArgs().size();
+  }
+
+  OpBuilder bodyBuilder = OpBuilder::atBlockBegin(fusedLoop.getBody());
+  for (auto [stageIndex, stage] : llvm::enumerate(stages))
+    for (Operation *op : stage.levels[levelIndex].preludeOps)
+      cloneOpAndMapResults(bodyBuilder, op, mappings[stageIndex]);
+
+  if (levelIndex + 1 < stages.front().getDepth()) {
+    (void)buildFusedLoopNestAtLevel(bodyBuilder, stages, mappings,
+                                    levelIndex + 1);
+  } else {
+    for (auto [stageIndex, stage] : llvm::enumerate(stages))
+      for (Operation *op : stage.leafOps)
+        cloneOpAndMapResults(bodyBuilder, op, mappings[stageIndex]);
+  }
+
+  SmallVector<Value, 8> fusedYieldOperands;
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+    auto originalYield = cast<scf::YieldOp>(
+        stage.levels[levelIndex].loop.getBody()->getTerminator());
+    appendMappedValues(ValueRange(originalYield.getOperands()),
+                       mappings[stageIndex], fusedYieldOperands);
+  }
+
+  if (auto fusedYield =
+          dyn_cast<scf::YieldOp>(fusedLoop.getBody()->getTerminator())) {
+    fusedYield->setOperands(fusedYieldOperands);
+  } else {
+    OpBuilder yieldBuilder = OpBuilder::atBlockEnd(fusedLoop.getBody());
+    yieldBuilder.create<scf::YieldOp>(firstLoop.getLoc(), fusedYieldOperands);
+  }
+
+  unsigned resultOffset = 0;
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+    scf::ForOp originalLoop = stage.levels[levelIndex].loop;
+    for (Value originalResult : originalLoop.getResults())
+      mappings[stageIndex].map(originalResult,
+                               fusedLoop.getResults()[resultOffset++]);
+  }
+
+  return fusedLoop;
+}
+
+static bool fuseStageRun(SmallVectorImpl<StageInfo> &stages,
+                         llvm::raw_ostream *debugOS) {
+  if (stages.size() < 2) {
+    if (debugOS)
+      *debugOS << "[op-fusion] reject loop run: need at least 2 stages, got "
+               << stages.size() << "\n";
+    return false;
+  }
+
+  StageInfo &first = stages.front();
+  for (StageInfo &stage : llvm::drop_begin(stages)) {
+    if (!sameLoopNestShape(first, stage)) {
+      if (debugOS)
+        *debugOS << "[op-fusion] reject loop run: loop nest shape mismatch\n";
+      return false;
+    }
+  }
+  if (!arePreludeReordersLegal(stages, debugOS))
+    return false;
+
+  OpBuilder blockBuilder(first.getOuterLoop());
+  SmallVector<IRMapping, 8> stageMappings(stages.size());
+  auto fusedOuterLoop =
+      buildFusedLoopNestAtLevel(blockBuilder, stages, stageMappings, 0);
+
+  for (StageInfo &stage : llvm::drop_begin(stages))
+    for (Operation *setupOp : stage.setupOps)
+      setupOp->moveBefore(fusedOuterLoop);
+
+  for (StageInfo &stage : llvm::reverse(stages))
+    stage.getOuterLoop().erase();
+
+  return true;
+}
+
+static bool fuseStageRunsInBlock(Block &block, llvm::raw_ostream *debugOS) {
+  bool changed = false;
+  bool localChange = true;
+
+  while (localChange) {
+    localChange = false;
+    for (Operation &op : block) {
+      auto firstLoop = dyn_cast<scf::ForOp>(op);
+      if (!firstLoop)
+        continue;
+
+      SmallVector<StageInfo, 8> stages =
+          collectStageRunFrom(firstLoop, debugOS);
+      if (!fuseStageRun(stages, debugOS))
+        continue;
+
+      changed = true;
+      localChange = true;
+      break;
+    }
+  }
+
+  return changed;
+}
+
+struct PTOLowLevelLoopFusionPass
+    : public pto::impl::PTOLowLevelLoopFusionBase<
+          PTOLowLevelLoopFusionPass> {
+  using pto::impl::PTOLowLevelLoopFusionBase<
+      PTOLowLevelLoopFusionPass>::PTOLowLevelLoopFusionBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    const bool traceEnabled =
+        debug || (std::getenv("PTO_LL_LOOP_FUSION_TRACE") != nullptr);
+    llvm::raw_ostream *traceOS = traceEnabled ? &llvm::errs() : nullptr;
+
+    int fusedFuncs = 0;
+    for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+      if (func.isExternal())
+        continue;
+      if (func.getSymName().starts_with("__pto_oplib_"))
+        continue;
+      if (func.empty())
+        continue;
+
+      bool changed = false;
+      func.walk([&](pto::FusionRegionOp fusionRegion) {
+        changed |= fuseStageRunsInBlock(fusionRegion.getBody().front(), traceOS);
+      });
+      if (changed)
+        ++fusedFuncs;
+    }
+
+    if (traceEnabled) {
+      llvm::errs() << "[op-fusion] low-level loop fusion changed " << fusedFuncs
+                   << " function(s)\n";
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOLowLevelLoopFusionPass(
+    const PTOLowLevelLoopFusionOptions &options) {
+  return std::make_unique<PTOLowLevelLoopFusionPass>(options);
+}

--- a/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_OPSCHEDULING
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static constexpr llvm::StringLiteral kFusionGroupIdAttr =
+    "pto.fusion.group_id";
+static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+
+enum class SchedulingBarrierKind {
+  Movable,
+  LocalBoundary,
+  HardBoundary,
+};
+
+struct GroupMember {
+  Operation *op = nullptr;
+  int64_t order = 0;
+  unsigned originalIndex = 0;
+};
+
+struct ScheduledGroup {
+  int64_t groupId = 0;
+  unsigned firstOriginalIndex = 0;
+  SmallVector<GroupMember, 8> members;
+};
+
+static std::optional<int64_t> getRequiredI64Attr(Operation *op,
+                                                 StringRef attrName) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName))
+    return attr.getInt();
+  return std::nullopt;
+}
+
+static bool hasIncompleteFusionMetadata(Operation *op) {
+  const bool hasGroupId = op->hasAttr(kFusionGroupIdAttr);
+  const bool hasOrder = op->hasAttr(kFusionOrderAttr);
+  return hasGroupId != hasOrder;
+}
+
+static bool sharesAnyValue(ArrayRef<Value> lhs, ArrayRef<Value> rhs) {
+  for (Value value : lhs)
+    if (llvm::is_contained(rhs, value))
+      return true;
+  return false;
+}
+
+static SchedulingBarrierKind classifySchedulingBarrier(Operation *op) {
+  FailureOr<pto::FusionOpSemantics> semanticsOr = pto::getFusionOpSemantics(op);
+  if (succeeded(semanticsOr)) {
+    switch (semanticsOr->kind) {
+    case pto::FusionOpKind::Compute:
+      return SchedulingBarrierKind::Movable;
+    case pto::FusionOpKind::LocalBoundary:
+      return SchedulingBarrierKind::LocalBoundary;
+    case pto::FusionOpKind::HardBoundary:
+      return SchedulingBarrierKind::HardBoundary;
+    }
+  } else {
+    return SchedulingBarrierKind::HardBoundary;
+  }
+
+  if (op->hasTrait<OpTrait::IsTerminator>() || !op->getRegions().empty())
+    return SchedulingBarrierKind::HardBoundary;
+  if (isa<CallOpInterface>(op))
+    return SchedulingBarrierKind::HardBoundary;
+  if (!isMemoryEffectFree(op))
+    return SchedulingBarrierKind::HardBoundary;
+  return SchedulingBarrierKind::Movable;
+}
+
+static bool hasDependencyOnLocalBoundary(Operation *movingOp,
+                                         Operation *boundaryOp) {
+  FailureOr<pto::FusionOpSemantics> movingSemanticsOr =
+      pto::getFusionOpSemantics(movingOp);
+  FailureOr<pto::FusionOpSemantics> boundarySemanticsOr =
+      pto::getFusionOpSemantics(boundaryOp);
+  if (failed(movingSemanticsOr) || failed(boundarySemanticsOr))
+    return true;
+
+  const pto::FusionOpSemantics &movingSemantics = *movingSemanticsOr;
+  const pto::FusionOpSemantics &boundarySemantics = *boundarySemanticsOr;
+
+  return sharesAnyValue(boundarySemantics.tileOutputs,
+                        movingSemantics.tileInputs) ||
+         sharesAnyValue(boundarySemantics.tileOutputs,
+                        movingSemantics.tileOutputs) ||
+         sharesAnyValue(movingSemantics.tileOutputs,
+                        boundarySemantics.tileInputs) ||
+         sharesAnyValue(movingSemantics.tileOutputs,
+                        boundarySemantics.tileOutputs);
+}
+
+static bool crossesOperandDefinition(Operation *movingOp, Operation *candidate) {
+  for (Value operand : movingOp->getOperands()) {
+    Operation *defOp = operand.getDefiningOp();
+    if (defOp == candidate)
+      return true;
+  }
+  return false;
+}
+
+static bool canMoveEarlierAcross(Operation *movingOp, Operation *candidate) {
+  if (crossesOperandDefinition(movingOp, candidate))
+    return false;
+
+  switch (classifySchedulingBarrier(candidate)) {
+  case SchedulingBarrierKind::Movable:
+    return true;
+  case SchedulingBarrierKind::LocalBoundary:
+    return !hasDependencyOnLocalBoundary(movingOp, candidate);
+  case SchedulingBarrierKind::HardBoundary:
+    return false;
+  }
+  return false;
+}
+
+static bool canMoveLaterAcross(Operation *movingOp, Operation *candidate) {
+  for (Value operand : candidate->getOperands()) {
+    Operation *defOp = operand.getDefiningOp();
+    if (defOp == movingOp)
+      return false;
+  }
+
+  FailureOr<pto::FusionOpSemantics> movingSemanticsOr =
+      pto::getFusionOpSemantics(movingOp);
+  FailureOr<pto::FusionOpSemantics> candidateSemanticsOr =
+      pto::getFusionOpSemantics(candidate);
+  if (succeeded(movingSemanticsOr) && succeeded(candidateSemanticsOr)) {
+    if (sharesAnyValue(movingSemanticsOr->tileOutputs,
+                       candidateSemanticsOr->tileInputs) ||
+        sharesAnyValue(movingSemanticsOr->tileOutputs,
+                       candidateSemanticsOr->tileOutputs))
+      return false;
+  }
+
+  switch (classifySchedulingBarrier(candidate)) {
+  case SchedulingBarrierKind::Movable:
+    return true;
+  case SchedulingBarrierKind::LocalBoundary:
+    return !hasDependencyOnLocalBoundary(movingOp, candidate);
+  case SchedulingBarrierKind::HardBoundary:
+    return false;
+  }
+  return false;
+}
+
+static bool canMoveAfter(Operation *movingOp, Operation *anchorOp) {
+  if (!movingOp || !anchorOp || movingOp == anchorOp)
+    return false;
+  if (movingOp->getBlock() != anchorOp->getBlock())
+    return false;
+
+  Operation *cursor = anchorOp->getNextNode();
+  while (cursor && cursor != movingOp) {
+    if (!canMoveEarlierAcross(movingOp, cursor))
+      return false;
+    cursor = cursor->getNextNode();
+  }
+  return cursor == movingOp;
+}
+
+static LogicalResult
+collectScheduledGroups(Block &block, SmallVectorImpl<ScheduledGroup> &groups) {
+  DenseMap<int64_t, unsigned> groupIndexById;
+
+  unsigned originalIndex = 0;
+  for (Operation &op : block) {
+    if (hasIncompleteFusionMetadata(&op)) {
+      op.emitError("expected pto.fusion.group_id and pto.fusion.order to "
+                   "either both exist or both be absent");
+      return failure();
+    }
+
+    std::optional<int64_t> groupId =
+        getRequiredI64Attr(&op, kFusionGroupIdAttr);
+    if (!groupId) {
+      ++originalIndex;
+      continue;
+    }
+
+    std::optional<int64_t> order = getRequiredI64Attr(&op, kFusionOrderAttr);
+    if (!order) {
+      op.emitError("missing required pto.fusion.order attribute");
+      return failure();
+    }
+
+    auto [it, inserted] = groupIndexById.try_emplace(*groupId, groups.size());
+    if (inserted) {
+      ScheduledGroup group;
+      group.groupId = *groupId;
+      group.firstOriginalIndex = originalIndex;
+      groups.push_back(std::move(group));
+    }
+
+    ScheduledGroup &group = groups[it->second];
+    group.members.push_back(GroupMember{&op, *order, originalIndex});
+    ++originalIndex;
+  }
+
+  llvm::sort(groups, [](const ScheduledGroup &lhs, const ScheduledGroup &rhs) {
+    if (lhs.firstOriginalIndex != rhs.firstOriginalIndex)
+      return lhs.firstOriginalIndex < rhs.firstOriginalIndex;
+    return lhs.groupId < rhs.groupId;
+  });
+
+  for (ScheduledGroup &group : groups) {
+    llvm::sort(group.members, [](const GroupMember &lhs, const GroupMember &rhs) {
+      if (lhs.order != rhs.order)
+        return lhs.order < rhs.order;
+      return lhs.originalIndex < rhs.originalIndex;
+    });
+
+    std::optional<int64_t> previousOrder;
+    for (const GroupMember &member : group.members) {
+      if (classifySchedulingBarrier(member.op) !=
+          SchedulingBarrierKind::Movable) {
+        member.op->emitError("fusion scheduling metadata must only annotate "
+                             "movable compute ops");
+        return failure();
+      }
+      if (previousOrder && *previousOrder == member.order) {
+        member.op->emitError("duplicate pto.fusion.order within one fusion "
+                             "group");
+        return failure();
+      }
+      previousOrder = member.order;
+    }
+  }
+
+  return success();
+}
+
+static void scheduleGroup(ScheduledGroup &group) {
+  if (group.members.size() < 2)
+    return;
+
+  Operation *placement = group.members.front().op;
+  for (GroupMember &member : llvm::drop_begin(group.members)) {
+    Operation *op = member.op;
+    while (op != placement && op != placement->getNextNode()) {
+      if (canMoveAfter(op, placement)) {
+        op->moveAfter(placement);
+        break;
+      }
+
+      Operation *blockingOp = placement->getNextNode();
+      if (!blockingOp || blockingOp == op ||
+          !canMoveLaterAcross(placement, blockingOp))
+        break;
+
+      placement->moveAfter(blockingOp);
+    }
+    placement = op;
+  }
+}
+
+static LogicalResult scheduleRegion(Region &region) {
+  for (Block &block : region.getBlocks()) {
+    SmallVector<ScheduledGroup, 8> groups;
+    if (failed(collectScheduledGroups(block, groups)))
+      return failure();
+    for (ScheduledGroup &group : groups)
+      scheduleGroup(group);
+
+    for (Operation &op : block)
+      for (Region &nestedRegion : op.getRegions())
+        if (failed(scheduleRegion(nestedRegion)))
+          return failure();
+  }
+  return success();
+}
+
+struct OpSchedulingPass
+    : public pto::impl::OpSchedulingBase<OpSchedulingPass> {
+  using pto::impl::OpSchedulingBase<OpSchedulingPass>::OpSchedulingBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    if (failed(scheduleRegion(func.getRegion())))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createOpSchedulingPass() {
+  return std::make_unique<OpSchedulingPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOPreFusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOPreFusionAnalysis.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+#include "PTO/Transforms/TileFusion/FusionAnalysis.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PREFUSIONANALYSIS
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct PreFusionAnalysisPass
+    : public pto::impl::PreFusionAnalysisBase<PreFusionAnalysisPass> {
+  using pto::impl::PreFusionAnalysisBase<
+      PreFusionAnalysisPass>::PreFusionAnalysisBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    const auto &analysis = getAnalysis<pto::PreFusionAnalysis>();
+    if (!analysis.isValid()) {
+      signalPassFailure();
+      return;
+    }
+
+    markAllAnalysesPreserved();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPreFusionAnalysisPass() {
+  return std::make_unique<PreFusionAnalysisPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/Passes.h"
+#include "PTO/Transforms/TileFusion/FusionAnalysis.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PRINTPREFUSIONANALYSIS
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static StringRef stringifyComputeFamily(pto::FusionComputeFamily family) {
+  switch (family) {
+  case pto::FusionComputeFamily::Elementwise:
+    return "elementwise";
+  case pto::FusionComputeFamily::ScalarExpand:
+    return "scalar_expand";
+  case pto::FusionComputeFamily::RowBroadcastBinary:
+    return "row_broadcast_binary";
+  case pto::FusionComputeFamily::ReduceRow:
+    return "reduce_row";
+  case pto::FusionComputeFamily::ReduceCol:
+    return "reduce_col";
+  case pto::FusionComputeFamily::Unknown:
+    return "unknown";
+  }
+  return "unknown";
+}
+
+static StringRef stringifyIterationProof(pto::IterationDomainProof proof) {
+  switch (proof) {
+  case pto::IterationDomainProof::Proven:
+    return "proven";
+  case pto::IterationDomainProof::Unproven:
+    return "unproven";
+  }
+  return "unproven";
+}
+
+static StringRef stringifyUnprovenReason(
+    pto::IterationDomainUnprovenReason reason) {
+  switch (reason) {
+  case pto::IterationDomainUnprovenReason::None:
+    return "none";
+  case pto::IterationDomainUnprovenReason::MissingTileDomain:
+    return "missing_tile_domain";
+  case pto::IterationDomainUnprovenReason::DynamicShape:
+    return "dynamic_shape";
+  case pto::IterationDomainUnprovenReason::InconsistentShape:
+    return "inconsistent_shape";
+  }
+  return "missing_tile_domain";
+}
+
+static StringRef stringifyWriteInstanceEscapeClass(
+    pto::FusionWriteInstanceEscapeClass escapeClass) {
+  switch (escapeClass) {
+  case pto::FusionWriteInstanceEscapeClass::Internal:
+    return "internal";
+  case pto::FusionWriteInstanceEscapeClass::LocalBoundaryExternal:
+    return "local_boundary_external";
+  case pto::FusionWriteInstanceEscapeClass::HardExternal:
+    return "hard_external";
+  }
+  return "internal";
+}
+
+static void appendIndexList(llvm::raw_ostream &os, ArrayRef<unsigned> values) {
+  os << "[";
+  for (auto [idx, value] : llvm::enumerate(values)) {
+    if (idx)
+      os << ", ";
+    os << value;
+  }
+  os << "]";
+}
+
+static void appendOptionalIndex(llvm::raw_ostream &os,
+                                std::optional<unsigned> value) {
+  if (!value) {
+    os << "<none>";
+    return;
+  }
+  os << *value;
+}
+
+static void appendDomain(llvm::raw_ostream &os,
+                         const pto::IterationDomainInfo &info) {
+  auto printDim = [&](int64_t dim) {
+    if (dim == ShapedType::kDynamic)
+      os << "?";
+    else
+      os << dim;
+  };
+
+  os << "(";
+  printDim(info.vRow);
+  os << "x";
+  printDim(info.vCol);
+  os << ")";
+}
+
+static std::string makeExternalValueLabel(unsigned ordinal) {
+  return (llvm::Twine("external#") + llvm::Twine(ordinal)).str();
+}
+
+static std::string makeBoundaryValueLabel(unsigned ordinal) {
+  return (llvm::Twine("boundary#") + llvm::Twine(ordinal)).str();
+}
+
+static DenseMap<Value, std::string>
+buildValueLabels(Block &block, const pto::FusionBlockAnalysis &analysis) {
+  DenseMap<Value, std::string> labels;
+  unsigned externalOrdinal = 0;
+  unsigned boundaryOrdinal = 0;
+
+  for (const pto::FusionComputeNode &node : analysis.computeNodes) {
+    for (auto [idx, output] : llvm::enumerate(node.semantics.tileOutputs))
+      labels.try_emplace(
+          output,
+          (llvm::Twine("node") + llvm::Twine(node.id) + ".out" +
+           llvm::Twine(idx))
+              .str());
+  }
+
+  for (Operation &op : block) {
+    FailureOr<pto::FusionOpSemantics> semanticsOr =
+        pto::getFusionOpSemantics(&op);
+    if (failed(semanticsOr))
+      continue;
+
+    if (semanticsOr->kind == pto::FusionOpKind::LocalBoundary) {
+      for (Value input : semanticsOr->tileInputs)
+        if (!labels.count(input))
+          labels.try_emplace(input, makeExternalValueLabel(externalOrdinal++));
+      for (Value output : semanticsOr->tileOutputs)
+        if (!labels.count(output))
+          labels.try_emplace(output, makeBoundaryValueLabel(boundaryOrdinal++));
+      continue;
+    }
+
+    for (Value input : semanticsOr->tileInputs)
+      if (!labels.count(input))
+        labels.try_emplace(input, makeExternalValueLabel(externalOrdinal++));
+  }
+
+  return labels;
+}
+
+static void printLocalBoundaries(llvm::raw_ostream &os, Block &block,
+                                 DenseMap<Value, std::string> &valueLabels) {
+  unsigned boundaryId = 0;
+  for (Operation &op : block) {
+    FailureOr<pto::FusionOpSemantics> semanticsOr =
+        pto::getFusionOpSemantics(&op);
+    if (failed(semanticsOr) ||
+        semanticsOr->kind != pto::FusionOpKind::LocalBoundary)
+      continue;
+
+    os << "    local_boundary[" << boundaryId++ << "] op="
+       << semanticsOr->opName << " inputs=[";
+    for (auto [idx, input] : llvm::enumerate(semanticsOr->tileInputs)) {
+      if (idx)
+        os << ", ";
+      os << valueLabels.lookup(input);
+    }
+    os << "] outputs=[";
+    for (auto [idx, output] : llvm::enumerate(semanticsOr->tileOutputs)) {
+      if (idx)
+        os << ", ";
+      os << valueLabels.lookup(output);
+    }
+    os << "]\n";
+  }
+}
+
+struct PrintPreFusionAnalysisPass
+    : public pto::impl::PrintPreFusionAnalysisBase<
+          PrintPreFusionAnalysisPass> {
+  using pto::impl::PrintPreFusionAnalysisBase<
+      PrintPreFusionAnalysisPass>::PrintPreFusionAnalysisBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+
+    const auto &analysis = getAnalysis<pto::PreFusionAnalysis>();
+    if (!analysis.isValid()) {
+      signalPassFailure();
+      return;
+    }
+
+    llvm::raw_ostream &os = llvm::outs();
+    os << "PreFusionAnalysis @" << func.getSymName() << "\n";
+
+    for (auto [blockIndex, blockAnalysis] :
+         llvm::enumerate(analysis.getResult().blocks)) {
+      os << "  block[" << blockIndex << "]\n";
+      DenseMap<Value, std::string> valueLabels =
+          buildValueLabels(*blockAnalysis.block, blockAnalysis);
+      printLocalBoundaries(os, *blockAnalysis.block, valueLabels);
+
+      for (const pto::IterationDomainClass &klass :
+           blockAnalysis.iterationDomainClasses) {
+        os << "    domain_class[" << klass.id << "] domain=";
+        appendDomain(os, klass.info);
+        os << " proof=" << stringifyIterationProof(klass.info.proof)
+           << " reason="
+           << stringifyUnprovenReason(klass.info.unprovenReason)
+           << " members=";
+        appendIndexList(os, klass.members);
+        os << "\n";
+      }
+
+      for (const pto::FusionComputeNode &node : blockAnalysis.computeNodes) {
+        os << "    compute[" << node.id << "] op=" << node.semantics.opName
+           << " family="
+           << stringifyComputeFamily(node.semantics.computeFamily)
+           << " domain_class=" << node.iterationDomainClass << " inputs=[";
+        for (auto [idx, input] : llvm::enumerate(node.semantics.tileInputs)) {
+          if (idx)
+            os << ", ";
+          os << valueLabels.lookup(input);
+        }
+        os << "] outputs=[";
+        for (auto [idx, output] : llvm::enumerate(node.semantics.tileOutputs)) {
+          if (idx)
+            os << ", ";
+          os << valueLabels.lookup(output);
+        }
+        os << "] incoming=";
+        appendIndexList(os, node.incomingEdges);
+        os << " outgoing=";
+        appendIndexList(os, node.outgoingEdges);
+        os << "\n";
+      }
+
+      for (auto [edgeIndex, edge] : llvm::enumerate(blockAnalysis.edges)) {
+        os << "    edge[" << edgeIndex << "] producer=" << edge.producerNode
+           << " consumer=" << edge.consumerNode
+           << " value=" << valueLabels.lookup(edge.value) << "\n";
+      }
+
+      for (const pto::FusionValueLiveness &live : blockAnalysis.liveness) {
+        os << "    liveness value=" << valueLabels.lookup(live.value)
+           << " producer=";
+        appendOptionalIndex(os, live.producerNode);
+        os << " consumers=";
+        appendIndexList(os, live.consumerNodes);
+        os << " write_instances=";
+        appendIndexList(os, live.writeInstances);
+        os << " last_local_consumer=";
+        appendOptionalIndex(os, live.lastLocalConsumer);
+        os << " external_users=" << (live.hasExternalUsers ? "true" : "false")
+           << " escapes_block=" << (live.escapesBlock ? "true" : "false")
+           << " boundary_users="
+           << (live.hasLocalBoundaryUsers ? "true" : "false")
+           << " hard_boundary_users="
+           << (live.hasLocalHardBoundaryUsers ? "true" : "false") << "\n";
+      }
+
+      for (const pto::FusionWriteInstanceLiveness &writeInstance :
+           blockAnalysis.writeInstances) {
+        os << "    write_instance[" << writeInstance.id
+           << "] value=" << valueLabels.lookup(writeInstance.value)
+           << " storage=" << valueLabels.lookup(writeInstance.storageValue)
+           << " producer=";
+        appendOptionalIndex(os, writeInstance.producerNode);
+        os << " consumers=";
+        appendIndexList(os, writeInstance.consumerNodes);
+        os << " last_local_consumer=";
+        appendOptionalIndex(os, writeInstance.lastLocalConsumer);
+        os << " escape_class="
+           << stringifyWriteInstanceEscapeClass(writeInstance.escapeClass)
+           << " external_users="
+           << (writeInstance.hasExternalUsers ? "true" : "false")
+           << " escapes_block="
+           << (writeInstance.escapesBlock ? "true" : "false")
+           << " boundary_users="
+           << (writeInstance.hasLocalBoundaryUsers ? "true" : "false")
+           << " hard_boundary_users="
+           << (writeInstance.hasLocalHardBoundaryUsers ? "true" : "false")
+           << "\n";
+      }
+    }
+
+    markAllAnalysesPreserved();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPrintPreFusionAnalysisPass() {
+  return std::make_unique<PrintPreFusionAnalysisPass>();
+}

--- a/test/lit/tile_fusion/fusion_plan_diamond.pto
+++ b/test/lit/tile_fusion/fusion_plan_diamond.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards FusionPlan annotation for a diamond-shaped tile DAG so all supported
+// block-local compute ops remain in one ordered fusion group.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_plan_diamond(
+      %arg0: !pto.tile_buf<vec, 32x32xf32>,
+      %arg1: !pto.tile_buf<vec, 32x32xf32>,
+      %arg2: !pto.tile_buf<vec, 32x32xf32>,
+      %arg3: !pto.tile_buf<vec, 32x32xf32>,
+      %arg4: !pto.tile_buf<vec, 32x32xf32>,
+      %arg5: !pto.tile_buf<vec, 32x32xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp3 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp4 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp5 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp6 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp7 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tmax ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tsub ins(%tmp0, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tsub ins(%tmp0, %arg3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp1 : !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp2 : !pto.tile_buf<vec, 32x32xf32>) outs(%tmp4 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%tmp3, %arg4 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp5 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%tmp4, %arg5 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp6 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp5, %tmp6 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp7 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @fusion_plan_diamond(
+// CHECK: pto.tmax{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.tsub{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: pto.tsub{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 3 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 4 : i64}
+// CHECK: pto.tmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 5 : i64}
+// CHECK: pto.tmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 6 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 7 : i64}

--- a/test/lit/tile_fusion/fusion_plan_dynamic_shape_negative.pto
+++ b/test/lit/tile_fusion/fusion_plan_dynamic_shape_negative.pto
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards FusionPlan's conservative dynamic-shape behavior: dynamic valid-shape
+// tile ops must not receive pto.fusion.* metadata.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_plan_dynamic_shape_negative(
+      %arg0: !pto.tile_buf<vec, 64x32xf32, valid=?x?>,
+      %vrow: index,
+      %vcol: index) {
+    %tmp0 = pto.alloc_tile valid_row = %vrow valid_col = %vcol : !pto.tile_buf<vec, 64x32xf32, valid=?x?>
+    %tmp1 = pto.alloc_tile valid_row = %vrow valid_col = %vcol : !pto.tile_buf<vec, 64x32xf32, valid=?x?>
+
+    pto.tadd ins(%arg0, %arg0 : !pto.tile_buf<vec, 64x32xf32, valid=?x?>, !pto.tile_buf<vec, 64x32xf32, valid=?x?>) outs(%tmp0 : !pto.tile_buf<vec, 64x32xf32, valid=?x?>)
+    pto.tmul ins(%tmp0, %arg0 : !pto.tile_buf<vec, 64x32xf32, valid=?x?>, !pto.tile_buf<vec, 64x32xf32, valid=?x?>) outs(%tmp1 : !pto.tile_buf<vec, 64x32xf32, valid=?x?>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @fusion_plan_dynamic_shape_negative(
+// CHECK: pto.tadd ins(%arg0, %arg0
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: pto.tmul ins(%0, %arg0
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: return

--- a/test/lit/tile_fusion/fusion_plan_interleaved_join.pto
+++ b/test/lit/tile_fusion/fusion_plan_interleaved_join.pto
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards FusionPlan group discovery when unrelated compute ops are interleaved
+// with an otherwise valid join-shaped fusion group.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_plan_interleaved_join(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @fusion_plan_interleaved_join(
+// CHECK: pto.trowexpandmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.tadd ins(%arg2, %arg3
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: pto.trowexpandmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: pto.tmul ins(%arg2, %arg3
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}

--- a/test/lit/tile_fusion/fusion_plan_join.pto
+++ b/test/lit/tile_fusion/fusion_plan_join.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards FusionPlan annotation for a join-shaped block-local tile DAG before
+// scheduling and region formation consume the metadata.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_plan_join(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @fusion_plan_join(
+// CHECK: pto.trowexpandmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.trowexpandmul{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}

--- a/test/lit/tile_fusion/fusion_plan_treshape_boundary.pto
+++ b/test/lit/tile_fusion/fusion_plan_treshape_boundary.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards FusionPlan boundaries around pto.treshape while allowing a later
+// unrelated same-domain chain to form a normal fusion group.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_plan_treshape_boundary(
+      %arg0: !pto.tile_buf<vec, 32x32xf32>,
+      %arg1: !pto.tile_buf<vec, 64x16xf32>,
+      %arg2: !pto.tile_buf<vec, 32x32xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 64x16xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp3 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%arg0, %arg0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    %view = pto.treshape %tmp0 : !pto.tile_buf<vec, 32x32xf32> -> !pto.tile_buf<vec, 64x16xf32>
+    pto.tmul ins(%view, %arg1 : !pto.tile_buf<vec, 64x16xf32>, !pto.tile_buf<vec, 64x16xf32>) outs(%tmp1 : !pto.tile_buf<vec, 64x16xf32>)
+    pto.tadd ins(%arg2, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%tmp2, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @fusion_plan_treshape_boundary(
+// CHECK: pto.tadd ins(%arg0, %arg0
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: %[[VIEW:.*]] = pto.treshape %0
+// CHECK: pto.tmul ins(%[[VIEW]], %arg1
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: pto.tadd ins(%arg2, %arg2
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.tmul ins(%2, %arg2
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: return

--- a/test/lit/tile_fusion/fusion_region_basic.pto
+++ b/test/lit/tile_fusion/fusion_region_basic.pto
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards PTOFusionRegionGen wrapping of one scheduled fusion span into one
+// pto.fusion_region whose escaping result becomes an explicit yield.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_region_basic(
+      %dst_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// CHECK-LABEL: func.func @fusion_region_basic(
+// CHECK: pto.fusion_region {
+// CHECK: pto.trowexpandmul
+// CHECK-NEXT: pto.trowexpandmul
+// CHECK-NEXT: pto.tadd
+// CHECK-NEXT: pto.yield(%{{.*}}) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// CHECK: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>
+// CHECK-NOT: pto.fusion_region
+// CHECK: pto.tadd ins(%{{.*}}, %{{.*}}
+// CHECK-NEXT: pto.tmul ins(%{{.*}}, %{{.*}}
+// CHECK: pto.tstore ins(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>)

--- a/test/lit/tile_fusion/fusion_region_interface.pto
+++ b/test/lit/tile_fusion/fusion_region_interface.pto
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region interface construction: escaping values become explicit
+// results while external inputs stay implicit captures.
+//
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s
+
+module {
+  func.func @fusion_region_interface(
+      %dst0_ptr: !pto.ptr<f32>,
+      %dst1_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst0_view = pto.make_tensor_view %dst0_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst0_part = pto.partition_view %dst0_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst1_view = pto.make_tensor_view %dst1_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst1_part = pto.partition_view %dst1_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %sum = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%sum : !pto.tile_buf<vec, 32x32xf32>)
+
+    pto.tstore ins(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst0_part : !pto.partition_tensor_view<32x32xf32>)
+    pto.tstore ins(%sum : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst1_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// CHECK-LABEL: func.func @fusion_region_interface(
+// CHECK: %[[REGION:.*]]:2 = pto.fusion_region {
+// CHECK: %[[TMP0:[0-9]+]] = pto.alloc_tile
+// CHECK: %[[TMP1:[0-9]+]] = pto.alloc_tile
+// CHECK: %[[SUM:[0-9]+]] = pto.alloc_tile
+// CHECK: pto.trowexpandmul ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%[[TMP0]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: pto.trowexpandmul ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%[[TMP1]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: pto.tadd ins(%[[TMP0]], %[[TMP1]] : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%[[SUM]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: pto.yield(%[[TMP0]], %[[SUM]]) : (!pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) -> ()
+// CHECK: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>
+// CHECK: pto.tstore ins(%[[REGION]]#0 : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: pto.tstore ins(%[[REGION]]#1 : !pto.tile_buf<vec, 32x32xf32>)

--- a/test/lit/tile_fusion/fusion_region_internal_dead_omission.pto
+++ b/test/lit/tile_fusion/fusion_region_internal_dead_omission.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region frontier analysis so overwritten region-local temporaries
+// are not added to pto.yield.
+//
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s
+
+module {
+  func.func @fusion_region_internal_dead_omission(
+      %dst_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %scratch: !pto.tile_buf<vec, 32x32xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %tmp = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %sum = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>)
+                       outs(%tmp : !pto.tile_buf<vec, 32x32xf32>)
+                       {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+    pto.tadd ins(%tmp, %full1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>)
+             outs(%sum : !pto.tile_buf<vec, 32x32xf32>)
+             {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>)
+             outs(%tmp : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%sum : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// CHECK-LABEL: func.func @fusion_region_internal_dead_omission(
+// CHECK: %[[REGION:[0-9]+]] = pto.fusion_region {
+// CHECK: %[[TMP:[0-9]+]] = pto.alloc_tile
+// CHECK: %[[SUM:[0-9]+]] = pto.alloc_tile
+// CHECK: pto.trowexpandmul ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%[[TMP]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: pto.tadd ins(%[[TMP]], %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%[[SUM]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK-NOT: pto.yield(%[[TMP]])
+// CHECK: pto.yield(%[[SUM]]) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// CHECK: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>
+// CHECK: pto.tstore ins(%[[REGION]] : !pto.tile_buf<vec, 32x32xf32>)

--- a/test/lit/tile_fusion/fusion_region_valid.pto
+++ b/test/lit/tile_fusion/fusion_region_valid.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards the canonical pto.fusion_region assembly form with one yielded result.
+//
+// RUN: ptoas --pto-level=level3 --emit-pto-ir %s | FileCheck %s
+
+module {
+  func.func @fusion_region_valid() {
+    %c0 = arith.constant 0 : index
+    %0 = pto.fusion_region {
+      pto.yield(%c0) : (index) -> ()
+    } : index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fusion_region_valid()
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[R:.*]] = pto.fusion_region {
+// CHECK:   pto.yield(%[[C0]]) : (index) -> ()
+// CHECK: } : index

--- a/test/lit/tile_fusion/fusion_region_verify_block_args.pto
+++ b/test/lit/tile_fusion/fusion_region_verify_block_args.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region verifier diagnostics for illegal explicit body block
+// arguments.
+//
+// RUN: not ptoas --pto-level=level3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_region_block_args_invalid() {
+    %0 = pto.fusion_region {
+    ^bb0(%arg0: index):
+      pto.yield(%arg0) : (index) -> ()
+    } : index
+    return
+  }
+}
+
+// CHECK: error: 'pto.fusion_region' op expects body block to have no arguments, got 1

--- a/test/lit/tile_fusion/fusion_region_verify_missing_yield.pto
+++ b/test/lit/tile_fusion/fusion_region_verify_missing_yield.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region verifier diagnostics when the body does not terminate
+// with pto.yield.
+//
+// RUN: not ptoas --pto-level=level3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_region_missing_yield_invalid() {
+    %0 = pto.fusion_region {
+      %c0 = arith.constant 0 : index
+    } : index
+    return
+  }
+}
+
+// CHECK: error: 'pto.fusion_region' op expects body to terminate with pto.yield

--- a/test/lit/tile_fusion/fusion_region_verify_yield_count_mismatch.pto
+++ b/test/lit/tile_fusion/fusion_region_verify_yield_count_mismatch.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region verifier diagnostics when yield operand count does not
+// match region result count.
+//
+// RUN: not ptoas --pto-level=level3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_region_yield_count_mismatch_invalid() {
+    %0 = pto.fusion_region {
+      pto.yield() : () -> ()
+    } : index
+    return
+  }
+}
+
+// CHECK: error: 'pto.fusion_region' op expects pto.yield to return 1 values, got 0

--- a/test/lit/tile_fusion/fusion_region_verify_yield_type_mismatch.pto
+++ b/test/lit/tile_fusion/fusion_region_verify_yield_type_mismatch.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards fusion_region verifier diagnostics when yielded value types do not
+// match region result types.
+//
+// RUN: not ptoas --pto-level=level3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @fusion_region_yield_type_mismatch_invalid() {
+    %c0 = arith.constant 0 : index
+    %0 = pto.fusion_region {
+      pto.yield(%c0) : (index) -> ()
+    } : i32
+    return
+  }
+}
+
+// CHECK: error: 'pto.fusion_region' op expects yielded value #0 to have type 'i32', got 'index'

--- a/test/lit/tile_fusion/op_fusion_adapter_placement_level2_tadd.pto
+++ b/test/lit/tile_fusion/op_fusion_adapter_placement_level2_tadd.pto
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards level2 fusion adapter placement around fusion formation, PlanMemory,
+// optional sync insertion, and the non-fused baseline when op fusion is off.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 %s --emit-pto-ir -o - | FileCheck %s --check-prefix=NOFUSE
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=FORM
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-view-to-memref -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=SEAM
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-insert-sync --emit-vpto %s --mlir-print-ir-after=pto-insert-sync -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=SYNC
+
+module {
+  func.func @fusion_adapter_placement_level2_tadd(%dst_ptr: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %a = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %b = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %c = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %d = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %out = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%a, %b : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%c, %d : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%out : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%out : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// NOFUSE-LABEL: func.func @fusion_adapter_placement_level2_tadd(
+// NOFUSE-NOT: pto.fusion_region
+// NOFUSE: pto.tadd ins(
+// NOFUSE-NEXT: pto.tadd ins(
+// NOFUSE-NEXT: pto.tadd ins(
+// NOFUSE: pto.tstore ins(
+// NOFUSE: return
+
+// FORM: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// FORM-LABEL: func.func @fusion_adapter_placement_level2_tadd(
+// FORM: pto.fusion_region {
+// FORM: pto.alloc_tile
+// FORM: pto.alloc_tile
+// FORM: pto.alloc_tile
+// FORM: pto.tadd ins(
+// FORM-NEXT: pto.tadd ins(
+// FORM-NEXT: pto.tadd ins(
+// FORM-NEXT: pto.yield(
+
+// SEAM-LABEL: func.func @fusion_adapter_placement_level2_tadd(
+// SEAM: pto.fusion_region {
+// SEAM: memref.alloc()
+// SEAM: pto.bind_tile
+// SEAM: memref.alloc()
+// SEAM: pto.bind_tile
+// SEAM: memref.alloc()
+// SEAM: pto.bind_tile
+// SEAM: pto.tadd ins(
+// SEAM-NEXT: pto.tadd ins(
+// SEAM-NEXT: pto.tadd ins(
+// SEAM-NEXT: pto.yield(
+// SEAM: } {pto.fusion.group_id = 0 : i64} : memref<32x32xf32
+// SEAM: pto.tstore ins(
+// SEAM: return
+
+// SYNC-LABEL: func.func @fusion_adapter_placement_level2_tadd(
+// SYNC: pto.fusion_region {
+// SYNC: pto.yield(
+// SYNC: } {pto.fusion.group_id = 0 : i64} : memref<32x32xf32
+// SYNC: pto.tstore ins(
+// SYNC: pto.barrier <PIPE_ALL> {pto.auto_sync_tail_barrier}
+// SYNC: return

--- a/test/lit/tile_fusion/op_fusion_adapter_placement_level3_tadd.pto
+++ b/test/lit/tile_fusion/op_fusion_adapter_placement_level3_tadd.pto
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards level3 fusion adapter placement so manual-address tile IR is fused
+// before ExpandTileOp without re-running PlanMemory, and stays non-fused when
+// op fusion is disabled.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 %s --emit-pto-ir -o - | FileCheck %s --check-prefix=NOFUSE
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=SEAM
+
+module {
+  func.func @fusion_adapter_placement_level3_tadd(%dst_ptr: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %c20480_i64 = arith.constant 20480 : i64
+    %c24576_i64 = arith.constant 24576 : i64
+    %c28672_i64 = arith.constant 28672 : i64
+
+    %a = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %b = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %c = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %d = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp0 = pto.alloc_tile addr = %c16384_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile addr = %c20480_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %out = pto.alloc_tile addr = %c24576_i64 : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%a, %b : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%c, %d : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%out : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%out : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// NOFUSE-LABEL: func.func @fusion_adapter_placement_level3_tadd(
+// NOFUSE-NOT: pto.fusion_region
+// NOFUSE: pto.tadd ins(
+// NOFUSE-NEXT: pto.tadd ins(
+// NOFUSE-NEXT: pto.tadd ins(
+// NOFUSE: pto.tstore ins(
+// NOFUSE: return
+
+// SEAM: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// SEAM-LABEL: func.func @fusion_adapter_placement_level3_tadd(
+// SEAM: %[[A:.*]] = pto.alloc_tile addr = %c0_i64
+// SEAM: %[[B:.*]] = pto.alloc_tile addr = %c4096_i64
+// SEAM: %[[C:.*]] = pto.alloc_tile addr = %c8192_i64
+// SEAM: %[[D:.*]] = pto.alloc_tile addr = %c12288_i64
+// SEAM: pto.fusion_region {
+// SEAM-NOT: pto.pointer_cast
+// SEAM: %[[TMP0:.*]] = pto.alloc_tile addr = %c16384_i64
+// SEAM: %[[TMP1:.*]] = pto.alloc_tile addr = %c20480_i64
+// SEAM: %[[OUT:.*]] = pto.alloc_tile addr = %c24576_i64
+// SEAM: pto.tadd ins(%[[A]], %[[B]]
+// SEAM-NEXT: pto.tadd ins(%[[C]], %[[D]]
+// SEAM-NEXT: pto.tadd ins(%[[TMP0]], %[[TMP1]]
+// SEAM-NEXT: pto.yield(%[[OUT]]) : (!pto.tile_buf<vec, 32x32xf32>) -> ()

--- a/test/lit/tile_fusion/op_fusion_backend_lifecycle_level3.pto
+++ b/test/lit/tile_fusion/op_fusion_backend_lifecycle_level3.pto
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards the level3 backend fusion lifecycle through loop fusion, predicate
+// elision, load/store elision, and final region flattening.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-low-level-loop-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=LLF
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-predicate-elision -o /dev/null 2>&1 | FileCheck %s --check-prefix=PRED
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-load-store-elision -o /dev/null 2>&1 | FileCheck %s --check-prefix=LS
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-flatten-fusion-region -o /dev/null 2>&1 | FileCheck %s --check-prefix=FLAT
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @fusion_backend_lifecycle_level3(%dst_ptr: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c1024 = arith.constant 1024 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf32> -> !pto.partition_tensor_view<1x1x1x32x32xf32>
+
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %c20480_i64 = arith.constant 20480 : i64
+    %c24576_i64 = arith.constant 24576 : i64
+
+    %a = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %b = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %c = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %d = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp0 = pto.alloc_tile addr = %c16384_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile addr = %c20480_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %out = pto.alloc_tile addr = %c24576_i64 : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%a, %b : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%c, %d : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%out : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%out : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
+    return
+  }
+}
+
+// LLF: // -----// IR Dump After PTOLowLevelLoopFusion (pto-low-level-loop-fusion) //----- //
+// LLF-LABEL: func.func @fusion_backend_lifecycle_level3(
+// LLF: %[[REGION:.*]] = pto.fusion_region {
+// LLF: scf.for
+// LLF: scf.for {{.*}} -> (i32, i32, i32) {
+// LLF: pto.plt_b32
+// LLF: pto.vadd
+// LLF: pto.vsts
+// LLF: pto.plt_b32
+// LLF: pto.vadd
+// LLF: pto.vsts
+// LLF: pto.plt_b32
+// LLF: pto.vadd
+// LLF: pto.vsts
+// LLF: }
+// LLF: pto.yield(%{{.*}}) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// LLF: pto.copy_ubuf_to_gm
+
+// PRED: // -----// IR Dump After PTOFusionPredicateElision (pto-fusion-predicate-elision) //----- //
+// PRED-LABEL: func.func @fusion_backend_lifecycle_level3(
+// PRED: %[[REGION:.*]] = pto.fusion_region {
+// PRED: scf.for
+// PRED: pto.plt_b32
+// PRED: pto.vadd
+// PRED: pto.vsts
+// PRED: pto.vlds
+// PRED: pto.vlds
+// PRED: pto.vadd
+// PRED: pto.vsts
+// PRED: pto.vlds
+// PRED: pto.vlds
+// PRED: pto.vadd
+// PRED: pto.yield(%{{.*}}) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// PRED: pto.copy_ubuf_to_gm
+
+// LS: // -----// IR Dump After PTOFusionLoadStoreElision (pto-fusion-load-store-elision) //----- //
+// LS-LABEL: func.func @fusion_backend_lifecycle_level3(
+// LS: %[[REGION:.*]] = pto.fusion_region {
+// LS: pto.vadd
+// LS-NOT: pto.vsts
+// LS: pto.vlds
+// LS: pto.vlds
+// LS: pto.vadd
+// LS-NOT: pto.vsts
+// LS: pto.vadd
+// LS: pto.vsts
+// LS: pto.yield(%{{.*}}) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// LS: pto.copy_ubuf_to_gm
+
+// FLAT: // -----// IR Dump After PTOFlattenFusionRegion (pto-flatten-fusion-region) //----- //
+// FLAT-LABEL: func.func @fusion_backend_lifecycle_level3(
+// FLAT-NOT: pto.fusion_region
+// FLAT: scf.for %arg1 = %c0 to %c32 step %c1 {
+// FLAT: pto.vlds
+// FLAT: pto.vlds
+// FLAT: pto.vadd
+// FLAT-NOT: pto.vsts
+// FLAT: pto.vlds
+// FLAT: pto.vlds
+// FLAT: pto.vadd
+// FLAT-NOT: pto.vsts
+// FLAT: pto.vadd
+// FLAT: pto.vsts
+// FLAT: }
+// FLAT: pto.copy_ubuf_to_gm
+// FLAT: return

--- a/test/lit/tile_fusion/op_fusion_cli_flags.pto
+++ b/test/lit/tile_fusion/op_fusion_cli_flags.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards --enable-op-fusion CLI visibility and warnings when the selected
+// backend or architecture cannot run VPTO A5 tile fusion.
+//
+// RUN: ptoas --help-hidden 2>&1 | FileCheck %s --check-prefix=HELP
+// RUN: ptoas --pto-arch=a5 --enable-op-fusion %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EMITC
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a3 --enable-op-fusion --emit-vpto %s -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @fusion_cli_flags() {
+    return
+  }
+}
+
+// HELP: --enable-op-fusion
+
+// EMITC: Warning: --enable-op-fusion is ignored because --pto-backend=vpto is required.
+
+// A3: Warning: --enable-op-fusion is ignored because --pto-arch=a5 is required.

--- a/test/lit/tile_fusion/op_fusion_frontend_stages_level2.pto
+++ b/test/lit/tile_fusion/op_fusion_frontend_stages_level2.pto
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards the level2 frontend fusion sequence: planning, scheduling, and
+// fusion_region generation before later level2 adapter passes.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan --mlir-print-ir-after=pto-op-scheduling --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN --check-prefix=SCHEDULE --check-prefix=REGION
+
+module {
+  func.func @fusion_frontend_stages_level2(
+      %dst_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>,
+      %row1: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// PLAN: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// PLAN-LABEL: func.func @fusion_frontend_stages_level2(
+// PLAN: pto.trowexpandmul ins(%arg1, %arg5
+// PLAN-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// PLAN: pto.tadd ins(%arg3, %arg4
+// PLAN-NOT: {pto.fusion.group_id
+// PLAN: pto.trowexpandmul ins(%arg2, %arg6
+// PLAN-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// PLAN: pto.tmul ins(%arg3, %arg4
+// PLAN-NOT: {pto.fusion.group_id
+// PLAN: pto.tadd ins(%2, %4
+// PLAN-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+
+// SCHEDULE: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// SCHEDULE-LABEL: func.func @fusion_frontend_stages_level2(
+// SCHEDULE: pto.trowexpandmul ins(%arg1, %arg5
+// SCHEDULE-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// SCHEDULE-NEXT: pto.trowexpandmul ins(%arg2, %arg6
+// SCHEDULE-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// SCHEDULE-NEXT: pto.tadd ins(%2, %4
+// SCHEDULE-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// SCHEDULE-NEXT: pto.tadd ins(%arg3, %arg4
+// SCHEDULE-NEXT: pto.tmul ins(%arg3, %arg4
+
+// REGION: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// REGION-LABEL: func.func @fusion_frontend_stages_level2(
+// REGION: pto.fusion_region {
+// REGION: %[[INNER0:.*]] = pto.alloc_tile
+// REGION: %[[INNER1:.*]] = pto.alloc_tile
+// REGION: %[[INNER2:.*]] = pto.alloc_tile
+// REGION: pto.trowexpandmul ins(%arg1, %arg5
+// REGION-NEXT: pto.trowexpandmul ins(%arg2, %arg6
+// REGION-NEXT: pto.tadd ins(%[[INNER0]], %[[INNER1]]
+// REGION-NEXT: pto.yield(%[[INNER2]]) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// REGION: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>
+// REGION-NEXT: pto.tadd ins(%arg3, %arg4
+// REGION-NEXT: pto.tmul ins(%arg3, %arg4
+// REGION: pto.tstore ins(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>)

--- a/test/lit/tile_fusion/op_fusion_region_pipeline_level2.pto
+++ b/test/lit/tile_fusion/op_fusion_region_pipeline_level2.pto
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards level2 fusion_region formation on tile-native IR and its later
+// preservation through the level2 pipeline, with and without insert-sync.
+//
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=FORM
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-view-to-memref -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=LEVEL2-PLAIN
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-insert-sync --emit-vpto %s --mlir-print-ir-after=pto-insert-sync -o /dev/null 2>&1 || true; } | FileCheck %s --check-prefix=LEVEL2-SYNC
+
+module {
+  func.func @fusion_region_pipeline_level2(
+      %dst_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>,
+      %row1: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// FORM: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// FORM-LABEL: func.func @fusion_region_pipeline_level2(
+// FORM: pto.fusion_region {
+// FORM: pto.alloc_tile
+// FORM: pto.alloc_tile
+// FORM: pto.trowexpandmul
+// FORM-NEXT: pto.trowexpandmul
+// FORM-NEXT: pto.tadd
+// FORM-NEXT: pto.yield(
+// FORM: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>
+// FORM: pto.tadd ins(%{{.*}}, %{{.*}}
+// FORM-NEXT: pto.tmul ins(%{{.*}}, %{{.*}}
+// FORM: pto.tstore ins(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>)
+//
+// LEVEL2-PLAIN-LABEL: func.func @fusion_region_pipeline_level2(
+// LEVEL2-PLAIN: pto.fusion_region {
+// LEVEL2-PLAIN: pto.trowexpandmul
+// LEVEL2-PLAIN-NEXT: pto.trowexpandmul
+// LEVEL2-PLAIN-NEXT: pto.tadd
+// LEVEL2-PLAIN-NEXT: pto.yield(
+// LEVEL2-PLAIN: } {pto.fusion.group_id = 0 : i64} : memref<32x32xf32
+// LEVEL2-PLAIN: pto.tadd ins(
+// LEVEL2-PLAIN-NEXT: pto.tmul ins(
+// LEVEL2-PLAIN: pto.tstore ins(
+// LEVEL2-PLAIN-NOT: pto.barrier
+// LEVEL2-PLAIN: return
+//
+// LEVEL2-SYNC-LABEL: func.func @fusion_region_pipeline_level2(
+// LEVEL2-SYNC: pto.fusion_region {
+// LEVEL2-SYNC: pto.trowexpandmul
+// LEVEL2-SYNC-NEXT: pto.trowexpandmul
+// LEVEL2-SYNC-NEXT: pto.tadd
+// LEVEL2-SYNC: pto.yield(
+// LEVEL2-SYNC: } {pto.fusion.group_id = 0 : i64} : memref<32x32xf32
+// LEVEL2-SYNC: pto.tadd ins(
+// LEVEL2-SYNC-NEXT: pto.tmul ins(
+// LEVEL2-SYNC: pto.tstore ins(
+// LEVEL2-SYNC: pto.barrier <PIPE_ALL> {pto.auto_sync_tail_barrier}
+// LEVEL2-SYNC: return

--- a/test/lit/tile_fusion/op_fusion_region_pipeline_level3.pto
+++ b/test/lit/tile_fusion/op_fusion_region_pipeline_level3.pto
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards level3 fusion_region formation before ExpandTileOp while preserving
+// manual alloc_tile addresses.
+//
+// RUN: { ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level3 --enable-op-fusion --emit-vpto %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 || true; } | FileCheck %s
+
+module {
+  func.func @fusion_region_pipeline_level3(
+      %dst_ptr: !pto.ptr<f32>,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>,
+      %row1: !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %c20480_i64 = arith.constant 20480 : i64
+    %c24576_i64 = arith.constant 24576 : i64
+
+    %tmp0 = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile addr = %c16384_i64 : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32, blayout=col_major>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tstore ins(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After PTOFusionRegionGen (pto-fusion-region-gen) //----- //
+// CHECK-LABEL: func.func @fusion_region_pipeline_level3(
+// CHECK: pto.alloc_tile addr = %c12288_i64
+// CHECK: pto.alloc_tile addr = %c16384_i64
+// CHECK: pto.fusion_region {
+// CHECK-NOT: pto.pointer_cast
+// CHECK: pto.alloc_tile addr = %c0_i64
+// CHECK: pto.alloc_tile addr = %c4096_i64
+// CHECK: pto.alloc_tile addr = %c8192_i64
+// CHECK: pto.trowexpandmul
+// CHECK-NEXT: pto.trowexpandmul
+// CHECK-NEXT: pto.tadd ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%[[OUT:[0-9]+]] : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK-NEXT: pto.yield(%[[OUT]]) : (!pto.tile_buf<vec, 32x32xf32>) -> ()
+// CHECK: } {pto.fusion.group_id = 0 : i64} : !pto.tile_buf<vec, 32x32xf32>
+// CHECK: pto.tadd ins(%{{.*}}, %{{.*}}
+// CHECK-NEXT: pto.tmul ins(%{{.*}}, %{{.*}}
+// CHECK: pto.tstore ins(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>)
+// CHECK: return

--- a/test/lit/tile_fusion/op_scheduling_basic.pto
+++ b/test/lit/tile_fusion/op_scheduling_basic.pto
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards OpScheduling compaction of one planned group into a contiguous span
+// while preserving fusion order.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-op-scheduling -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @op_scheduling_basic(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// CHECK-LABEL: func.func @op_scheduling_basic(
+// CHECK: pto.trowexpandmul{{.*}}outs(%[[DST0:[0-9]+]] :
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK-NEXT: pto.trowexpandmul{{.*}}outs(%[[DST1:[0-9]+]] :
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK-NEXT: pto.tadd ins(%[[DST0]], %[[DST1]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// CHECK-NEXT: pto.tadd ins(%arg2, %arg3
+// CHECK-NEXT: pto.tmul ins(%arg2, %arg3

--- a/test/lit/tile_fusion/op_scheduling_negative_call_boundary.pto
+++ b/test/lit/tile_fusion/op_scheduling_negative_call_boundary.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards OpScheduling against moving planned fusion members across an unrelated
+// function call boundary.
+//
+// RUN: not ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-op-scheduling -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func private @touch_boundary()
+
+  func.func @op_scheduling_negative_call_boundary(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%full0, %full1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    func.call @touch_boundary() : () -> ()
+    pto.tadd ins(%tmp0, %full2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// CHECK-LABEL: func.func @op_scheduling_negative_call_boundary(
+// CHECK: pto.tadd{{.*}}outs(%[[DST0:[0-9]+]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK-NEXT: call @touch_boundary()
+// CHECK-NEXT: pto.tadd ins(%[[DST0]], %arg2
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: error: expected one contiguous span per pto.fusion.group_id within a basic block

--- a/test/lit/tile_fusion/op_scheduling_negative_region.pto
+++ b/test/lit/tile_fusion/op_scheduling_negative_region.pto
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards OpScheduling against moving planned fusion members across an unrelated
+// region boundary.
+//
+// RUN: not ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-op-scheduling -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @op_scheduling_negative_region(
+      %cond: i1,
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    scf.if %cond {
+      pto.tadd ins(%full1, %full2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise : !pto.tile_buf<vec, 32x32xf32>)
+      scf.yield
+    } else {
+      scf.yield
+    }
+    pto.trowexpandmul ins(%tmp0, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// CHECK-LABEL: func.func @op_scheduling_negative_region(
+// CHECK: pto.trowexpandmul{{.*}}outs(%[[DST0:[0-9]+]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK-NEXT: scf.if %arg0 {
+// CHECK: pto.tadd ins(%arg2, %arg3
+// CHECK: pto.trowexpandmul ins(%[[DST0]], %arg5
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: error: expected one contiguous span per pto.fusion.group_id within a basic block

--- a/test/lit/tile_fusion/op_scheduling_negative_ssa.pto
+++ b/test/lit/tile_fusion/op_scheduling_negative_ssa.pto
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards OpScheduling against moving planned fusion members across an SSA
+// definition consumed by a later group member.
+//
+// RUN: not ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-op-scheduling -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func private @produce_row(
+      !pto.tile_buf<vec, 32x32xf32>)
+      -> !pto.tile_buf<vec, 32x1xf32>
+
+  func.func @op_scheduling_negative_ssa(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    %rowTmp = func.call @produce_row(%tmp0) : (!pto.tile_buf<vec, 32x32xf32>) -> !pto.tile_buf<vec, 32x1xf32>
+    pto.trowexpandmul ins(%tmp0, %rowTmp : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// CHECK-LABEL: func.func @op_scheduling_negative_ssa(
+// CHECK: pto.trowexpandmul{{.*}}outs(%[[DST0:[0-9]+]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK-NEXT: %[[ROW:[0-9]+]] = call @produce_row(%[[DST0]])
+// CHECK-NEXT: pto.trowexpandmul ins(%[[DST0]], %[[ROW]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: error: expected one contiguous span per pto.fusion.group_id within a basic block

--- a/test/lit/tile_fusion/op_scheduling_treshape.pto
+++ b/test/lit/tile_fusion/op_scheduling_treshape.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards OpScheduling compaction across an unrelated local treshape chain while
+// keeping that treshape chain outside the fused span.
+//
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-op-scheduling -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @op_scheduling_treshape(
+      %full0: !pto.tile_buf<vec, 32x32xf32>,
+      %full1: !pto.tile_buf<vec, 32x32xf32>,
+      %full2: !pto.tile_buf<vec, 32x32xf32>,
+      %full3: !pto.tile_buf<vec, 32x32xf32>,
+      %wide: !pto.tile_buf<vec, 64x16xf32>,
+      %row0: !pto.tile_buf<vec, 32x1xf32>,
+      %row1: !pto.tile_buf<vec, 32x1xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %noise1 = pto.alloc_tile : !pto.tile_buf<vec, 64x16xf32>
+
+    pto.trowexpandmul ins(%full0, %row0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%full2, %full3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%noise0 : !pto.tile_buf<vec, 32x32xf32>)
+    %view = pto.treshape %noise0 : !pto.tile_buf<vec, 32x32xf32> -> !pto.tile_buf<vec, 64x16xf32>
+    pto.trowexpandmul ins(%full1, %row1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x1xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %tmp1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tmul ins(%view, %wide : !pto.tile_buf<vec, 64x16xf32>, !pto.tile_buf<vec, 64x16xf32>) outs(%noise1 : !pto.tile_buf<vec, 64x16xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After OpScheduling (pto-op-scheduling) //----- //
+// CHECK-LABEL: func.func @op_scheduling_treshape(
+// CHECK: pto.trowexpandmul{{.*}}outs(%[[DST0:[0-9]+]] :
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK-NEXT: pto.trowexpandmul{{.*}}outs(%[[DST1:[0-9]+]] :
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK-NEXT: pto.tadd ins(%[[DST0]], %[[DST1]]
+// CHECK-SAME: {pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// CHECK-NEXT: pto.tadd ins(%arg2, %arg3
+// CHECK-NEXT: %[[RESHAPED:[0-9]+]] = pto.treshape
+// CHECK-NEXT: pto.tmul ins(%[[RESHAPED]], %arg4

--- a/test/lit/vpto/fold_tile_buf_intrinsics.pto
+++ b/test/lit/vpto/fold_tile_buf_intrinsics.pto
@@ -8,22 +8,36 @@
 
 // Unit test for FoldTileBufIntrinsics on the VPTO tile-op expansion path.
 //
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-fold-tile-buf-intrinsics %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-fold-tile-buf-intrinsics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=SHAPE
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=pto-fold-tile-buf-intrinsics %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ADDR
 //
-// After FoldTileBufIntrinsics:
-// - tile_buf_addr / tile_valid_rows / tile_valid_cols should be gone
-// - the expanded body should already use concrete memrefs/constants
-// CHECK-LABEL: func.func @TADD
-// CHECK-NOT: pto.tile_buf_addr
-// CHECK-NOT: pto.tile_valid_rows
-// CHECK-NOT: pto.tile_valid_cols
-// CHECK-NOT: pto.bind_tile
-// CHECK: pto.pointer_cast(
-// CHECK: arith.constant 16 : index
-// CHECK: arith.constant 64 : index
-// CHECK: pto.vlds
-// CHECK: pto.vadd
-// CHECK: pto.vsts
+// After the first shape-only FoldTileBufIntrinsics:
+// - tile_valid_rows / tile_valid_cols should be gone
+// - tile_buf_addr is intentionally preserved for the later addr-only fold
+// SHAPE-LABEL: func.func @TADD
+// SHAPE: pto.tile_buf_addr
+// SHAPE-NOT: pto.tile_valid_rows
+// SHAPE-NOT: pto.tile_valid_cols
+// SHAPE: arith.constant 16 : index
+// SHAPE: arith.constant 64 : index
+// SHAPE: pto.vlds
+// SHAPE: pto.vadd
+// SHAPE: pto.vsts
+
+// After the later addr-only FoldTileBufIntrinsics:
+// - tile_buf_addr should also be gone
+// - the expanded body should use concrete memrefs/constants
+// ADDR-LABEL: func.func @TADD
+// ADDR: pto.pointer_cast(
+// ADDR: pto.pointer_cast(
+// ADDR: pto.pointer_cast(
+// ADDR-NOT: pto.tile_buf_addr
+// ADDR-NOT: pto.tile_valid_rows
+// ADDR-NOT: pto.tile_valid_cols
+// ADDR-NOT: pto.bind_tile
+// ADDR: pto.vlds
+// ADDR: pto.vadd
+// ADDR: pto.vsts
 
 module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @TADD() {

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -278,6 +278,12 @@ static llvm::cl::opt<int> graphSyncSolverEventIdMax(
         "Lower values exercise the PIPE_ALL coloring fallback sooner."),
     llvm::cl::init(8));
 
+static llvm::cl::opt<bool> enableOpFusion(
+    "enable-op-fusion",
+    llvm::cl::desc("Enable tile fusion on the A5 VPTO path "
+                   "(ignored outside --pto-arch=a5 --pto-backend=vpto)"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableTileOpExpand(
     "enable-tile-op-expand",
     llvm::cl::desc(
@@ -1158,24 +1164,34 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addPass(pto::createPTOValidateVPTOEmissionIRPass());
 }
 
-static void lowerPTOToVPTOBackend(PassManager &pm, int argc, char **argv) {
-  // TileOp Expand path:
-  //   1. ExpandTileOp: instantiate TileLang DSL templates, replace tile ops
-  //      with func.call to template functions (tile_buf params)
-  //   2. InlineLibCall: inline template function bodies
-  //   3. FoldTileBufIntrinsics: fold tile_buf_addr / tile_valid_rows /
-  //      tile_valid_cols to concrete memref/constant values
+static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module, int argc,
+                                  char **argv) {
   auto &kernelModulePM = pm.nest<ModuleOp>();
+  auto moduleArchAttr =
+      module->getAttrOfType<mlir::StringAttr>("pto.target_arch");
+  const bool enableA5VPTOPostLoweringFusionLifecycle =
+      enableOpFusion && moduleArchAttr && moduleArchAttr.getValue() == "a5";
+
   pto::ExpandTileOpOptions expandOpts = resolveExpandTileOpOptions(argc, argv);
   kernelModulePM.addPass(pto::createExpandTileOpPass(expandOpts));
 
   kernelModulePM.addPass(pto::createPTOInlineLibCallPass());
   kernelModulePM.addNestedPass<mlir::func::FuncOp>(
-      pto::createFoldTileBufIntrinsicsPass());
-  // FoldTileBufIntrinsics materializes many constant branch conditions.
-  // Clean them up immediately on the TileOp expansion path before the
-  // authoring-stage VPTO verifier and let the existing CSE passes remove the
-  // resulting dead values later in the pipeline.
+      pto::createFoldTileBufIntrinsicsPass("shape-only"));
+  if (enableA5VPTOPostLoweringFusionLifecycle) {
+    kernelModulePM.addPass(pto::createPTOLowLevelLoopFusionPass());
+    kernelModulePM.addPass(mlir::createCanonicalizerPass());
+    kernelModulePM.addPass(mlir::createCSEPass());
+    kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOFusionPredicateElisionPass());
+    kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOFusionLoadStoreElisionPass());
+    kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOFlattenFusionRegionPass());
+    kernelModulePM.addPass(mlir::createCSEPass());
+  }
+  kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+      pto::createFoldTileBufIntrinsicsPass("addr-only"));
   kernelModulePM.addPass(mlir::createSCCPPass());
   kernelModulePM.addPass(mlir::createCanonicalizerPass());
 }
@@ -1240,7 +1256,7 @@ static LogicalResult runVPTOBackendPipeline(OwningOpRef<ModuleOp> &module,
   if (!hasTileOpsToExpand && hasTilelangHelpers)
     inlineTilelangHelpersOnVPTOInput(pm);
   if (hasTileOpsToExpand)
-    lowerPTOToVPTOBackend(pm, argc, argv);
+    lowerPTOToVPTOBackend(pm, module.get(), argc, argv);
   prepareVPTOForEmission(pm);
   if (failed(applyConfiguredPassManagerCLOptions(
           pm, "VPTO unified emission pipeline")))
@@ -1404,6 +1420,19 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (arch != "a5" && enableOpFusion) {
+    llvm::errs() << "Warning: --enable-op-fusion is ignored because "
+                    "--pto-arch=a5 is required.\n";
+  }
+
+  if (effectiveBackend == PTOBackend::EmitC && arch == "a5" && enableOpFusion) {
+    llvm::errs() << "Warning: --enable-op-fusion is ignored because "
+                    "--pto-backend=vpto is required.\n";
+  }
+
+  const bool enableA5VPTOFusionPath =
+      enableOpFusion && effectiveBackend == PTOBackend::VPTO && arch == "a5";
+
   bool invalidAutoSyncTailHint = false;
   module->walk([&](mlir::func::FuncOp func) {
     auto hintAttr =
@@ -1524,6 +1553,15 @@ int main(int argc, char **argv) {
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOA5NormalizeTMovPass());
+
+  // Keep tile fusion on tile-native PTO IR and run it before PlanMemory on
+  // the A5 VPTO fusion path.
+  if (enableA5VPTOFusionPath) {
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createFusionPlanPass());
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createOpSchedulingPass());
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOFusionRegionGenPass());
+  }
+
   pm.addPass(pto::createPTOViewToMemrefPass());
 
   if (effectiveLevel != PTOBuildLevel::Level3) {
@@ -1566,6 +1604,7 @@ int main(int argc, char **argv) {
   // backends consume the same post-planning seam IR.
   pm.addPass(pto::createPTOMaterializeTileHandlesPass());
   pm.addPass(createCSEPass());
+
   if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline")))
     return 1;
 

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -216,6 +216,8 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1099, "pto.comm.treduce", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x109A, "pto.tpartargmax", 0, 0x00, 0x00, 6, 0, 0, 0x00},
   {0x109B, "pto.tpartargmin", 0, 0x00, 0x00, 6, 0, 0, 0x00},
+  {0x109C, "pto.fusion_region", 0, 0x02, 0x00, 0, 0, 1, 0x00},
+  {0x109D, "pto.yield", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -422,6 +424,8 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.comm.treduce", 0x1099)
     .Case("pto.tpartargmax", 0x109A)
     .Case("pto.tpartargmin", 0x109B)
+    .Case("pto.fusion_region", 0x109C)
+    .Case("pto.yield", 0x109D)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -613,6 +617,8 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.comm.treduce", OpcodeAndVariant{0x1099, 0, 0})
     .Case("pto.tpartargmax", OpcodeAndVariant{0x109A, 0, 0})
     .Case("pto.tpartargmin", OpcodeAndVariant{0x109B, 0, 0})
+    .Case("pto.fusion_region", OpcodeAndVariant{0x109C, 0, 0})
+    .Case("pto.yield", OpcodeAndVariant{0x109D, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})


### PR DESCRIPTION
## Summary
- reintroduce VPTO tile fusion pipeline pieces on top of `feature-vpto-backend`
- add tile fusion analyses / passes / verifier coverage and lit regressions
- include the paged-attention fusion regression and the PTOViewToMemref fix for fusion-region yielded results

## Validation
- `llvm-lit -sv test/lit/tile_fusion/op_fusion_paged_attention_online_update.pto`
- `ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir test/lit/tile_fusion/op_fusion_paged_attention_online_update.pto -o /dev/null`

## Notes
- the copied paged-attention regression is currently kept as a fusion/container regression; full `emit-vpto` on that sample still hits downstream TileLang template coverage gaps unrelated to the fusion-region result fix.
