### PR TITLE
fix(dsl): merge branch-local if bindings (#398)

### DIFF
--- a/tilelang-dsl/docs/user_guide/06-control-flow.md
+++ b/tilelang-dsl/docs/user_guide/06-control-flow.md
@@ -178,4 +178,6 @@ else:
 # 'step' here is the merged result from both branches
 ```
 
-Variables defined in only one branch are local to that branch.
+Variables defined in only one branch are local to that branch. Variables assigned
+in both branches with the same name and type are merged even when the binding is
+first introduced inside the `if`/`else`.

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -2611,10 +2611,23 @@ class _SemanticAnalyzer:
 
         updated_env = dict(env)
         merged_results: list[SemanticIfResult] = []
-        for name, outer_binding in env.items():
+        merge_names = list(env)
+        merge_names.extend(
+            name
+            for name in then_env
+            if name not in env and name in else_env
+        )
+        for name in merge_names:
+            outer_binding = env.get(name)
             then_binding = then_env.get(name, outer_binding)
             else_binding = else_env.get(name, outer_binding)
-            if then_binding is outer_binding and else_binding is outer_binding:
+            if outer_binding is None:
+                if then_binding is None or else_binding is None:
+                    continue
+            else:
+                if then_binding is outer_binding and else_binding is outer_binding:
+                    continue
+            if then_binding is None or else_binding is None:
                 continue
             if then_binding.type != else_binding.type:
                 raise TypeError(

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -7645,6 +7645,48 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"pto\.strict_vecscope\(%tmp_\d+, %tmp_\d+, %c0, %upper_\d+, %step_\d+\)",
         )
 
+    def test_explicit_vecscope_if_merges_new_binding_defined_in_both_branches(self) -> None:
+        @pto.vkernel(op="explicit_vecscope_if_result_unique", dtypes=[(pto.f32, pto.f32, pto.i32)])
+        def kernel(src: pto.Tile, dst: pto.Tile, flag: pto.i32):
+            mask = pto.make_mask(pto.f32, pto.PAT.ALL)
+            with pto.vecscope():
+                if flag:
+                    vec = pto.vlds(src, 0)
+                else:
+                    vec = pto.vlds(src, 64)
+                pto.vsts(vec, dst, 0, mask)
+            return None
+
+        specialized = kernel.specialize(
+            src=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+            dst=pto.TileSpecialization(shape=(8, 128), memory_space=pto.MemorySpace.UB),
+        )
+
+        frontend_kernel = build_frontend_kernel_node(specialized)
+        vecscope_stmt = next(stmt for stmt in frontend_kernel.body if isinstance(stmt, FrontendVecscopeStmt))
+        self.assertIsInstance(vecscope_stmt.body[0], FrontendIfStmt)
+
+        semantic_kernel = analyze_frontend_kernel(frontend_kernel)
+        semantic_vecscope = next(
+            stmt for stmt in semantic_kernel.body if isinstance(stmt, SemanticVecscopeStmt)
+        )
+        if_stmt = semantic_vecscope.body[0]
+        self.assertIsInstance(if_stmt, SemanticIfStmt)
+        self.assertEqual([result.result_binding.name for result in if_stmt.results], ["vec"])
+        self.assertIsInstance(semantic_vecscope.body[1], SemanticVectorStoreStmt)
+
+        text = specialized.mlir_text()
+        self.assertIn("pto.vecscope {", text)
+        self.assertRegex(
+            text,
+            r"%vec_\d+ = scf\.if %tmp_\d+ -> \(!pto\.vreg<64xf32>\) \{",
+        )
+        self.assertRegex(
+            text,
+            r"scf\.yield %vec_\d+ : !pto\.vreg<64xf32>",
+        )
+        self.assertIn("pto.vsts", text)
+
     def test_extended_sync_buffer_ops_lower_to_authoring_surface(self) -> None:
         Pipe = pto.Pipe
         Event = pto.Event


### PR DESCRIPTION
## Summary
- merge `if/else` bindings that are first introduced inside both branches when their names and types match
- add a regression test covering explicit `pto.vecscope()` with branch-local vector values consumed after the branch
- document the updated conditional merge behavior in the control-flow guide

## Validation
- `PYTHONPATH=$PWD/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_explicit_vecscope_if_merges_new_binding_defined_in_both_branches`
- `PYTHONPATH=$PWD/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_if_else_and_sync_ops_lower_to_scf_if_and_authoring_sync_ops`
- `PYTHONPATH=$PWD/tilelang-dsl/python python3 -m unittest tilelang-dsl.tests.test_tilelang_dsl_v1.TileLangDSLDescriptorTests.test_if_else_with_two_merged_bindings_lowers_to_multi_result_scf_if`

Closes #398