### PR TITLE
Support index-type operands in tile op template expansion.

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -180,8 +180,7 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
 // Helpers
 // ============================================================================
 static std::string getDtypeString(Type elemTy) {
-  // TODO: i32
-  if (elemTy.isIndex()) return "i64";
+  if (elemTy.isIndex()) return "i32";
   if (elemTy.isInteger(1)) return "i1";
   if (elemTy.isF32()) return "f32";
   if (elemTy.isF16()) return "f16";
@@ -209,8 +208,6 @@ static Value bridgeOperandToType(OpBuilder &builder, Location loc,
   if (srcTy == dstTy)
     return operand;
   if (srcTy.isIndex() && isa<IntegerType>(dstTy))
-    return builder.create<arith::IndexCastOp>(loc, dstTy, operand);
-  if (isa<IntegerType>(srcTy) && dstTy.isIndex())
     return builder.create<arith::IndexCastOp>(loc, dstTy, operand);
   return builder.create<UnrealizedConversionCastOp>(loc, dstTy, operand)
       .getResult(0);

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -180,6 +180,8 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
 // Helpers
 // ============================================================================
 static std::string getDtypeString(Type elemTy) {
+  // TODO: i32
+  if (elemTy.isIndex()) return "i64";
   if (elemTy.isInteger(1)) return "i1";
   if (elemTy.isF32()) return "f32";
   if (elemTy.isF16()) return "f16";
@@ -197,6 +199,21 @@ static std::string getDtypeString(Type elemTy) {
   if (elemTy.isSignlessInteger(16)) return "i16";
   if (elemTy.isSignlessInteger(8)) return "i8";
   return "";
+}
+
+// Cast `operand` to `dstTy`, preferring semantically precise ops over the
+// generic unrealized cast so later lowering passes don't get stuck.
+static Value bridgeOperandToType(OpBuilder &builder, Location loc,
+                                 Value operand, Type dstTy) {
+  Type srcTy = operand.getType();
+  if (srcTy == dstTy)
+    return operand;
+  if (srcTy.isIndex() && isa<IntegerType>(dstTy))
+    return builder.create<arith::IndexCastOp>(loc, dstTy, operand);
+  if (isa<IntegerType>(srcTy) && dstTy.isIndex())
+    return builder.create<arith::IndexCastOp>(loc, dstTy, operand);
+  return builder.create<UnrealizedConversionCastOp>(loc, dstTy, operand)
+      .getResult(0);
 }
 
 static StringRef getTileOpName(Operation *op) {
@@ -926,8 +943,8 @@ LogicalResult ExpandState::expandTileOpsInFunction(func::FuncOp func,
     for (unsigned i = 0; i < op->getNumOperands(); ++i) {
       Value operand = op->getOperand(i);
       if (i < fnArgTypes.size() && operand.getType() != fnArgTypes[i]) {
-        operand = builder.create<UnrealizedConversionCastOp>(
-            op->getLoc(), fnArgTypes[i], operand).getResult(0);
+        operand = bridgeOperandToType(builder, op->getLoc(), operand,
+                                      fnArgTypes[i]);
       }
       operands.push_back(operand);
     }

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from .types import (
+    AnyInt,
     AnyMask,
     AnyType,
     MaskType,
@@ -940,6 +941,24 @@ class _ConstraintParamView:
     @property
     def dtype(self) -> Any:
         return self._attrs.get("dtype")
+
+    @property
+    def element_type(self) -> Any:
+        return self.dtype
+
+    @property
+    def value(self) -> Any:
+        if self._attrs.get("kind") == "scalar":
+            return self._attrs.get("value")
+        return None
+
+    def __add__(self, other: Any) -> Any:
+        v = self.value
+        return None if v is None else v + other
+
+    def __radd__(self, other: Any) -> Any:
+        v = self.value
+        return None if v is None else other + v
 
     @property
     def memory_space(self) -> Any:
@@ -1881,11 +1900,13 @@ def _matches_wildcard(pattern: WildcardType, actual: ScalarType | MaskType) -> b
 
 
 def _matches_scalar_annotation(
-    annotation: ScalarType | MaskType | WildcardType | TypeVariable,
+    annotation: ScalarType | MaskType | WildcardType | TypeVariable | type[int],
     actual: ScalarType | MaskType,
 ) -> bool:
     if isinstance(annotation, (ScalarType, MaskType)):
         return annotation == actual
+    if annotation is int:
+        return isinstance(actual, ScalarType) and is_integer_dtype(actual)
     if isinstance(annotation, WildcardType):
         return _matches_wildcard(annotation, actual)
     if isinstance(annotation, TypeVariable):
@@ -1993,6 +2014,12 @@ def _validate_parameter_spec(param: inspect.Parameter) -> KernelParameterSpec:
             kind="mask",
             annotation=annotation,
         )
+    if annotation is int:
+        return KernelParameterSpec(
+            name=param.name,
+            kind="scalar",
+            annotation=annotation,
+        )
     if isinstance(annotation, (ScalarType, WildcardType, TypeVariable)):
         return KernelParameterSpec(
             name=param.name,
@@ -2026,6 +2053,9 @@ def _default_dtype_signature(
             continue
         if param_spec.kind == "mask":
             defaults.append(param_spec.annotation if isinstance(param_spec.annotation, MaskType) else AnyMask)
+            continue
+        if param_spec.annotation is int:
+            defaults.append(AnyInt)
             continue
         if isinstance(param_spec.annotation, (WildcardType, TypeVariable)):
             defaults.append(AnyType)

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from .types import (
-    AnyInt,
     AnyMask,
     AnyType,
     MaskType,
@@ -941,24 +940,6 @@ class _ConstraintParamView:
     @property
     def dtype(self) -> Any:
         return self._attrs.get("dtype")
-
-    @property
-    def element_type(self) -> Any:
-        return self.dtype
-
-    @property
-    def value(self) -> Any:
-        if self._attrs.get("kind") == "scalar":
-            return self._attrs.get("value")
-        return None
-
-    def __add__(self, other: Any) -> Any:
-        v = self.value
-        return None if v is None else v + other
-
-    def __radd__(self, other: Any) -> Any:
-        v = self.value
-        return None if v is None else other + v
 
     @property
     def memory_space(self) -> Any:
@@ -1900,13 +1881,11 @@ def _matches_wildcard(pattern: WildcardType, actual: ScalarType | MaskType) -> b
 
 
 def _matches_scalar_annotation(
-    annotation: ScalarType | MaskType | WildcardType | TypeVariable | type[int],
+    annotation: ScalarType | MaskType | WildcardType | TypeVariable,
     actual: ScalarType | MaskType,
 ) -> bool:
     if isinstance(annotation, (ScalarType, MaskType)):
         return annotation == actual
-    if annotation is int:
-        return isinstance(actual, ScalarType) and is_integer_dtype(actual)
     if isinstance(annotation, WildcardType):
         return _matches_wildcard(annotation, actual)
     if isinstance(annotation, TypeVariable):
@@ -2014,12 +1993,6 @@ def _validate_parameter_spec(param: inspect.Parameter) -> KernelParameterSpec:
             kind="mask",
             annotation=annotation,
         )
-    if annotation is int:
-        return KernelParameterSpec(
-            name=param.name,
-            kind="scalar",
-            annotation=annotation,
-        )
     if isinstance(annotation, (ScalarType, WildcardType, TypeVariable)):
         return KernelParameterSpec(
             name=param.name,
@@ -2053,9 +2026,6 @@ def _default_dtype_signature(
             continue
         if param_spec.kind == "mask":
             defaults.append(param_spec.annotation if isinstance(param_spec.annotation, MaskType) else AnyMask)
-            continue
-        if param_spec.annotation is int:
-            defaults.append(AnyInt)
             continue
         if isinstance(param_spec.annotation, (WildcardType, TypeVariable)):
             defaults.append(AnyType)


### PR DESCRIPTION
Fix issue #378 

Problem:

  ExpandTileOp 在为 tile op 构建 specialization key 时，遇到 index 类型的操作数会直接返回std::nullopt，导致报错 "cannot build specialization key for this operand schema"，整个模板展开流程提前失败。

  根本原因：

  - getDtypeString 没有处理 index 类型，无法为其生成 dtype 字符串，key 构建中断；调用点用 UnrealizedConversionCastOp 做类型桥接，对 index ↔ integer 的转换语义不明确，会给后续 lowering pass 留下悬空的 unrealized cast。

  ---
  Fix

  - getDtypeString 新增 index → "i64" 映射，使 index 类型参数能参与 specialization key 构建
  - 新增 bridgeOperandToType，对 index ↔ IntegerType 使用语义明确的 arith.index_cast，其余情况回退到 UnrealizedConversionCastOp，替换原调用点
