### PR TITLE
fix(dsl): expose static scalar values in constraints

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -115,6 +115,9 @@ struct OperandTypeInfo {
   // --- Vector-only (builtin VectorType) ---
   SmallVector<int64_t> vectorShape;
 
+  // --- Scalar-only ---
+  std::optional<int64_t> scalarValue;
+
   /// Equality for SpecKey caching — only compares fields relevant to each kind.
   bool operator==(const OperandTypeInfo &rhs) const {
     if (kind != rhs.kind || dtype != rhs.dtype)
@@ -127,7 +130,9 @@ struct OperandTypeInfo {
              fractal == rhs.fractal && pad == rhs.pad;
     if (kind == OperandKind::Vector)
       return vectorShape == rhs.vectorShape;
-    // View and Scalar: dtype alone is sufficient for template caching.
+    if (kind == OperandKind::Scalar)
+      return scalarValue == rhs.scalarValue;
+    // View: dtype alone is sufficient for template caching.
     return true;
   }
 };
@@ -147,8 +152,38 @@ struct SpecKey {
   }
 };
 
-// ============================================================================
-// Helpers
+struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
+  static inline SpecKey getEmptyKey() { return {"", "", {}}; }
+  static inline SpecKey getTombstoneKey() { return {"__tombstone__", "", {}}; }
+  static unsigned getHashValue(const SpecKey &key) {
+    unsigned h = llvm::hash_combine(key.opName, key.targetArch);
+    for (const auto &op : key.operands) {
+      h = llvm::hash_combine(h, static_cast<int>(op.kind), op.dtype);
+      if (op.kind == OperandKind::Tile) {
+        h = llvm::hash_combine(h, op.tileMemorySpace, op.blayout,
+                               op.slayout, op.fractal, op.pad);
+        for (int64_t d : op.tileShape)
+          h = llvm::hash_combine(h, d);
+        for (int64_t d : op.tileValidShape)
+          h = llvm::hash_combine(h, d);
+      } else if (op.kind == OperandKind::Vector) {
+        for (int64_t d : op.vectorShape)
+          h = llvm::hash_combine(h, d);
+      } else if (op.kind == OperandKind::Scalar) {
+        h = llvm::hash_combine(h, op.scalarValue.has_value());
+        if (op.scalarValue)
+          h = llvm::hash_combine(h, *op.scalarValue);
+      }
+      // View: only kind + dtype contribute to hash.
+    }
+    for (const auto &[attrName, attrValue] : key.contextAttrs)
+      h = llvm::hash_combine(h, attrName, attrValue);
+    return h;
+  }
+  static bool isEqual(const SpecKey &lhs, const SpecKey &rhs) {
+    return lhs == rhs;
+  }
+};
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -507,6 +542,9 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
   info.dtype = getDtypeString(ty);
   if (info.dtype.empty())
     return std::nullopt;
+  int64_t scalarValue = 0;
+  if (getStaticIntFromValue(value, scalarValue))
+    info.scalarValue = scalarValue;
   return info;
 }
 
@@ -640,7 +678,12 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
     }
 
     // Scalar
-    json += "{\"kind\":\"scalar\",\"dtype\":\"" + op.dtype + "\"}";
+    json += "{\"kind\":\"scalar\",\"dtype\":\"" + op.dtype + "\"";
+    if (op.scalarValue) {
+      json += ",\"value\":";
+      json += std::to_string(*op.scalarValue);
+    }
+    json += "}";
   }
   json += "]";
   return json;
@@ -1002,6 +1045,8 @@ func::FuncOp ExpandState::invokeTilelangDSL(const SpecKey &key,
     } else if (op.kind == OperandKind::Vector) {
       for (int64_t d : op.vectorShape)
         uniqueName += "_" + std::to_string(d);
+    } else if (op.kind == OperandKind::Scalar && op.scalarValue) {
+      uniqueName += "_sv" + std::to_string(*op.scalarValue);
     }
   }
   for (const auto &[attrName, attrValue] : key.contextAttrs)

