### PR TITLE
fix(vpto): support signless i8*i8->i32 mad lowering (https://github.com/mouliangyu/PTOAS/issues/381)

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -226,6 +226,11 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
+static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
+  return intType && intType.getWidth() == width &&
+         (intType.isSigned() || intType.isSignless());
+}
+
 static std::string getMadRhsFragment(Type type) {
   if (type.isF16())
     return "f16";
@@ -234,9 +239,9 @@ static std::string getMadRhsFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 4)
+    if (isSignedOrSignlessInteger(intType, 4))
       return "s4";
-    if (intType.isSigned() && intType.getWidth() == 8)
+    if (isSignedOrSignlessInteger(intType, 8))
       return "s8";
     if (intType.isUnsigned() && intType.getWidth() == 2)
       return "u2";
@@ -263,7 +268,7 @@ static std::string getMadDstFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 32)
+    if (isSignedOrSignlessInteger(intType, 32))
       return "s32";
   }
   return {};
@@ -284,6 +289,9 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.bf162f32.c310").getValue();
   if (lhsElem.isF32() && rhs == "f32" && dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
+  if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
+      rhs == "s8" && dst == "s32")
+    return StringAttr::get(context, "llvm.hivm.MAD.s82s32.c310").getValue();
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();


### PR DESCRIPTION
Fix issue: https://github.com/mouliangyu/PTOAS/issues/381

Problem:
  issue #381 的核心问题出在 VPTO LLVM lowering 的 MAD callee 分发上。tmatmul 展开后会生成 pto.mad_raw，其中 int8 case 的实际类型是 signless i8 * i8 -> i32，不是 si8 * si8 -> si32，可以在 test/tilelang_st/npu/a5/src/st/testcase/tmatmul/tmatmul.pto:106 对应的 matmul case 里看到。但 lib/PTO/Transforms/VPTOLLVMEmitter.cpp:235 原来的 MAD 类型分发只把 signed integer 当成 s4/s8/s32 处理：

  - getMadRhsFragment 只识别 signed i4/i8
  - getMadDstFragment 只识别 signed i32
  - buildMadTypedCalleeName 里也没有 s8*s8->s32 的 callee 分支

  结果是 i8/i8/i32 这组类型拿不到合法的 intrinsic 名称，pto.mad_raw 在 LowerVPTOOpsPass 中无法完成 lowering，最终以 illegal op 形式报错：failed to legalize operation 'pto.mad_raw' that was explicitly marked illegal

Fix:
  修复思路是把 PTO IR 中的 signless integer 语义和 MAD lowering 对齐。PTO IR 默认大量使用 signless integer，因此这里不应该只接受 si8/si32，而应该把 i8/si8 统一映射为 s8，把 i32/si32 统一映射为 s32。

  具体改动在 lib/PTO/Transforms/VPTOLLVMEmitter.cpp:229：

  - 新增 isSignedOrSignlessInteger(IntegerType, width) helper
  - getMadRhsFragment 对 i4/i8 和 si4/si8 统一返回 s4/s8
  - getMadDstFragment 对 i32 和 si32 统一返回 s32
  - 在 buildMadTypedCalleeName 中补充 s8*s8->s32 到 llvm.hivm.MAD.s82s32.c310 的分发