### PR TITLE
fix(vpto): lower signless i8*i8->i32 MAD to llvm.hivm.MAD.s8.c310

### DIFF
--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -292,7 +292,7 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
   if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
       rhs == "s8" && dst == "s32")
-    return StringAttr::get(context, "llvm.hivm.MAD.s82s32.c310").getValue();
+    return StringAttr::get(context, "llvm.hivm.MAD.s8.c310").getValue();
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -227,6 +227,11 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
+static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
+  return intType && intType.getWidth() == width &&
+         (intType.isSigned() || intType.isSignless());
+}
+
 static std::string getMadRhsFragment(Type type) {
   if (type.isF16())
     return "f16";
@@ -235,9 +240,9 @@ static std::string getMadRhsFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 4)
+    if (isSignedOrSignlessInteger(intType, 4))
       return "s4";
-    if (intType.isSigned() && intType.getWidth() == 8)
+    if (isSignedOrSignlessInteger(intType, 8))
       return "s8";
     if (intType.isUnsigned() && intType.getWidth() == 2)
       return "u2";
@@ -264,7 +269,7 @@ static std::string getMadDstFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 32)
+    if (isSignedOrSignlessInteger(intType, 32))
       return "s32";
   }
   return {};
@@ -285,6 +290,9 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.bf162f32.c310").getValue();
   if (lhsElem.isF32() && rhs == "f32" && dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
+  if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
+      rhs == "s8" && dst == "s32")
+    return StringAttr::get(context, "llvm.hivm.MAD.s82s32.c310").getValue();
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();

--- a/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
+++ b/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
@@ -23,7 +23,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       : !pto.ptr<f32, l0a>, !pto.ptr<f32, l0b>, !pto.ptr<f32, l0c>, !pto.ptr<f32, bt>, i64, i64, i64
     return
   }
+
+  func.func @mad_semantic_vpto_llvm_i8(
+      %lhs: !pto.ptr<i8, l0a>,
+      %rhs: !pto.ptr<i8, l0b>,
+      %dst: !pto.ptr<i32, l0c>) attributes {pto.aicore} {
+    %c16 = arith.constant 16 : i64
+    pto.mad %lhs, %rhs, %dst, %c16, %c16, %c16 unit_flag(check_only) disable_gemv
+      : !pto.ptr<i8, l0a>, !pto.ptr<i8, l0b>, !pto.ptr<i32, l0c>, i64, i64, i64
+    return
+  }
 }
 
 // CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_mix_aic
 // CHECK-COUNT-3: llvm.call @llvm.hivm.MAD.f322f32.c310
+// CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_i8_mix_aic
+// CHECK: llvm.call @llvm.hivm.MAD.s8.c310


### PR DESCRIPTION
## Summary
- cherry-pick PR #389's signless `i8*i8->i32` MAD lowering support onto `feature-vpto-backend`
- fix the integer MAD LLVM callee to use `llvm.hivm.MAD.s8.c310`
- add a VPTO cube lit regression that checks the `i8 -> i32` path emits the correct intrinsic

## Validation
- `cmake --build build --target ptoas -j $(nproc)`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto test/lit/vpto/cube/mad_semantic_vpto_llvm.pto -o /tmp/mad_semantic_vpto_llvm.o --mlir-print-ir-after=convert-func-to-llvm 2>&1 | rg -n "llvm\\.hivm\\.MAD\\.(f322f32\\.c310|s8\\.c310|s82s32\\.c310)|mad_semantic_vpto_llvm_i8"`
- `mkdir -p /tmp/ptoas-lit && ( build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto test/lit/vpto/cube/mad_semantic_vpto_llvm.pto -o /tmp/ptoas-lit/mad.o --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/FileCheck test/lit/vpto/cube/mad_semantic_vpto_llvm.pto`

Fixes #381
Supersedes #389