--- a/tilelang-dsl/docs/user_guide/03-kernel-declaration.md
+++ b/tilelang-dsl/docs/user_guide/03-kernel-declaration.md
@@ -175,6 +175,7 @@ def large_batch_matmul(a: pto.Tile, b: pto.Tile, c: pto.Tile) -> None:
 Constraint callables bind by parameter name.
 
 - Kernel parameter names such as `src`, `dst`, `a`, `b` receive lightweight proxy objects, so constraints can use direct expressions like `src.shape[0] <= dst.shape[0]`.
+- Scalar kernel parameters receive a lightweight proxy as well; use `indexCol.value` to read a compile-time constant when the caller passed a static integer or index operand.
 - Extra `context_attrs` passed to `pto.select_kernel(...)` bind by key name, for example `batch`, `enabled`, or `expected_rows`.
 
 ##### Parameter Proxy Objects
@@ -183,6 +184,7 @@ When a constraint argument name matches a kernel parameter name, the callable re
 
 - For `TensorView` parameters, the proxy exposes `rank`, `shape`, `strides`, `dtype`, and `memory_space`.
 - For `Tile` parameters, the proxy exposes `rank`, `shape`, `valid_shape`, `dtype`, `memory_space`, and `config`.
+- For scalar parameters, the proxy exposes `dtype` and `value`. `value` is "unknown" when the operand is not a compile-time constant.
 - `shape`, `strides`, and `valid_shape` support index access such as `src.shape[0]` or `dst.valid_shape[1]`.
 - Missing or not-yet-known metadata evaluates as "unknown", so comparisons conservatively pass rather than failing early.
 

--- a/tilelang-dsl/python/tilelang_dsl/expand_helper.py
+++ b/tilelang-dsl/python/tilelang_dsl/expand_helper.py
@@ -205,7 +205,10 @@ def _parse_operand_specs(spec_text: str) -> list[dict]:
         if dtype is None:
             raise ValueError(f"operand-specs[{index}] has unsupported dtype {dtype_name!r}")
         if kind == "scalar":
-            specs.append({"kind": "scalar", "dtype": dtype})
+            scalar_spec = {"kind": "scalar", "dtype": dtype}
+            if "value" in raw:
+                scalar_spec["value"] = int(raw["value"])
+            specs.append(scalar_spec)
             continue
         if kind == "tile":
             shape = raw.get("shape")
@@ -340,6 +343,8 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, obje
         attrs[f"{prefix}_kind"] = operand_spec["kind"]
         attrs[f"{prefix}_dtype"] = operand_spec["dtype"]
         if operand_spec["kind"] == "scalar":
+            if "value" in operand_spec:
+                attrs[f"{prefix}_value"] = operand_spec["value"]
             continue
         shape = tuple(operand_spec["shape"])
         attrs[f"{prefix}_shape"] = shape

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -855,6 +855,12 @@ class _ConstraintValue:
     def __rfloordiv__(self, other: Any) -> "_ConstraintValue":
         return _ConstraintValue(self._coerce_other(other)).__floordiv__(self)
 
+    def __mod__(self, other: Any) -> "_ConstraintValue":
+        return self._arith(other, lambda lhs, rhs: lhs % rhs)
+
+    def __rmod__(self, other: Any) -> "_ConstraintValue":
+        return _ConstraintValue(self._coerce_other(other)).__mod__(self)
+
     def __eq__(self, other: Any) -> bool:  # type: ignore[override]
         return self._compare(other, lambda lhs, rhs: lhs == rhs)
 
@@ -940,6 +946,10 @@ class _ConstraintParamView:
     @property
     def dtype(self) -> Any:
         return self._attrs.get("dtype")
+
+    @property
+    def value(self) -> _ConstraintValue:
+        return _ConstraintValue(self._attrs.get("value"))
 
     @property
     def memory_space(self) -> Any:
@@ -1287,6 +1297,7 @@ class VKernelDescriptor:
             set_sequence_attr("valid_shape")
             set_sequence_attr("strides")
             set_scalar_attr("rank")
+            set_scalar_attr("value")
             set_scalar_attr("memory_space")
             set_scalar_attr("config")
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -872,6 +872,131 @@ def template(src: pto.Tile, ex_vec: pto.vector(pto.i16, (4,)), dst: pto.Tile):
         self.assertEqual(context_attrs["arg1_shape"], (4,))
         self.assertEqual(context_attrs["arg1_rank"], 1)
 
+    def test_select_descriptor_propagates_static_scalar_values_into_constraints(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="pto.expand_helper_scalar_value_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+    constraints=[lambda indexCol: indexCol.value % 8 == 0],
+    priority=10,
+)
+def template_aligned(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+
+@pto.vkernel(
+    target="a5",
+    op="pto.expand_helper_scalar_value_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+)
+def template_fallback(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "expand_helper_scalar_value_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+
+            mod = expand_helper._import_py_file(module_path)
+            self.assertIsNotNone(mod)
+            descriptors = expand_helper._find_descriptors(mod)
+            self.assertTrue(descriptors)
+
+            aligned_operand_specs = expand_helper._parse_operand_specs(
+                """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "scalar",
+    "dtype": "i32",
+    "value": 8
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  }
+]
+"""
+            )
+            unaligned_operand_specs = expand_helper._parse_operand_specs(
+                """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "scalar",
+    "dtype": "i32",
+    "value": 1
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  }
+]
+"""
+            )
+
+            aligned = expand_helper._select_descriptor(
+                descriptors,
+                target="a5",
+                op_name="pto.expand_helper_scalar_value_unique",
+                operand_specs=aligned_operand_specs,
+            )
+            unaligned = expand_helper._select_descriptor(
+                descriptors,
+                target="a5",
+                op_name="pto.expand_helper_scalar_value_unique",
+                operand_specs=unaligned_operand_specs,
+            )
+
+        self.assertEqual(aligned.name, "template_aligned")
+        self.assertEqual(unaligned.name, "template_fallback")
+        self.assertEqual(aligned_operand_specs[1]["value"], 8)
+        context_attrs = expand_helper._build_positional_context_attrs(aligned_operand_specs)
+        self.assertEqual(context_attrs["arg1_value"], 8)
+
 
 class TileLangDSLSupportMatrixTests(unittest.TestCase):
     def test_stable_starter_surface_groups_map_to_stable_tier(self) -> None:
@@ -1656,6 +1781,117 @@ class TileLangDSLMatcherEntryTests(unittest.TestCase):
         )
 
         self.assertEqual(selected.name, "template_nd")
+
+    def test_select_kernel_constraints_can_read_scalar_parameter_values(self) -> None:
+        @pto.vkernel(
+            op="matcher_scalar_value_unique",
+            dtypes=[(pto.f32, pto.i32, pto.f32)],
+            constraints=[lambda indexCol: indexCol.value % 8 == 0],
+            priority=10,
+        )
+        def template_aligned(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+            return None
+
+        @pto.vkernel(
+            op="matcher_scalar_value_unique",
+            dtypes=[(pto.f32, pto.i32, pto.f32)],
+        )
+        def template_fallback(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+            return None
+
+        registry = pto.KernelRegistry((template_aligned, template_fallback))
+        aligned_operand_specs = expand_helper._parse_operand_specs(
+            """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "scalar",
+    "dtype": "i32",
+    "value": 8
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  }
+]
+"""
+        )
+        fallback_operand_specs = expand_helper._parse_operand_specs(
+            """
+[
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  },
+  {
+    "kind": "scalar",
+    "dtype": "i32",
+    "value": 1
+  },
+  {
+    "kind": "tile",
+    "dtype": "f32",
+    "shape": [1, 64],
+    "valid_shape": [1, 64],
+    "memory_space": "ub",
+    "config": {
+      "b_layout": "row_major",
+      "s_layout": "none_box",
+      "s_fractal_size": 512,
+      "pad_value": "0x0"
+    }
+  }
+]
+"""
+        )
+
+        aligned = pto.select_kernel(
+            "a5",
+            "matcher_scalar_value_unique",
+            (pto.f32, pto.i32, pto.f32),
+            context_attrs=expand_helper._build_positional_context_attrs(aligned_operand_specs),
+            registry=registry,
+        )
+        fallback = pto.select_kernel(
+            "a5",
+            "matcher_scalar_value_unique",
+            (pto.f32, pto.i32, pto.f32),
+            context_attrs=expand_helper._build_positional_context_attrs(fallback_operand_specs),
+            registry=registry,
+        )
+
+        self.assertEqual(aligned.name, "template_aligned")
+        self.assertEqual(fallback.name, "template_fallback")
 
     def test_select_kernel_binds_selected_op_for_multi_op_descriptor(self) -> None:
         @pto.vkernel(
@@ -7644,6 +7880,48 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             text,
             r"pto\.strict_vecscope\(%tmp_\d+, %tmp_\d+, %c0, %upper_\d+, %step_\d+\)",
         )
+
+    def test_explicit_vecscope_if_merges_new_binding_defined_in_both_branches(self) -> None:
+        @pto.vkernel(op="explicit_vecscope_if_result_unique", dtypes=[(pto.f32, pto.f32, pto.i32)])
+        def kernel(src: pto.Tile, dst: pto.Tile, flag: pto.i32):
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            with pto.vecscope():
+                if flag:
+                    vec = pto.vlds(src, 0)
+                else:
+                    vec = pto.vlds(src, 64)
+                pto.vsts(vec, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        frontend_kernel = build_frontend_kernel_node(specialized)
+        vecscope_stmt = next(stmt for stmt in frontend_kernel.body if isinstance(stmt, FrontendVecscopeStmt))
+        self.assertIsInstance(vecscope_stmt.body[0], FrontendIfStmt)
+
+        semantic_kernel = analyze_frontend_kernel(frontend_kernel)
+        semantic_vecscope = next(
+            stmt for stmt in semantic_kernel.body if isinstance(stmt, SemanticVecscopeStmt)
+        )
+        if_stmt = semantic_vecscope.body[0]
+        self.assertIsInstance(if_stmt, SemanticIfStmt)
+        self.assertEqual([result.result_binding.name for result in if_stmt.results], ["vec"])
+        self.assertIsInstance(semantic_vecscope.body[1], SemanticVectorStoreStmt)
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vecscope {", text)
+        self.assertRegex(
+            text,
+            r"%vec_\d+ = scf\.if %tmp_\d+ -> \(!pto\.vreg<64xf32>\) \{",
+        )
+        self.assertRegex(
+            text,
+            r"scf\.yield %vec_\d+ : !pto\.vreg<64xf32>",
+        )
+        self.assertIn("pto.vsts", text)
 
     def test_extended_sync_buffer_ops_lower_to_authoring_surface(self) -> None:
         Pipe = pto.Pipe


### PR DESCRIPTION
## Summary
- expose compile-time scalar constant values to TileLang constraint proxies via `param.value`
- thread scalar values through ExpandTileOp operand-spec serialization, Python expand_helper context attrs, and constraint evaluation views
- add regression coverage for descriptor selection and `pto.select_kernel(...)` scalar-value constraints

## Validation
- `python3 -m pytest tilelang-dsl/tests/test_tilelang_dsl_v1.py -k 'test_select_descriptor_propagates_static_scalar_values_into_constraints or test_select_kernel_constraints_can_read_scalar_parameter_values or positional_context or materialization_constraints_can_see_specializations'`
- `build/tools/ptoas/ptoas --version`

Closes #397
