### PR TITLE
Draft: Add flash_atten4 PTODSL compile/frontend port

### DIFF
--- a/docs/designs/flash_atten4_ptodsl_a5_port_plan_zh.md
+++ b/docs/designs/flash_atten4_ptodsl_a5_port_plan_zh.md
@@ -1,0 +1,239 @@
+# flash_atten4 A5 C++ 到 PTODSL 迁移计划
+
+## 目标和边界
+
+实际移植源是 GitCode `csjlchen/pto-isa` 的 `fa4dsl` 分支：
+
+```text
+kernels/manual/a5/flash_atten4/
+```
+
+`hw-native-sys/pto-isa` 的 `kernels/python/flash_atten/README_zh.md` 只作为 PTODSL 表达方式、测试方式和调度经验参考，不能作为移植源覆盖 A5 C++ 的默认参数或行为。
+
+当前 `ptodsl/examples/flash_atten4_port.py` 是 compile-only 的 PTODSL 迁移脚手架，不是高性能实现完成版。
+
+## A5 C++ 源码要点
+
+主要文件：
+
+```text
+fa_performance_kernel.h
+fa_performance_dn_kernel.cpp
+pto_macro_dn_matmul.hpp
+pto_macro_fa_dn_softmax.hpp
+pto_macro_fa_dn_gu.hpp
+```
+
+关键默认值来自 `fa_performance_kernel.h`：
+
+```text
+kFaCvFifoSize = 8
+kFaCvFifoConsSyncPeriod = 4
+kFaCubeS1 = 128
+kFaTileS1 = 256
+kFaQkPreload = 4
+kFaLaunchCoreCount = 28
+VEC_CORES = 2
+```
+
+主流水：
+
+```text
+compute_qk  -> qk_tile_fifo, fp32
+compute_p   -> p_tile_fifo, fp16, plus exp_max_ififo
+compute_pv  -> pv_tile_fifo, fp32
+compute_gu  -> running O update / final O
+```
+
+重要调度和内存设计：
+
+- 默认 `FIFO_MODE=1`，即 ALL_UB path；CMake 也支持 `0=ALL_GM`、`2=QK_PV_UB_ONLY`。
+- `TILE_FACTOR = TILE_S1 / CUBE_S1`，默认是 `2`。
+- `compute_qk` 和 `compute_pv` 在 cube core 上交错。
+- `compute_p` 和 `compute_gu` 在 vector core 上交错。
+- Vector 侧不是整块 `CUBE_S0 x CUBE_S1` 常驻处理，而是按 row-slice 降低 UB 压力：
+
+```text
+Vec_S0 = CUBE_S0 / VEC_CORES / TILE_FACTOR
+VecGuRows = CUBE_S0 / VEC_CORES
+```
+
+在默认 `CUBE_S0=128, VEC_CORES=2, TILE_FACTOR=2` 下，`Vec_S0=32`，`VecGuRows=64`。
+
+## 当前 PTODSL 状态
+
+已经具备：
+
+- PTODSL 文件 `ptodsl/examples/flash_atten4_port.py`。
+- 四阶段函数命名已经对齐 A5 源码：`fa4_compute_qk`、`fa4_compute_p`、`fa4_compute_pv`、`fa4_compute_gu`。
+- 默认形状已经按 A5 C++ 对齐：`S0=128`、`HEAD_DIM=128`、`CUBE_S1=128`、`TILE_S1=256`、`QK_PRELOAD=4`。
+- `CV_FIFO_SIZE=8`、`CV_FIFO_CONS_SYNC_PERIOD=4` 和 `FIFO_MODE=1` 已经暴露为 PTODSL constexpr 参数，后续接真实 FIFO 调度时可以复用入口契约。
+- Vector 侧物理 tile 已经开始按 A5 row-slice 思路收缩：默认 `Vec_S0=32`。
+- Manual-parity 默认形状已经可以通过 `ptoas --emit-pto-ir` 的 vec memory 检查。
+- Softmax/GU 状态更新已经改为 A5 风格：循环内维护未归一化 running O，最后用最终 `global_sum` 做归一化。
+- Entry signature 已加入 A5 scratch/通信指针雏形：`p_tile_fifo`、`exp_max_ififo`、`qk_tile_fifo`、`pv_tile_fifo`、`pv_pend_tile_fifo`、`o_parts_out`、`cv_comm_buf`。
+- QK/P/exp_max/PV/PV_pend/O_parts 阶段已经向对应 GM FIFO/scratch view 写入中间 tile，使 compile-only IR 中能看到 FIFO 数据边界。
+- QK/P FIFO 的物理 view 已经按 A5 `CV_FIFO_SIZE * TILE_FACTOR * CUBE_S0` 建模，sub-tile 不再复用同一个 FIFO row window。
+- 前端已加入 `Fa4StageSpec` / `Fa4FifoPolicy`，用 PTODSL 代码显式描述 `QK -> P -> PV -> GU` 的 stage graph、pipe 绑定、buffer id 和 FIFO handoff policy。
+- QK/P/PV/GU 四个 stage 已用 `pto.get_buf` / `pto.rls_buf` 标出 acquire/release 生命周期，使 compile/frontend IR 不再只依赖 `cv_comm_buf` marker 表达 stage 边界。
+- `FIFO_MODE` 已经影响 frontend logical handoff policy：`0=ALL_GM` 会从 GM FIFO 回读 QK/P/PV；`1=ALL_UB` 会保留 ptr-compatible scratch store，但消费者优先使用 UB 内 tile；`2=QK_PV_UB_ONLY` 会让 QK/PV 走 UB handoff、P 保留 GM handoff。
+- `cv_comm_buf` 入口不再是空参数：当前用 ui8 stage marker 写入 QK/P/PV/GU 四个阶段，先让通信控制面在 PTODSL/PTOAS frontend IR 中可见。
+- 已加入由 `QK_PRELOAD` 驱动的 prologue/steady/epilogue schedule marker：`10=prologue`、`20=steady`、`30=epilogue`。当前它是 shadow schedule，用来让流水结构先进入 IR，计算仍保留在顺序路径中。
+- 已加入 pending consumption drain 的 compile-only marker：`50=qk2sm drain`、`51=sm2pv drain`、`52=pv2gu drain`、`53=ubBuf drain`、`54=pvUbBuf drain`、`55=CV_BLOCK_END`，对应 A5 C++ 主循环后的 TSync/CV 通信尾部清理。
+- `FIFO_MODE` 不再是完全空参数：当前用 `60=ALL_GM`、`61=ALL_UB`、`62=QK_PV_UB_ONLY` marker 区分三种 specialization，并用 `80..85` marker 记录 QK/P/PV 的 GM/UB handoff policy，已加入 compile/frontend 回归。
+- 已加入 `kFaLaunchCoreCount=28` 对应的 launch-core cap，并用 `70` marker 表达 `logical_block_idx += launch_block_count` 的 logical-block stride。当前真实计算仍只走当前 block 的顺序路径，stride loop 还是 shadow marker。
+- `CAUSAL=True` 不再只是占位参数：当前在 softmax 前用 SIMT scalar loop 对 `kv_col > q_row` 的 score 写 `-inf`，并已加入 compile/frontend 回归。
+- 已加入第一层 compile-only 同步标记，对齐 A5 C++ 的 `BUF0_QK_READY=0/1`、`BUF1_SM_READY=2/3`、`UPDATE_READY=4/5`、`UB_BUF_READY=6/7` 四组 flag：QK->P、P->PV、PV->GU、FIFO slot reuse/backpressure 和输出复用边界在 IR 中已经可见。
+- compile-only 测试和 PTOAS frontend 小形状验证测试已经加入。
+- 为 PTODSL ptr/tile-buffer 过 PTOAS frontend 修了必要的 alias/liveness/type handoff。
+
+compile/frontend 收敛判定：
+
+- PTODSL entry signature 已覆盖 A5 C++ kernel 的 Q/K/V、QK/P/PV/PV_pend/exp_max/O/O_parts/CV comm 指针。
+- A5 默认 constexpr 已覆盖：`S0=128`、`HEAD_DIM=128`、`CUBE_S0=128`、`CUBE_S1=128`、`TILE_S1=256`、`QK_PRELOAD=4`、`CV_FIFO_SIZE=8`、`CV_FIFO_CONS_SYNC_PERIOD=4`、`FIFO_MODE=1`。
+- QK/P/PV/PV_pend/exp_max/O_parts 的 producer store、FIFO_MODE=0 的 GM consumer load、FIFO_MODE=1/2 的 UB handoff policy 都能在 MLIR/PTO IR 中看到。
+- QK/P FIFO 的 `TILE_FACTOR` 维度、row-slice `Vec_S0`、launch cap、shadow schedule、drain、stage acquire/release、`FIFO_MODE`、causal mask 都有 compile/frontend 回归。
+- dev-481211 上 `test_flash_atten4_port_compile.py`、`test_flash_atten4_port_frontend_verify.py` 和 manual 默认 artifact 的 `ptoas --emit-pto-ir` 已通过。
+
+## 使用方式
+
+以下命令只生成和验证 PTODSL/PTOAS frontend artifact，不执行 A5 runtime。
+
+在仓库根目录生成 A5 默认形状 MLIR：
+
+```bash
+python3 ptodsl/examples/flash_atten4_port.py -o /tmp/fa4_default.mlir
+```
+
+用 PTOAS frontend 检查：
+
+```bash
+build/tools/ptoas/ptoas /tmp/fa4_default.mlir --emit-pto-ir -o /tmp/fa4_default.pto
+```
+
+生成 causal 版本：
+
+```bash
+python3 ptodsl/examples/flash_atten4_port.py --causal -o /tmp/fa4_causal.mlir
+build/tools/ptoas/ptoas /tmp/fa4_causal.mlir --emit-pto-ir -o /tmp/fa4_causal.pto
+```
+
+切换 `FIFO_MODE`：
+
+```bash
+python3 ptodsl/examples/flash_atten4_port.py --fifo-mode 0 -o /tmp/fa4_fifo_gm.mlir
+python3 ptodsl/examples/flash_atten4_port.py --fifo-mode 1 -o /tmp/fa4_fifo_ub.mlir
+python3 ptodsl/examples/flash_atten4_port.py --fifo-mode 2 -o /tmp/fa4_fifo_qk_pv_ub.mlir
+```
+
+编译一个更大的 launch-cap 检查形状：
+
+```bash
+python3 ptodsl/examples/flash_atten4_port.py \
+  --s0 4096 --s1 1024 --cube-s0 128 --cube-s1 128 --tile-s1 256 \
+  -o /tmp/fa4_launch_cap.mlir
+```
+
+常用回归：
+
+```bash
+python3 ptodsl/tests/test_flash_atten4_port_compile.py
+python3 ptodsl/tests/test_flash_atten4_port_frontend_verify.py
+```
+
+CLI 参数说明：
+
+```text
+--s0 / --s1 / --head-dim          logical problem shape
+--cube-s0 / --cube-s1 / --tile-s1 A5 tiling shape
+--qk-preload                      QK preload depth, currently 3 or 4
+--cv-fifo-size                    CV FIFO depth, A5 default 8
+--cv-fifo-cons-sync-period        consumption sync period, A5 default 4
+--fifo-mode                       0=ALL_GM, 1=ALL_UB, 2=QK_PV_UB_ONLY
+--causal                          enable compile/frontend causal mask
+-o / --output                     output MLIR path, or '-' for stdout
+```
+
+`cv_comm_buf` marker 约定：
+
+```text
+1/2/3/4   QK/P/PV/GU stage marker
+10/20/30  prologue/steady/epilogue shadow schedule
+50..55    qk2sm/sm2pv/pv2gu/ubBuf/pvUbBuf/CV_BLOCK_END drain marker
+60/61/62  FIFO_MODE=ALL_GM/ALL_UB/QK_PV_UB_ONLY
+80/81     QK handoff is GM FIFO / UB tile
+82/83     P handoff is GM FIFO / UB tile
+84/85     PV handoff is GM FIFO / UB tile
+70        launch logical-block stride marker
+```
+
+当前差距：
+
+- 当前同步只是 `pto.sync.set/wait` 级别的编译可见标记，还没有实现 A5 `TSync` 的 allocate/free/record/wait 完整语义，也没有按真实 cube/vector core 拆分执行流。
+- `FIFO_MODE` 三种 specialization 已经改变 PTODSL frontend logical handoff policy，但还没有降成 A5 真实 GM/UB 分配、搬运和同步协议。
+- 当前 FIFO 已经有显式 GM view、ptr-compatible scratch store、静态环形 slot offset、stage acquire/release 和 GM/UB logical handoff policy，但尚未实现真实 cube/vector 并行下的消费反压和生命周期闭环。
+- 当前 `cv_comm_buf` 仍是 frontend 可观测的 stage/control marker，不是 A5 `TSyncCVID`/FFTS runtime 控制协议；正式协议应由后端 lowering 生成。
+- 当前 prologue/steady/epilogue 还是 shadow schedule，尚未把 `compute_qk/compute_p/compute_pv/compute_gu` 真正拆入三段流水执行。
+- 当前 launch logical-block stride 还是 shadow marker，尚未把计算主体搬进跨 logical block 的 outer loop。
+- A5 C++ 里的 `PV_UB_BUF_READY=8`、`CV_BLOCK_END=10` 已先映射成 `cv_comm_buf` marker；当前 PTODSL 静态 sync facade 限制 event id 在 `[0, 7]`，所以还没有生成对应 sync op。
+- `compute_p` 已表达在线 softmax 状态更新，但仍是 PTODSL vector/scalar row loop，不是 A5 `pto_macro_fa_dn_softmax.hpp` 的 DN vector instruction macro。
+- `compute_gu` 已经使用 A5 的未归一化 running O 语义，但仍是简化的 SIMT scalar loop，不是 A5 `pto_macro_fa_dn_gu.hpp` 的 vector instruction macro。
+- Cube 侧 full-CUBE_S0 matmul 目前先表达成 row-slice matmul，用于降低 compile-only artifact 的 vec 压力；后续要恢复到 A5 的 cube full tile + vector row-slice handoff。
+- causal mask 已有 compile/frontend 级实现，但还不是 A5 vector macro 内的高性能 mask 路径。
+
+## 后续开发顺序
+
+1. 保持 compile-only 小形状 frontend 测试，作为 PTODSL/PTOAS handoff 回归。
+2. 将 `compute_p` 继续收敛到 `pto_macro_fa_dn_softmax.hpp` 的 DN vector macro 语义和 tile op 边界：
+
+```text
+local_max
+new_global_max
+exp_max = exp((old_global_max - new_global_max) * scale)
+x_exp = exp((qk - new_global_max) * scale)
+new_global_sum = old_global_sum * exp_max + local_sum
+```
+
+3. 将 `compute_gu` 继续收敛到 `pto_macro_fa_dn_gu.hpp` 的 vector macro 语义和 tile op 边界：
+
+```text
+running_o = running_o * exp_max + pv
+final tile: running_o / new_global_sum
+```
+
+4. 后端把当前同步标记和 stage acquire/release 推进成真实 `TSync` 语义：
+
+```text
+qk2smSync: QK produce / softmax consume, plus FIFO slot reuse backpressure
+sm2pvSync: softmax produce / PV consume, plus P FIFO slot reuse backpressure
+pv2guSync: PV produce / GU consume, plus PV FIFO slot reuse backpressure
+ubBufSync / pvUbBufSync: UB tile reuse boundary
+```
+
+5. 后端把 shadow schedule 推进成真实的三段流水调度：
+
+```text
+prologue: preload QK[0..QK_PRELOAD-1]
+steady:   compute next QK while draining current P/PV/GU
+epilogue: drain remaining PV/GU
+```
+
+6. 最后把 `FIFO_MODE` logical handoff policy 降成真实 GM/UB 数据路径、把 causal mask 下沉到 A5 vector macro 路径、A5 端运行验证。
+
+## 验证策略
+
+dev-481211：
+
+- `python3 ptodsl/tests/test_flash_atten4_port_compile.py`
+- `python3 ptodsl/tests/test_flash_atten4_port_frontend_verify.py`
+- `ptoas --emit-pto-ir` 检查资源是否下降到可接受范围。
+
+A5 `192.168.1.52`：
+
+- 只在 `/root/zjm/` 下创建独立实验目录。
+- 先用 dev-481211 构建出的后端产物，避免 A5 内存不足。
+- 先跑小 case 正确性，再跑 manual 默认 case。
+
+A3 `101.245.68.6`：
+
+- 只用于兼容性验证，不作为 A5 `flash_atten4` 移植源。

--- a/ptodsl/examples/flash_atten4_port.py
+++ b/ptodsl/examples/flash_atten4_port.py
@@ -1,0 +1,1150 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+PTODSL port sketch of the hand-written A5 ``flash_atten4`` kernel.
+
+This is a compile-only porting step. It intentionally preserves the original
+high-performance kernel's stage decomposition:
+
+    compute_qk (Cube)
+      -> compute_p (SIMD/vector)
+      -> compute_pv (Cube)
+      -> compute_gu (SIMT/scalar update)
+
+The PTODSL version keeps the original blocking vocabulary:
+
+    S0 / S1 / HEAD_DIM
+    CUBE_S0 / CUBE_S1 / TILE_S1
+    TILE_FACTOR = TILE_S1 / CUBE_S1
+    QK_PRELOAD as a schedule knob
+
+The source of truth for this file is the GitCode fa4dsl A5 C++ implementation:
+
+    kernels/manual/a5/flash_atten4/
+
+The hw-native-sys Python FA example is only a secondary reference for PTODSL
+expression and validation style.
+
+What is still intentionally simplified at this stage:
+
+- the original A5/A3-specific ping-pong / CV FIFO / FFTS runtime semantics
+- the full overlap schedule across cube/vector subblocks
+- backend-lowered high-performance softmax/GU TileOps
+
+The goal here is to land the *port structure* in current PTODSL syntax while
+keeping the manual kernel's tiled pipeline recognizable.
+"""
+
+import argparse
+from dataclasses import dataclass
+from math import sqrt
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "ptodsl" / "__init__.py").exists():
+            sys.path.insert(0, str(candidate))
+            break
+    else:
+        raise RuntimeError(
+            "Unable to locate the PTODSL Python package root from flash_atten4_port.py"
+        )
+
+from ptodsl import pto, scalar
+
+
+MANUAL_S0 = 128
+MANUAL_HEAD_DIM = 128
+MANUAL_CUBE_S0 = 128
+MANUAL_CUBE_S1 = 128
+MANUAL_TILE_S1 = 256
+MANUAL_QK_PRELOAD = 4
+MANUAL_CV_FIFO_SIZE = 8
+MANUAL_CV_FIFO_CONS_SYNC_PERIOD = 4
+MANUAL_FIFO_MODE = 1
+MANUAL_VEC_CORES = 2
+MANUAL_SRC_VEC_TN_BUFFERS = 2
+MANUAL_LAUNCH_CORE_COUNT = 28
+DEFAULT_S1 = 1024
+
+# A5 fa_performance_dn_kernel.cpp::FftsBufferFlag.  PTODSL currently exposes
+# static sync event ids in [0, 7], so this compile-only port models the first
+# four two-flag TSync groups and leaves PV_UB_BUF_READY/CV_BLOCK_END for the
+# later real pipeline split.
+FA4_SYNC_QK2SM = 0
+FA4_SYNC_SM2PV = 2
+FA4_SYNC_PV2GU = 4
+FA4_SYNC_UB_BUF = 6
+
+FA4_COMM_STAGE_QK = 1
+FA4_COMM_STAGE_P = 2
+FA4_COMM_STAGE_PV = 3
+FA4_COMM_STAGE_GU = 4
+FA4_COMM_PHASE_PROLOGUE = 10
+FA4_COMM_PHASE_STEADY = 20
+FA4_COMM_PHASE_EPILOGUE = 30
+FA4_COMM_DRAIN_QK2SM = 50
+FA4_COMM_DRAIN_SM2PV = 51
+FA4_COMM_DRAIN_PV2GU = 52
+FA4_COMM_DRAIN_UB = 53
+FA4_COMM_DRAIN_PV_UB = 54
+FA4_COMM_BLOCK_END = 55
+FA4_COMM_FIFO_MODE_GM = 60
+FA4_COMM_FIFO_MODE_UB = 61
+FA4_COMM_FIFO_MODE_QK_PV_UB = 62
+FA4_COMM_LOGICAL_BLOCK_STRIDE = 70
+FA4_COMM_PATH_QK_GM = 80
+FA4_COMM_PATH_QK_UB = 81
+FA4_COMM_PATH_P_GM = 82
+FA4_COMM_PATH_P_UB = 83
+FA4_COMM_PATH_PV_GM = 84
+FA4_COMM_PATH_PV_UB = 85
+
+FA4_BUF_QK_STAGE = 0
+FA4_BUF_P_STAGE = 1
+FA4_BUF_PV_STAGE = 2
+FA4_BUF_GU_STAGE = 3
+
+
+@dataclass(frozen=True)
+class Fa4StageSpec:
+    name: str
+    pipe: object
+    buf_id: int
+    producer_sync: int | None
+    consumer_sync: int | None
+
+
+@dataclass(frozen=True)
+class Fa4FifoPolicy:
+    qk_from_gm_fifo: bool
+    p_from_gm_fifo: bool
+    pv_from_gm_fifo: bool
+
+
+FA4_STAGE_QK = Fa4StageSpec("qk", pto.Pipe.M, FA4_BUF_QK_STAGE, FA4_SYNC_QK2SM, None)
+FA4_STAGE_P = Fa4StageSpec("p", pto.Pipe.V, FA4_BUF_P_STAGE, FA4_SYNC_SM2PV, FA4_SYNC_QK2SM)
+FA4_STAGE_PV = Fa4StageSpec("pv", pto.Pipe.M, FA4_BUF_PV_STAGE, FA4_SYNC_PV2GU, FA4_SYNC_SM2PV)
+FA4_STAGE_GU = Fa4StageSpec("gu", pto.Pipe.V, FA4_BUF_GU_STAGE, None, FA4_SYNC_PV2GU)
+
+
+def _fa4_fifo_policy(fifo_mode: int) -> Fa4FifoPolicy:
+    if fifo_mode == 0:
+        return Fa4FifoPolicy(qk_from_gm_fifo=True, p_from_gm_fifo=True, pv_from_gm_fifo=True)
+    if fifo_mode == 1:
+        return Fa4FifoPolicy(qk_from_gm_fifo=False, p_from_gm_fifo=False, pv_from_gm_fifo=False)
+    if fifo_mode == 2:
+        return Fa4FifoPolicy(qk_from_gm_fifo=False, p_from_gm_fifo=True, pv_from_gm_fifo=False)
+    raise ValueError(f"unsupported FIFO_MODE={fifo_mode}")
+
+
+def describe_flash_atten4_frontend_plan(fifo_mode: int = MANUAL_FIFO_MODE):
+    policy = _fa4_fifo_policy(fifo_mode)
+    return {
+        "stages": [
+            {
+                "name": stage.name,
+                "buf_id": stage.buf_id,
+                "producer_sync": stage.producer_sync,
+                "consumer_sync": stage.consumer_sync,
+            }
+            for stage in (FA4_STAGE_QK, FA4_STAGE_P, FA4_STAGE_PV, FA4_STAGE_GU)
+        ],
+        "fifo_policy": {
+            "qk_from_gm_fifo": policy.qk_from_gm_fifo,
+            "p_from_gm_fifo": policy.p_from_gm_fifo,
+            "pv_from_gm_fifo": policy.pv_from_gm_fifo,
+        },
+    }
+
+
+def _min_i32(lhs, rhs):
+    return scalar.select(lhs < rhs, lhs, rhs)
+
+
+def _block_extent_i32(total, block_index, block_size):
+    block_size_i32 = pto.const(block_size, dtype=pto.i32)
+    remaining = total - block_index * block_size_i32
+    return _min_i32(remaining, block_size_i32)
+
+
+def _fa4_sync_record(event_id: int):
+    pto.set_cross_flag(pto.Pipe.FIX, event_id)
+
+
+def _fa4_sync_wait(event_id: int):
+    pto.wait_cross_flag(pto.Pipe.FIX, event_id)
+
+
+def _fa4_sync_record_if(condition, event_id: int):
+    with pto.if_(condition) as sync_br:
+        with sync_br.then_:
+            _fa4_sync_record(event_id)
+
+
+def _fa4_sync_wait_if(condition, event_id: int):
+    with pto.if_(condition) as sync_br:
+        with sync_br.then_:
+            _fa4_sync_wait(event_id)
+
+
+def _fa4_should_wait_consumption(sync_iter, fifo_size: int, sync_period: int):
+    period = pto.const(sync_period)
+    return (sync_iter >= pto.const(fifo_size)) & ((sync_iter % period) == pto.const(0))
+
+
+def _fa4_should_notify_consumption(sync_iter, sync_period: int):
+    period = pto.const(sync_period)
+    return ((sync_iter + pto.const(1)) % period) == pto.const(0)
+
+
+def _fa4_mark_cv_comm(cv_comm_ptr, offset, stage_code: int):
+    scalar.store(pto.ui8(stage_code), cv_comm_ptr, offset)
+
+
+def _fa4_acquire_stage(stage: Fa4StageSpec):
+    pto.get_buf(stage.pipe, stage.buf_id)
+
+
+def _fa4_release_stage(stage: Fa4StageSpec):
+    pto.rls_buf(stage.pipe, stage.buf_id)
+
+
+def _fa4_mark_fifo_path(cv_comm_ptr, path_comm_base, fifo_mode: int):
+    policy = _fa4_fifo_policy(fifo_mode)
+    _fa4_mark_cv_comm(
+        cv_comm_ptr,
+        path_comm_base,
+        FA4_COMM_PATH_QK_GM if policy.qk_from_gm_fifo else FA4_COMM_PATH_QK_UB,
+    )
+    _fa4_mark_cv_comm(
+        cv_comm_ptr,
+        path_comm_base + pto.const(1),
+        FA4_COMM_PATH_P_GM if policy.p_from_gm_fifo else FA4_COMM_PATH_P_UB,
+    )
+    _fa4_mark_cv_comm(
+        cv_comm_ptr,
+        path_comm_base + pto.const(2),
+        FA4_COMM_PATH_PV_GM if policy.pv_from_gm_fifo else FA4_COMM_PATH_PV_UB,
+    )
+
+
+def _fa4_pending_consumption_events(tiles_processed: int, fifo_size: int, sync_period: int) -> int:
+    if tiles_processed <= 0 or fifo_size <= 0 or sync_period <= 0:
+        return 0
+    notify_count = tiles_processed // sync_period
+    wait_count = 0
+    if tiles_processed > fifo_size:
+        last_iter = tiles_processed - 1
+        wait_count = (last_iter // sync_period) - ((fifo_size - 1) // sync_period)
+    max_pending = (fifo_size + sync_period - 1) // sync_period
+    pending = notify_count - wait_count
+    if pending < 0:
+        return 0
+    return pending if pending < max_pending else max_pending
+
+
+def _fa4_drain_pending_syncs(
+    cv_comm_ptr,
+    drain_comm_base,
+    tile_block_count: int,
+    cv_fifo_size: int,
+    cv_fifo_cons_sync_period: int,
+):
+    pending = _fa4_pending_consumption_events(
+        tile_block_count,
+        cv_fifo_size,
+        cv_fifo_cons_sync_period,
+    )
+    ub_drain_count = (
+        tile_block_count
+        if tile_block_count < MANUAL_SRC_VEC_TN_BUFFERS
+        else MANUAL_SRC_VEC_TN_BUFFERS
+    )
+
+    with pto.for_(0, pto.const(pending), step=1) as drain_idx:
+        _fa4_sync_wait(FA4_SYNC_QK2SM + 1)
+        _fa4_mark_cv_comm(cv_comm_ptr, drain_comm_base + drain_idx, FA4_COMM_DRAIN_QK2SM)
+
+    with pto.for_(0, pto.const(pending), step=1) as drain_idx:
+        _fa4_sync_wait(FA4_SYNC_SM2PV + 1)
+        _fa4_mark_cv_comm(
+            cv_comm_ptr,
+            drain_comm_base + pto.const(pending) + drain_idx,
+            FA4_COMM_DRAIN_SM2PV,
+        )
+
+    with pto.for_(0, pto.const(pending), step=1) as drain_idx:
+        _fa4_sync_wait(FA4_SYNC_PV2GU + 1)
+        _fa4_mark_cv_comm(
+            cv_comm_ptr,
+            drain_comm_base + pto.const(2 * pending) + drain_idx,
+            FA4_COMM_DRAIN_PV2GU,
+        )
+
+    with pto.for_(0, pto.const(ub_drain_count), step=1) as drain_idx:
+        _fa4_sync_wait(FA4_SYNC_UB_BUF + 1)
+        _fa4_mark_cv_comm(
+            cv_comm_ptr,
+            drain_comm_base + pto.const(3 * pending) + drain_idx,
+            FA4_COMM_DRAIN_UB,
+        )
+
+    pv_ub_drain_base = drain_comm_base + pto.const(3 * pending + ub_drain_count)
+    with pto.for_(0, pto.const(ub_drain_count), step=1) as drain_idx:
+        _fa4_mark_cv_comm(cv_comm_ptr, pv_ub_drain_base + drain_idx, FA4_COMM_DRAIN_PV_UB)
+
+    cv_block_end_base = pv_ub_drain_base + pto.const(ub_drain_count)
+    _fa4_mark_cv_comm(cv_comm_ptr, cv_block_end_base, FA4_COMM_BLOCK_END)
+
+
+def _fa4_mark_fifo_mode(cv_comm_ptr, mode_comm_base, fifo_mode: int):
+    if fifo_mode == 0:
+        _fa4_mark_cv_comm(cv_comm_ptr, mode_comm_base, FA4_COMM_FIFO_MODE_GM)
+    elif fifo_mode == 1:
+        _fa4_mark_cv_comm(cv_comm_ptr, mode_comm_base, FA4_COMM_FIFO_MODE_UB)
+    elif fifo_mode == 2:
+        _fa4_mark_cv_comm(cv_comm_ptr, mode_comm_base, FA4_COMM_FIFO_MODE_QK_PV_UB)
+
+
+def _fa4_mark_logical_block_stride(
+    cv_comm_ptr,
+    logical_comm_base,
+    block_idx,
+    logical_block_count: int,
+    launch_block_count: int,
+):
+    with pto.for_(0, pto.const(logical_block_count), step=launch_block_count) as logical_stride:
+        logical_block_idx = block_idx + logical_stride
+        with pto.if_(logical_block_idx < pto.const(logical_block_count)) as logical_br:
+            with logical_br.then_:
+                _fa4_mark_cv_comm(
+                    cv_comm_ptr,
+                    logical_comm_base + logical_block_idx,
+                    FA4_COMM_LOGICAL_BLOCK_STRIDE,
+                )
+
+
+def _fa4_mark_schedule_phases(
+    cv_comm_ptr,
+    schedule_base,
+    tile_block_count: int,
+    qk_preload: int,
+):
+    preload_tile_count = qk_preload if qk_preload < tile_block_count else tile_block_count
+    steady_tile_count = tile_block_count - qk_preload if tile_block_count > qk_preload else 0
+    epilogue_tile_count = tile_block_count - steady_tile_count
+
+    with pto.for_(0, pto.const(preload_tile_count), step=1) as preload_tile:
+        _fa4_mark_cv_comm(cv_comm_ptr, schedule_base + preload_tile, FA4_COMM_PHASE_PROLOGUE)
+
+    with pto.for_(0, pto.const(steady_tile_count), step=1) as steady_tile:
+        _fa4_mark_cv_comm(
+            cv_comm_ptr,
+            schedule_base + pto.const(tile_block_count) + steady_tile,
+            FA4_COMM_PHASE_STEADY,
+        )
+
+    with pto.for_(0, pto.const(epilogue_tile_count), step=1) as epilogue_tile:
+        _fa4_mark_cv_comm(
+            cv_comm_ptr,
+            schedule_base + pto.const(2 * tile_block_count) + epilogue_tile,
+            FA4_COMM_PHASE_EPILOGUE,
+        )
+
+
+@pto.cube
+def fa4_compute_qk(
+    q_mat: pto.Tile,
+    k_mat: pto.Tile,
+    q_l0a: pto.Tile,
+    k_l0b: pto.Tile,
+    qk_acc: pto.Tile,
+    scores_tile: pto.Tile,
+):
+    m = q_mat.valid_shape[0]
+    k = q_mat.valid_shape[1]
+    n = k_mat.valid_shape[0]
+
+    pto.mte_l1_l0a(q_mat.as_ptr(), q_l0a.as_ptr(), m, k)
+    pto.mte_l1_l0b(k_mat.as_ptr(), k_l0b.as_ptr(), k, n, transpose=True)
+    pto.mad(q_l0a.as_ptr(), k_l0b.as_ptr(), qk_acc.as_ptr(), m, n, k)
+    pto.mte_l0c_ub(qk_acc.as_ptr(), scores_tile.as_ptr(), m, n, n, n, 0)
+
+
+@pto.cube
+def fa4_compute_pv(
+    p_mat: pto.Tile,
+    v_mat: pto.Tile,
+    p_l0a: pto.Tile,
+    v_l0b: pto.Tile,
+    pv_acc: pto.Tile,
+    pv_tile: pto.Tile,
+):
+    m = p_mat.valid_shape[0]
+    k = p_mat.valid_shape[1]
+    n = v_mat.valid_shape[1]
+
+    pto.mte_l1_l0a(p_mat.as_ptr(), p_l0a.as_ptr(), m, k)
+    pto.mte_l1_l0b(v_mat.as_ptr(), v_l0b.as_ptr(), k, n)
+    pto.mad(p_l0a.as_ptr(), v_l0b.as_ptr(), pv_acc.as_ptr(), m, n, k)
+    pto.mte_l0c_ub(pv_acc.as_ptr(), pv_tile.as_ptr(), m, n, n, n, 0)
+
+
+@pto.simd
+def fa4_compute_p(
+    scores_tile: pto.Tile,
+    probs_tile: pto.Tile,
+    m_prev_tile: pto.Tile,
+    l_prev_tile: pto.Tile,
+    m_next_tile: pto.Tile,
+    l_next_tile: pto.Tile,
+    exp_max_tile: pto.Tile,
+    score_row_base: pto.i32,
+    rows: pto.i32,
+    cols: pto.i32,
+    scale: pto.f32,
+):
+    with pto.for_(0, rows, step=1) as row:
+        col_mask = pto.make_mask(pto.f32, cols)
+
+        raw_scores = pto.vlds(scores_tile[score_row_base + row, 0:])
+        scaled_scores = pto.vmuls(raw_scores, scale, col_mask)
+
+        m_prev = scalar.load(m_prev_tile[row, 0])
+        l_prev = scalar.load(l_prev_tile[row, 0])
+
+        row_max = pto.vcgmax(scaled_scores, col_mask)
+        m_next = scalar.max(m_prev, row_max)
+
+        shifted_scores = pto.vsubs(scaled_scores, m_next, col_mask)
+        probs = pto.vexp(shifted_scores, col_mask)
+        row_sum = pto.vcgadd(probs, col_mask)
+
+        exp_max = scalar.exp(m_prev - m_next)
+        l_next = l_prev * exp_max + row_sum
+
+        pto.vsts(probs, probs_tile[row, 0:], col_mask)
+        scalar.store(m_next, m_next_tile[row, 0])
+        scalar.store(l_next, l_next_tile[row, 0])
+        scalar.store(exp_max, exp_max_tile[row, 0])
+
+
+@pto.simt
+def fa4_apply_causal_mask(
+    scores_tile: pto.Tile,
+    score_row_base: pto.i32,
+    q_abs_row_base,
+    kv_abs_col_base,
+    rows: pto.i32,
+    cols: pto.i32,
+):
+    with pto.for_(0, rows, step=1) as row:
+        q_abs_row = q_abs_row_base + row
+
+        with pto.for_(0, cols, step=1) as col:
+            kv_abs_col = kv_abs_col_base + col
+
+            with pto.if_(kv_abs_col > q_abs_row) as mask_br:
+                with mask_br.then_:
+                    scalar.store(float("-inf"), scores_tile[score_row_base + row, col])
+
+
+@pto.simt
+def fa4_compute_gu(
+    o_prev_tile: pto.Tile,
+    pv_tile: pto.Tile,
+    exp_max_tile: pto.Tile,
+    o_next_tile: pto.Tile,
+    rows: pto.i32,
+    dim: pto.i32,
+):
+    with pto.for_(0, rows, step=1) as row:
+        exp_max = scalar.load(exp_max_tile[row, 0])
+
+        with pto.for_(0, dim, step=1) as col:
+            o_prev = scalar.load(o_prev_tile[row, col])
+            pv_val = scalar.load(pv_tile[row, col])
+            o_next = exp_max * o_prev + pv_val
+            scalar.store(o_next, o_next_tile[row, col])
+
+
+@pto.simt
+def fa4_finalize_o(
+    o_acc_tile: pto.Tile,
+    l_final_tile: pto.Tile,
+    o_final_tile: pto.Tile,
+    rows: pto.i32,
+    dim: pto.i32,
+):
+    with pto.for_(0, rows, step=1) as row:
+        denom = scalar.load(l_final_tile[row, 0])
+
+        with pto.for_(0, dim, step=1) as col:
+            acc = scalar.load(o_acc_tile[row, col])
+            scalar.store(acc / denom, o_final_tile[row, col])
+
+
+def fa4_process_subtile(
+    q_mat: pto.Tile,
+    k_part: pto.PartitionTensorView,
+    v_part: pto.PartitionTensorView,
+    qk_fifo_view: pto.TensorView,
+    p_fifo_view: pto.TensorView,
+    exp_max_fifo_view: pto.TensorView,
+    pv_fifo_view: pto.TensorView,
+    pv_pend_fifo_view: pto.TensorView,
+    o_parts_view: pto.TensorView,
+    cv_comm_ptr,
+    q_abs_row_base,
+    kv_abs_col_base,
+    k_mat: pto.Tile,
+    v_mat: pto.Tile,
+    o_prev_tile: pto.Tile,
+    o_next_tile: pto.Tile,
+    m_prev_tile: pto.Tile,
+    l_prev_tile: pto.Tile,
+    m_next_tile: pto.Tile,
+    l_next_tile: pto.Tile,
+    scores_tile: pto.Tile,
+    probs_tile: pto.Tile,
+    probs_f16_tile: pto.Tile,
+    p_mat: pto.Tile,
+    pv_tile: pto.Tile,
+    pv_pend_tile: pto.Tile,
+    exp_max_tile: pto.Tile,
+    q_l0a: pto.Tile,
+    p_l0a: pto.Tile,
+    rhs_l0b: pto.Tile,
+    qk_acc: pto.Tile,
+    pv_acc: pto.Tile,
+    tile_id,
+    qkp_fifo_row_base,
+    exp_max_fifo_row_base,
+    pv_fifo_row_base,
+    cv_comm_base,
+    o_parts_row_base,
+    score_row_base: pto.i32,
+    vec_rows: pto.i32,
+    cols: pto.i32,
+    dim: pto.i32,
+    scale: pto.f32,
+    cv_fifo_size: int,
+    cv_fifo_cons_sync_period: int,
+    fifo_mode: int,
+    causal: bool,
+):
+    fifo_policy = _fa4_fifo_policy(fifo_mode)
+    should_wait_consume = _fa4_should_wait_consumption(
+        tile_id,
+        cv_fifo_size,
+        cv_fifo_cons_sync_period,
+    )
+    should_notify_consume = _fa4_should_notify_consumption(
+        tile_id,
+        cv_fifo_cons_sync_period,
+    )
+    should_wait_ub_reuse = tile_id >= pto.const(MANUAL_SRC_VEC_TN_BUFFERS)
+    bytes_per_row = dim * pto.bytewidth(pto.f16)
+    gm_row_stride = k_part.strides[0] * pto.bytewidth(pto.f16)
+    mat_row_stride = k_mat.shape[1] * pto.bytewidth(pto.f16)
+
+    _fa4_sync_wait_if(should_wait_consume, FA4_SYNC_QK2SM + 1)
+    _fa4_sync_wait_if(should_wait_ub_reuse, FA4_SYNC_UB_BUF + 1)
+    _fa4_acquire_stage(FA4_STAGE_QK)
+    pto.mte_load(
+        k_part.as_ptr(),
+        k_mat.as_ptr(),
+        0,
+        bytes_per_row,
+        nburst=(cols, gm_row_stride, mat_row_stride),
+    )
+    pto.mte_load(
+        v_part.as_ptr(),
+        v_mat.as_ptr(),
+        0,
+        bytes_per_row,
+        nburst=(cols, gm_row_stride, mat_row_stride),
+    )
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+    fa4_compute_qk(q_mat, k_mat, q_l0a, rhs_l0b, qk_acc, scores_tile)
+    qk_fifo_part = pto.partition_view(
+        qk_fifo_view,
+        offsets=[qkp_fifo_row_base, 0],
+        sizes=[q_mat.shape[0], scores_tile.shape[1]],
+    )
+    pto.tile.store(scores_tile, qk_fifo_part)
+    _fa4_mark_cv_comm(cv_comm_ptr, cv_comm_base, FA4_COMM_STAGE_QK)
+    _fa4_sync_record(FA4_SYNC_QK2SM)
+    _fa4_release_stage(FA4_STAGE_QK)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+    _fa4_sync_wait(FA4_SYNC_QK2SM)
+    _fa4_acquire_stage(FA4_STAGE_P)
+    if fifo_policy.qk_from_gm_fifo:
+        pto.tile.load(qk_fifo_part, scores_tile)
+    if causal:
+        fa4_apply_causal_mask(
+            scores_tile,
+            score_row_base,
+            q_abs_row_base,
+            kv_abs_col_base,
+            vec_rows,
+            cols,
+        )
+    fa4_compute_p(
+        scores_tile,
+        probs_tile,
+        m_prev_tile,
+        l_prev_tile,
+        m_next_tile,
+        l_next_tile,
+        exp_max_tile,
+        score_row_base,
+        vec_rows,
+        cols,
+        scale,
+    )
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+    pto.tile.cvt(probs_tile, probs_f16_tile)
+    p_fifo_part = pto.partition_view(
+        p_fifo_view,
+        offsets=[qkp_fifo_row_base, 0],
+        sizes=[probs_f16_tile.shape[0], probs_f16_tile.shape[1]],
+    )
+    exp_max_fifo_part = pto.partition_view(
+        exp_max_fifo_view,
+        offsets=[exp_max_fifo_row_base, 0],
+        sizes=[exp_max_tile.shape[0], exp_max_tile.shape[1]],
+    )
+    pto.tile.store(probs_f16_tile, p_fifo_part)
+    pto.tile.store(exp_max_tile, exp_max_fifo_part)
+    _fa4_mark_cv_comm(cv_comm_ptr, cv_comm_base + pto.const(1), FA4_COMM_STAGE_P)
+    _fa4_sync_record_if(should_notify_consume, FA4_SYNC_QK2SM + 1)
+    _fa4_sync_record(FA4_SYNC_UB_BUF + 1)
+    _fa4_sync_record(FA4_SYNC_SM2PV)
+    _fa4_release_stage(FA4_STAGE_P)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+    _fa4_sync_wait(FA4_SYNC_SM2PV)
+    _fa4_sync_wait_if(should_wait_consume, FA4_SYNC_PV2GU + 1)
+    _fa4_acquire_stage(FA4_STAGE_PV)
+    if fifo_policy.p_from_gm_fifo:
+        pto.tile.load(p_fifo_part, p_mat)
+    else:
+        pto.tile.mov(probs_f16_tile, p_mat)
+    fa4_compute_pv(p_mat, v_mat, p_l0a, rhs_l0b, pv_acc, pv_tile)
+    pv_fifo_part = pto.partition_view(
+        pv_fifo_view,
+        offsets=[pv_fifo_row_base, 0],
+        sizes=[pv_tile.shape[0], pv_tile.shape[1]],
+    )
+    pv_pend_fifo_part = pto.partition_view(
+        pv_pend_fifo_view,
+        offsets=[pv_fifo_row_base, 0],
+        sizes=[pv_tile.shape[0], pv_tile.shape[1]],
+    )
+    pto.tile.store(pv_tile, pv_fifo_part)
+    pto.tile.store(pv_tile, pv_pend_fifo_part)
+    _fa4_mark_cv_comm(cv_comm_ptr, cv_comm_base + pto.const(2), FA4_COMM_STAGE_PV)
+    _fa4_sync_record(FA4_SYNC_SM2PV + 1)
+    _fa4_sync_record(FA4_SYNC_PV2GU)
+    _fa4_release_stage(FA4_STAGE_PV)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+    _fa4_sync_wait(FA4_SYNC_PV2GU)
+    _fa4_acquire_stage(FA4_STAGE_GU)
+    if fifo_policy.pv_from_gm_fifo:
+        pto.tile.load(pv_fifo_part, pv_tile)
+        pto.tile.load(pv_pend_fifo_part, pv_pend_tile)
+    pto.tile.load(exp_max_fifo_part, exp_max_tile)
+    fa4_compute_gu(
+        o_prev_tile,
+        pv_tile,
+        exp_max_tile,
+        o_next_tile,
+        vec_rows,
+        dim,
+    )
+    o_parts_part = pto.partition_view(
+        o_parts_view,
+        offsets=[o_parts_row_base, 0],
+        sizes=[o_next_tile.shape[0], o_next_tile.shape[1]],
+    )
+    pto.tile.store(o_next_tile, o_parts_part)
+    _fa4_mark_cv_comm(cv_comm_ptr, cv_comm_base + pto.const(3), FA4_COMM_STAGE_GU)
+    pto.tile.load(o_parts_part, o_next_tile)
+    _fa4_sync_record_if(should_notify_consume, FA4_SYNC_PV2GU + 1)
+    _fa4_sync_record(FA4_SYNC_UB_BUF)
+    _fa4_release_stage(FA4_STAGE_GU)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def emit_flash_atten4_port_mlir(
+    *,
+    s0=MANUAL_S0,
+    s1=DEFAULT_S1,
+    head_dim=MANUAL_HEAD_DIM,
+    cube_s0=MANUAL_CUBE_S0,
+    cube_s1=MANUAL_CUBE_S1,
+    tile_s1=MANUAL_TILE_S1,
+    qk_preload=MANUAL_QK_PRELOAD,
+    cv_fifo_size=MANUAL_CV_FIFO_SIZE,
+    cv_fifo_cons_sync_period=MANUAL_CV_FIFO_CONS_SYNC_PERIOD,
+    fifo_mode=MANUAL_FIFO_MODE,
+    causal=False,
+):
+    if s0 <= 0 or s1 <= 0 or head_dim <= 0:
+        raise ValueError("s0, s1, and head_dim must be positive")
+    if cube_s0 <= 0 or cube_s1 <= 0 or tile_s1 <= 0:
+        raise ValueError("cube_s0, cube_s1, and tile_s1 must be positive")
+    if s0 % cube_s0 != 0:
+        raise ValueError("s0 must be divisible by cube_s0 for the staged flash_atten4 port")
+    if s1 % tile_s1 != 0:
+        raise ValueError("s1 must be divisible by tile_s1 for the staged flash_atten4 port")
+    if tile_s1 % cube_s1 != 0:
+        raise ValueError("tile_s1 must be divisible by cube_s1")
+    if cube_s0 % (MANUAL_VEC_CORES * (tile_s1 // cube_s1)) != 0:
+        raise ValueError("cube_s0 must be divisible by VEC_CORES * TILE_FACTOR")
+    if cube_s0 // MANUAL_VEC_CORES // (tile_s1 // cube_s1) < 16:
+        raise ValueError("row-sliced Vec_S0 must be at least 16 for PTODSL tile layout")
+    if qk_preload not in (3, 4):
+        raise ValueError("qk_preload must be 3 or 4 for the staged flash_atten4 port")
+    if cv_fifo_size <= 0:
+        raise ValueError("cv_fifo_size must be positive")
+    if cv_fifo_cons_sync_period <= 0:
+        raise ValueError("cv_fifo_cons_sync_period must be positive")
+    if fifo_mode not in (0, 1, 2):
+        raise ValueError("fifo_mode must be 0, 1, or 2")
+    if s1 < tile_s1 * qk_preload:
+        raise ValueError("s1 must cover at least qk_preload TILE_S1 tiles")
+
+    compiled = flash_atten4_port_kernel.compile(
+        S0=s0,
+        S1=s1,
+        HEAD_DIM=head_dim,
+        CUBE_S0=cube_s0,
+        CUBE_S1=cube_s1,
+        TILE_S1=tile_s1,
+        QK_PRELOAD=qk_preload,
+        CV_FIFO_SIZE=cv_fifo_size,
+        CV_FIFO_CONS_SYNC_PERIOD=cv_fifo_cons_sync_period,
+        FIFO_MODE=fifo_mode,
+        CAUSAL=causal,
+    )
+    return compiled.mlir_text()
+
+
+@pto.jit(target="a5", mode="explicit", insert_sync=False)
+def flash_atten4_port_kernel(
+    Q_ptr: pto.ptr(pto.f16, "gm"),
+    K_ptr: pto.ptr(pto.f16, "gm"),
+    V_ptr: pto.ptr(pto.f16, "gm"),
+    P_fifo_ptr: pto.ptr(pto.f16, "gm"),
+    Exp_max_fifo_ptr: pto.ptr(pto.f32, "gm"),
+    QK_fifo_ptr: pto.ptr(pto.f32, "gm"),
+    PV_fifo_ptr: pto.ptr(pto.f32, "gm"),
+    PV_pend_fifo_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+    O_parts_ptr: pto.ptr(pto.f32, "gm"),
+    CV_comm_ptr: pto.ptr(pto.ui8, "gm"),
+    *,
+    S0: pto.constexpr = MANUAL_S0,
+    S1: pto.constexpr = DEFAULT_S1,
+    HEAD_DIM: pto.constexpr = MANUAL_HEAD_DIM,
+    CUBE_S0: pto.constexpr = MANUAL_CUBE_S0,
+    CUBE_S1: pto.constexpr = MANUAL_CUBE_S1,
+    TILE_S1: pto.constexpr = MANUAL_TILE_S1,
+    QK_PRELOAD: pto.constexpr = MANUAL_QK_PRELOAD,
+    CV_FIFO_SIZE: pto.constexpr = MANUAL_CV_FIFO_SIZE,
+    CV_FIFO_CONS_SYNC_PERIOD: pto.constexpr = MANUAL_CV_FIFO_CONS_SYNC_PERIOD,
+    FIFO_MODE: pto.constexpr = MANUAL_FIFO_MODE,
+    CAUSAL: pto.constexpr = False,
+):
+    _ = QK_PRELOAD
+    _ = CV_FIFO_SIZE
+    _ = CV_FIFO_CONS_SYNC_PERIOD
+    _ = PV_pend_fifo_ptr
+    _ = O_parts_ptr
+
+    logical_block_count = S0 // CUBE_S0
+    launch_block_count = (
+        logical_block_count
+        if logical_block_count < MANUAL_LAUNCH_CORE_COUNT
+        else MANUAL_LAUNCH_CORE_COUNT
+    )
+    tile_block_count = S1 // TILE_S1
+    tile_factor = TILE_S1 // CUBE_S1
+    vec_s0 = CUBE_S0 // MANUAL_VEC_CORES // tile_factor
+    vec_gu_rows = CUBE_S0 // MANUAL_VEC_CORES
+    scale = pto.const(1.0 / sqrt(float(HEAD_DIM)), dtype=pto.f32)
+
+    q_view = pto.make_tensor_view(Q_ptr, shape=[S0, HEAD_DIM], strides=[HEAD_DIM, 1])
+    k_view = pto.make_tensor_view(K_ptr, shape=[S1, HEAD_DIM], strides=[HEAD_DIM, 1])
+    v_view = pto.make_tensor_view(V_ptr, shape=[S1, HEAD_DIM], strides=[HEAD_DIM, 1])
+    o_view = pto.make_tensor_view(O_ptr, shape=[S0, HEAD_DIM], strides=[HEAD_DIM, 1])
+    o_parts_view = pto.make_tensor_view(O_parts_ptr, shape=[S0, HEAD_DIM], strides=[HEAD_DIM, 1])
+    qk_fifo_view = pto.make_tensor_view(
+        QK_fifo_ptr,
+        shape=[CV_FIFO_SIZE * tile_factor * CUBE_S0, CUBE_S1],
+        strides=[CUBE_S1, 1],
+    )
+    p_fifo_view = pto.make_tensor_view(
+        P_fifo_ptr,
+        shape=[CV_FIFO_SIZE * tile_factor * CUBE_S0, CUBE_S1],
+        strides=[CUBE_S1, 1],
+    )
+    exp_max_fifo_view = pto.make_tensor_view(
+        Exp_max_fifo_ptr,
+        shape=[CV_FIFO_SIZE * CUBE_S0, 1],
+        strides=[1, 1],
+    )
+    pv_fifo_view = pto.make_tensor_view(
+        PV_fifo_ptr,
+        shape=[CV_FIFO_SIZE * CUBE_S0, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+    )
+    pv_pend_fifo_view = pto.make_tensor_view(
+        PV_pend_fifo_ptr,
+        shape=[CV_FIFO_SIZE * CUBE_S0, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+    )
+
+    block_idx = scalar.index_cast(pto.get_block_idx())
+    active_block = block_idx < pto.const(launch_block_count)
+
+    with pto.if_(active_block) as active_block_br:
+        with active_block_br.then_:
+            q_row_base = block_idx * pto.const(CUBE_S0)
+            cube_rows_idx = pto.const(CUBE_S0)
+            vec_rows_idx = pto.const(vec_s0)
+            full_dim_idx = pto.const(HEAD_DIM)
+            cube_rows = pto.const(CUBE_S0, dtype=pto.i32)
+            vec_rows = pto.const(vec_s0, dtype=pto.i32)
+            full_dim = pto.const(HEAD_DIM, dtype=pto.i32)
+            one = pto.const(1, dtype=pto.i32)
+            vec_subblock = scalar.index_cast(pto.get_subblock_idx())
+            vec_subblock_rows = pto.const(vec_gu_rows)
+            stage_comm_bytes_per_block = tile_block_count * tile_factor * 4
+            schedule_comm_bytes_per_block = tile_block_count * 3
+            pending_consumption_events = _fa4_pending_consumption_events(
+                tile_block_count,
+                CV_FIFO_SIZE,
+                CV_FIFO_CONS_SYNC_PERIOD,
+            )
+            ub_drain_count = (
+                tile_block_count
+                if tile_block_count < MANUAL_SRC_VEC_TN_BUFFERS
+                else MANUAL_SRC_VEC_TN_BUFFERS
+            )
+            drain_comm_bytes_per_block = pending_consumption_events * 3 + ub_drain_count * 2 + 1
+            mode_comm_bytes_per_block = 1
+            path_comm_bytes_per_block = 3
+            logical_comm_bytes_per_block = logical_block_count
+            cv_comm_block_base = block_idx * pto.const(
+                stage_comm_bytes_per_block
+                + schedule_comm_bytes_per_block
+                + drain_comm_bytes_per_block
+                + mode_comm_bytes_per_block
+                + path_comm_bytes_per_block
+                + logical_comm_bytes_per_block
+            )
+            schedule_comm_base = cv_comm_block_base + pto.const(stage_comm_bytes_per_block)
+            drain_comm_base = schedule_comm_base + pto.const(schedule_comm_bytes_per_block)
+            mode_comm_base = drain_comm_base + pto.const(drain_comm_bytes_per_block)
+            path_comm_base = mode_comm_base + pto.const(mode_comm_bytes_per_block)
+            logical_comm_base = path_comm_base + pto.const(path_comm_bytes_per_block)
+
+            _fa4_mark_fifo_mode(CV_comm_ptr, mode_comm_base, FIFO_MODE)
+            _fa4_mark_fifo_path(CV_comm_ptr, path_comm_base, FIFO_MODE)
+            _fa4_mark_logical_block_stride(
+                CV_comm_ptr,
+                logical_comm_base,
+                block_idx,
+                logical_block_count,
+                launch_block_count,
+            )
+
+            _fa4_mark_schedule_phases(
+                CV_comm_ptr,
+                schedule_comm_base,
+                tile_block_count,
+                QK_PRELOAD,
+            )
+
+            q_part = pto.partition_view(
+                q_view,
+                offsets=[q_row_base, 0],
+                sizes=[cube_rows_idx, full_dim_idx],
+            )
+
+            q_mat = pto.alloc_tile(
+                shape=[CUBE_S0, HEAD_DIM],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.MAT,
+                valid_shape=[cube_rows, full_dim],
+                blayout="ColMajor",
+                slayout="RowMajor",
+            )
+            q_l0a = pto.alloc_tile(
+                shape=[CUBE_S0, HEAD_DIM],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.LEFT,
+                valid_shape=[cube_rows, full_dim],
+            )
+
+            k_mat = pto.alloc_tile(
+                shape=[CUBE_S1, HEAD_DIM],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.MAT,
+                valid_shape=[pto.const(CUBE_S1, dtype=pto.i32), full_dim],
+                blayout="ColMajor",
+                slayout="RowMajor",
+            )
+            v_mat = pto.alloc_tile(
+                shape=[CUBE_S1, HEAD_DIM],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.MAT,
+                valid_shape=[pto.const(CUBE_S1, dtype=pto.i32), full_dim],
+                blayout="ColMajor",
+                slayout="RowMajor",
+            )
+            rhs_l0b = pto.alloc_tile(
+                shape=[CUBE_S1, HEAD_DIM],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.RIGHT,
+                valid_shape=[pto.const(CUBE_S1, dtype=pto.i32), full_dim],
+            )
+
+            scores_tile = pto.alloc_tile(shape=[CUBE_S0, CUBE_S1], dtype=pto.f32)
+            probs_tile = pto.alloc_tile(shape=[vec_s0, CUBE_S1], dtype=pto.f32)
+            probs_f16_tile = pto.alloc_tile(shape=[vec_s0, CUBE_S1], dtype=pto.f16)
+            p_mat = pto.alloc_tile(
+                shape=[vec_s0, CUBE_S1],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.MAT,
+            )
+            p_l0a = pto.alloc_tile(
+                shape=[vec_s0, CUBE_S1],
+                dtype=pto.f16,
+                memory_space=pto.MemorySpace.LEFT,
+            )
+            qk_acc = pto.alloc_tile(
+                shape=[CUBE_S0, CUBE_S1],
+                dtype=pto.f32,
+                memory_space=pto.MemorySpace.ACC,
+            )
+            pv_acc = pto.alloc_tile(
+                shape=[vec_s0, HEAD_DIM],
+                dtype=pto.f32,
+                memory_space=pto.MemorySpace.ACC,
+                valid_shape=[vec_rows, full_dim],
+            )
+            pv_tile = pto.alloc_tile(
+                shape=[vec_s0, HEAD_DIM],
+                dtype=pto.f32,
+                valid_shape=[vec_rows, full_dim],
+            )
+            pv_pend_tile = pto.alloc_tile(
+                shape=[vec_s0, HEAD_DIM],
+                dtype=pto.f32,
+                valid_shape=[vec_rows, full_dim],
+            )
+
+            o_prev_tile = pto.alloc_tile(shape=[vec_s0, HEAD_DIM], dtype=pto.f32, valid_shape=[vec_rows, full_dim])
+            o_next_tile = pto.alloc_tile(shape=[vec_s0, HEAD_DIM], dtype=pto.f32, valid_shape=[vec_rows, full_dim])
+            m_prev_tile = pto.alloc_tile(shape=[vec_s0, 1], dtype=pto.f32, valid_shape=[vec_rows, one], blayout="ColMajor")
+            m_next_tile = pto.alloc_tile(shape=[vec_s0, 1], dtype=pto.f32, valid_shape=[vec_rows, one], blayout="ColMajor")
+            l_prev_tile = pto.alloc_tile(shape=[vec_s0, 1], dtype=pto.f32, valid_shape=[vec_rows, one], blayout="ColMajor")
+            l_next_tile = pto.alloc_tile(shape=[vec_s0, 1], dtype=pto.f32, valid_shape=[vec_rows, one], blayout="ColMajor")
+            exp_max_tile = pto.alloc_tile(shape=[vec_s0, 1], dtype=pto.f32, valid_shape=[vec_rows, one], blayout="ColMajor")
+            o_final_tile = pto.alloc_tile(shape=[vec_s0, HEAD_DIM], dtype=pto.f32, valid_shape=[vec_rows, full_dim])
+
+            pto.tile.load(q_part, q_mat)
+
+            with pto.for_(0, pto.const(tile_factor), step=1) as row_slice:
+                row_slice_base = (
+                    q_row_base
+                    + vec_subblock * vec_subblock_rows
+                    + row_slice * pto.const(vec_s0)
+                )
+                score_row_index = (
+                    vec_subblock * vec_subblock_rows
+                    + row_slice * pto.const(vec_s0)
+                )
+                m_prev_tile.fill(float("-inf"))
+                l_prev_tile.fill(0.0)
+                o_prev_tile.fill(0.0)
+
+                with pto.for_(0, pto.const(tile_block_count), step=1) as tile_id:
+                    with pto.for_(0, pto.const(tile_factor), step=1) as sub_tile:
+                        fifo_slot = tile_id % pto.const(CV_FIFO_SIZE)
+                        qkp_fifo_row_base = (
+                            fifo_slot * pto.const(tile_factor * CUBE_S0)
+                            + sub_tile * pto.const(CUBE_S0)
+                            + score_row_index
+                        )
+                        exp_max_fifo_row_base = (
+                            fifo_slot * pto.const(CUBE_S0)
+                            + score_row_index
+                        )
+                        pv_fifo_row_base = (
+                            fifo_slot * pto.const(CUBE_S0)
+                            + score_row_index
+                        )
+                        cv_comm_base = (
+                            cv_comm_block_base
+                            + (
+                                tile_id * pto.const(tile_factor)
+                                + sub_tile
+                            )
+                            * pto.const(4)
+                        )
+                        kv_row_base = (
+                            tile_id * pto.const(TILE_S1)
+                            + sub_tile * pto.const(CUBE_S1)
+                        )
+                        kv_rows_idx = pto.const(CUBE_S1)
+                        kv_rows = pto.const(CUBE_S1, dtype=pto.i32)
+
+                        k_part = pto.partition_view(
+                            k_view,
+                            offsets=[kv_row_base, 0],
+                            sizes=[kv_rows_idx, full_dim_idx],
+                        )
+                        v_part = pto.partition_view(
+                            v_view,
+                            offsets=[kv_row_base, 0],
+                            sizes=[kv_rows_idx, full_dim_idx],
+                        )
+
+                        fa4_process_subtile(
+                            q_mat,
+                            k_part,
+                            v_part,
+                            qk_fifo_view,
+                            p_fifo_view,
+                            exp_max_fifo_view,
+                            pv_fifo_view,
+                            pv_pend_fifo_view,
+                            o_parts_view,
+                            CV_comm_ptr,
+                            row_slice_base,
+                            kv_row_base,
+                            k_mat,
+                            v_mat,
+                            o_prev_tile,
+                            o_next_tile,
+                            m_prev_tile,
+                            l_prev_tile,
+                            m_next_tile,
+                            l_next_tile,
+                            scores_tile,
+                            probs_tile,
+                            probs_f16_tile,
+                            p_mat,
+                            pv_tile,
+                            pv_pend_tile,
+                            exp_max_tile,
+                            q_l0a,
+                            p_l0a,
+                            rhs_l0b,
+                            qk_acc,
+                            pv_acc,
+                            tile_id,
+                            qkp_fifo_row_base,
+                            exp_max_fifo_row_base,
+                            pv_fifo_row_base,
+                            cv_comm_base,
+                            row_slice_base,
+                            scalar.index_cast(
+                                pto.i32,
+                                score_row_index,
+                            ),
+                            vec_rows,
+                            kv_rows,
+                            full_dim,
+                            scale,
+                            CV_FIFO_SIZE,
+                            CV_FIFO_CONS_SYNC_PERIOD,
+                            FIFO_MODE,
+                            CAUSAL,
+                        )
+
+                        pto.tile.mov(m_next_tile, m_prev_tile)
+                        pto.tile.mov(l_next_tile, l_prev_tile)
+                        pto.tile.mov(o_next_tile, o_prev_tile)
+
+                o_part = pto.partition_view(
+                    o_view,
+                    offsets=[row_slice_base, 0],
+                    sizes=[vec_rows_idx, full_dim_idx],
+                )
+                fa4_finalize_o(o_prev_tile, l_prev_tile, o_final_tile, vec_rows, full_dim)
+                pto.tile.store(o_final_tile, o_part)
+
+                _fa4_drain_pending_syncs(
+                    CV_comm_ptr,
+                    drain_comm_base,
+                    tile_block_count,
+                    CV_FIFO_SIZE,
+                    CV_FIFO_CONS_SYNC_PERIOD,
+                )
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Emit compile-only PTODSL MLIR for the A5 flash_atten4 port.",
+    )
+    parser.add_argument("--s0", type=int, default=MANUAL_S0)
+    parser.add_argument("--s1", type=int, default=DEFAULT_S1)
+    parser.add_argument("--head-dim", type=int, default=MANUAL_HEAD_DIM)
+    parser.add_argument("--cube-s0", type=int, default=MANUAL_CUBE_S0)
+    parser.add_argument("--cube-s1", type=int, default=MANUAL_CUBE_S1)
+    parser.add_argument("--tile-s1", type=int, default=MANUAL_TILE_S1)
+    parser.add_argument("--qk-preload", type=int, default=MANUAL_QK_PRELOAD, choices=(3, 4))
+    parser.add_argument("--cv-fifo-size", type=int, default=MANUAL_CV_FIFO_SIZE)
+    parser.add_argument(
+        "--cv-fifo-cons-sync-period",
+        type=int,
+        default=MANUAL_CV_FIFO_CONS_SYNC_PERIOD,
+    )
+    parser.add_argument("--fifo-mode", type=int, default=MANUAL_FIFO_MODE, choices=(0, 1, 2))
+    parser.add_argument("--causal", action="store_true")
+    parser.add_argument("-o", "--output", default="-", help="output MLIR path, or '-' for stdout")
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    mlir_text = emit_flash_atten4_port_mlir(
+        s0=args.s0,
+        s1=args.s1,
+        head_dim=args.head_dim,
+        cube_s0=args.cube_s0,
+        cube_s1=args.cube_s1,
+        tile_s1=args.tile_s1,
+        qk_preload=args.qk_preload,
+        cv_fifo_size=args.cv_fifo_size,
+        cv_fifo_cons_sync_period=args.cv_fifo_cons_sync_period,
+        fifo_mode=args.fifo_mode,
+        causal=args.causal,
+    )
+    if args.output == "-":
+        print(mlir_text)
+        return
+    Path(args.output).write_text(mlir_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_flash_atten4_port_compile.py
+++ b/ptodsl/tests/test_flash_atten4_port_compile.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import tempfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
+
+from ptodsl._bootstrap import make_context
+from mlir.ir import Module
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_parse_roundtrip_and_verify(text: str, label: str) -> None:
+    with make_context() as ctx:
+        parsed = Module.parse(text, ctx)
+        parsed.operation.verify()
+        roundtrip_text = str(parsed)
+    expect(
+        roundtrip_text == text,
+        f"{label} should survive Module.parse(...) round-trip without textual drift",
+    )
+
+
+def load_demo():
+    demo_path = REPO_ROOT / "ptodsl" / "examples" / "flash_atten4_port.py"
+    expect(demo_path.is_file(), f"missing flash_atten4 port demo: {demo_path}")
+
+    spec = spec_from_file_location("ptodsl_flash_atten4_port_demo", demo_path)
+    expect(spec is not None and spec.loader is not None, f"unable to create import spec for {demo_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    demo = load_demo()
+
+    expect(
+        hasattr(demo, "emit_flash_atten4_port_mlir"),
+        "flash_atten4 port demo should export emit_flash_atten4_port_mlir(...)",
+    )
+    expect(
+        hasattr(demo, "flash_atten4_port_kernel"),
+        "flash_atten4 port demo should export flash_atten4_port_kernel",
+    )
+    expect(
+        hasattr(demo, "build_arg_parser"),
+        "flash_atten4 port demo should expose a CLI argument parser",
+    )
+    expect(
+        hasattr(demo, "describe_flash_atten4_frontend_plan"),
+        "flash_atten4 port demo should expose its frontend stage/FIFO plan",
+    )
+    frontend_plan = demo.describe_flash_atten4_frontend_plan(fifo_mode=1)
+    expect(
+        [stage["name"] for stage in frontend_plan["stages"]] == ["qk", "p", "pv", "gu"],
+        f"unexpected frontend stage order: {frontend_plan!r}",
+    )
+    expect(
+        frontend_plan["fifo_policy"] == {
+            "qk_from_gm_fifo": False,
+            "p_from_gm_fifo": False,
+            "pv_from_gm_fifo": False,
+        },
+        f"unexpected FIFO_MODE=1 frontend policy: {frontend_plan!r}",
+    )
+
+    wrapper_text = demo.emit_flash_atten4_port_mlir(
+        s0=128,
+        s1=1024,
+        head_dim=128,
+        cube_s0=128,
+        cube_s1=128,
+        tile_s1=256,
+        qk_preload=4,
+        cv_fifo_size=8,
+        cv_fifo_cons_sync_period=4,
+        fifo_mode=1,
+        causal=False,
+    )
+    expect_parse_roundtrip_and_verify(wrapper_text, "flash_atten4 port wrapper-emitted MLIR")
+    expect("func.func @flash_atten4_port_kernel" in wrapper_text, "wrapper compile should emit the port kernel entry")
+    expect('pto.mode = "explicit"' in wrapper_text, "wrapper compile should carry explicit mode metadata")
+    expect("pto.tcvt" in wrapper_text, "wrapper compile should keep the P fp32->f16 conversion stage")
+    expect(wrapper_text.count("pto.mad") == 2, "wrapper compile should keep the two cube matmul stages")
+    expect(wrapper_text.count("pto.sync.set <PIPE_FIX>") >= 8, "wrapper compile should expose A5 FFTS producer/backpressure markers")
+    expect(wrapper_text.count("pto.sync.wait <PIPE_FIX>") >= 10, "wrapper compile should expose A5 FFTS consumer/backpressure/drain markers")
+    expect("!pto.tensor_view<2048x128xf32>" in wrapper_text, "wrapper compile should size QK FIFO as CV_FIFO_SIZE*TILE_FACTOR*CUBE_S0")
+    expect("!pto.tensor_view<2048x128xf16>" in wrapper_text, "wrapper compile should size P FIFO as CV_FIFO_SIZE*TILE_FACTOR*CUBE_S0")
+    expect(wrapper_text.count("pto.get_buf") >= 4, "wrapper compile should expose stage acquire lifecycle ops")
+    expect(wrapper_text.count("pto.rls_buf") >= 4, "wrapper compile should expose stage release lifecycle ops")
+    expect(wrapper_text.count("pto.tstore") >= 6, "wrapper compile should keep ptr-compatible scratch stores for QK/P/PV/PV_pend/exp_max/O_parts")
+    expect(wrapper_text.count("pto.tload") >= 3, "wrapper compile should keep required Q/O/scratch reloads in FIFO_MODE=1")
+    expect(wrapper_text.count("!pto.ptr<ui8, gm>, ui8") >= 4, "wrapper compile should write CV communication stage markers")
+    expect("arith.constant 10 : i8" in wrapper_text, "wrapper compile should mark the QK_PRELOAD prologue phase")
+    expect("arith.constant 20 : i8" in wrapper_text, "wrapper compile should mark the steady phase")
+    expect("arith.constant 30 : i8" in wrapper_text, "wrapper compile should mark the epilogue phase")
+    expect("arith.constant 50 : i8" in wrapper_text, "wrapper compile should mark qk2sm drain")
+    expect("arith.constant 51 : i8" in wrapper_text, "wrapper compile should mark sm2pv drain")
+    expect("arith.constant 52 : i8" in wrapper_text, "wrapper compile should mark pv2gu drain")
+    expect("arith.constant 53 : i8" in wrapper_text, "wrapper compile should mark ubBuf drain")
+    expect("arith.constant 54 : i8" in wrapper_text, "wrapper compile should mark pvUbBuf drain")
+    expect("arith.constant 55 : i8" in wrapper_text, "wrapper compile should mark CV block end")
+    expect("arith.constant 61 : i8" in wrapper_text, "wrapper compile should mark FIFO_MODE=1 ALL_UB")
+    expect("arith.constant 81 : i8" in wrapper_text, "wrapper compile should mark QK UB handoff for FIFO_MODE=1")
+    expect("arith.constant 83 : i8" in wrapper_text, "wrapper compile should mark P UB handoff for FIFO_MODE=1")
+    expect("arith.constant 85 : i8" in wrapper_text, "wrapper compile should mark PV UB handoff for FIFO_MODE=1")
+    expect("arith.constant 70 : i8" in wrapper_text, "wrapper compile should mark launch-core logical-block striding")
+    expect(wrapper_text.count("scf.for") >= 2, "wrapper compile should keep the tile loop and subtile loop structure")
+    expect("!pto.tile_buf<mat, 32x128xf16" in wrapper_text, "wrapper compile should materialize the A5 row-sliced Q MAT tile")
+    expect("!pto.tile_buf<vec, 32x128xf32" in wrapper_text, "wrapper compile should materialize the A5 row-sliced score/prob subtile")
+    expect("!pto.tile_buf<vec, 32x128xf32" in wrapper_text, "wrapper compile should materialize the A5 row-sliced running O subtile")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cli_output = Path(tmpdir) / "fa4_cli.mlir"
+        demo.main([
+            "--s0", "128",
+            "--s1", "1024",
+            "--head-dim", "128",
+            "--cube-s0", "128",
+            "--cube-s1", "128",
+            "--tile-s1", "256",
+            "--qk-preload", "4",
+            "--cv-fifo-size", "8",
+            "--cv-fifo-cons-sync-period", "4",
+            "--fifo-mode", "1",
+            "-o", str(cli_output),
+        ])
+        cli_text = cli_output.read_text(encoding="utf-8")
+        expect_parse_roundtrip_and_verify(cli_text, "flash_atten4 CLI-emitted MLIR")
+        expect("func.func @flash_atten4_port_kernel" in cli_text, "CLI output should contain the kernel entry")
+
+    compiled = demo.flash_atten4_port_kernel.compile(
+        S0=64,
+        S1=128,
+        HEAD_DIM=128,
+        CUBE_S0=32,
+        CUBE_S1=64,
+        TILE_S1=64,
+        QK_PRELOAD=4,
+        CV_FIFO_SIZE=8,
+        CV_FIFO_CONS_SYNC_PERIOD=4,
+        FIFO_MODE=1,
+        CAUSAL=True,
+    )
+    compiled.verify()
+
+    expect(
+        compiled.constexpr_bindings == {
+            "S0": 64,
+            "S1": 128,
+            "HEAD_DIM": 128,
+            "CUBE_S0": 32,
+            "CUBE_S1": 64,
+            "TILE_S1": 64,
+            "QK_PRELOAD": 4,
+            "CV_FIFO_SIZE": 8,
+            "CV_FIFO_CONS_SYNC_PERIOD": 4,
+            "FIFO_MODE": 1,
+            "CAUSAL": True,
+        },
+        f"unexpected constexpr bindings: {compiled.constexpr_bindings!r}",
+    )
+
+    specialized_text = compiled.mlir_text()
+    expect_parse_roundtrip_and_verify(specialized_text, "flash_atten4 port specialized MLIR")
+    expect(specialized_text.count("pto.mad") == 2, "specialized compile should still keep the two cube matmul stages")
+    expect(specialized_text.count("pto.sync.set <PIPE_FIX>") >= 8, "specialized compile should still expose FFTS producer/backpressure markers")
+    expect(specialized_text.count("pto.sync.wait <PIPE_FIX>") >= 10, "specialized compile should still expose FFTS consumer/backpressure/drain markers")
+    expect("0xFF800000" in specialized_text, "CAUSAL=True specialization should materialize -inf score masking")
+    expect("arith.cmpi sgt" in specialized_text, "CAUSAL=True specialization should compare kv column against q row")
+    expect("pto.tcvt" in specialized_text, "specialized compile should still keep the P fp32->f16 conversion stage")
+    expect("!pto.tile_buf<mat, 16x64xf16" in specialized_text, "TILE_S1=CUBE_S1 specialization should shrink the row-sliced subtile MAT shape")
+
+    for fifo_mode, marker, path_markers in (
+        (0, "arith.constant 60 : i8", ("arith.constant 80 : i8", "arith.constant 82 : i8", "arith.constant 84 : i8")),
+        (2, "arith.constant 62 : i8", ("arith.constant 81 : i8", "arith.constant 82 : i8", "arith.constant 85 : i8")),
+    ):
+        mode_text = demo.flash_atten4_port_kernel.compile(
+            S0=64,
+            S1=128,
+            HEAD_DIM=128,
+            CUBE_S0=32,
+            CUBE_S1=64,
+            TILE_S1=64,
+            QK_PRELOAD=4,
+            CV_FIFO_SIZE=8,
+            CV_FIFO_CONS_SYNC_PERIOD=4,
+            FIFO_MODE=fifo_mode,
+            CAUSAL=False,
+        ).mlir_text()
+        expect_parse_roundtrip_and_verify(mode_text, f"flash_atten4 FIFO_MODE={fifo_mode} MLIR")
+        expect(marker in mode_text, f"FIFO_MODE={fifo_mode} compile should materialize marker {marker}")
+        expect(all(path_marker in mode_text for path_marker in path_markers), f"FIFO_MODE={fifo_mode} should materialize handoff path markers {path_markers}")
+        if fifo_mode == 0:
+            expect(mode_text.count("pto.tload") >= 7, "FIFO_MODE=0 should keep all GM FIFO consumer reloads")
+
+    launch_cap_text = demo.flash_atten4_port_kernel.compile(
+        S0=4096,
+        S1=1024,
+        HEAD_DIM=128,
+        CUBE_S0=128,
+        CUBE_S1=128,
+        TILE_S1=256,
+        QK_PRELOAD=4,
+        CV_FIFO_SIZE=8,
+        CV_FIFO_CONS_SYNC_PERIOD=4,
+        FIFO_MODE=1,
+        CAUSAL=False,
+    ).mlir_text()
+    expect_parse_roundtrip_and_verify(launch_cap_text, "flash_atten4 launch cap MLIR")
+    expect("arith.constant 28 : index" in launch_cap_text, "launch cap compile should materialize kFaLaunchCoreCount=28")
+    expect("arith.constant 70 : i8" in launch_cap_text, "launch cap compile should keep logical-block stride marker")
+
+    cached = demo.flash_atten4_port_kernel.cached_specializations()
+    expect(len(cached) >= 2, "wrapper compile plus direct compile should populate cached specializations")
+    print("ptodsl_flash_atten4_port_compile: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_flash_atten4_port_frontend_verify.py
+++ b/ptodsl/tests/test_flash_atten4_port_frontend_verify.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def resolve_ptoas_binary() -> Path:
+    candidates = [
+        REPO_ROOT / "build" / "tools" / "ptoas" / "ptoas",
+        REPO_ROOT / "install" / "bin" / "ptoas",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    from_path = shutil.which("ptoas")
+    if from_path:
+        return Path(from_path)
+
+    raise FileNotFoundError("unable to locate a ptoas binary under build/, install/, or PATH")
+
+
+def run_ptoas_frontend_verify(ptoas_bin: Path, mlir_text: str, label: str) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False, encoding="utf-8") as handle:
+        handle.write(mlir_text)
+        input_path = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [str(ptoas_bin), str(input_path), "--emit-pto-ir", "-o", "-"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    expect(
+        result.returncode == 0,
+        f"{label} should pass PTOAS frontend verification.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    expect(result.stdout.strip(), f"{label} should emit non-empty PTO IR after PTOAS frontend passes")
+    return result.stdout
+
+
+def load_demo():
+    demo_path = REPO_ROOT / "ptodsl" / "examples" / "flash_atten4_port.py"
+    expect(demo_path.is_file(), f"missing flash_atten4 port demo: {demo_path}")
+
+    spec = spec_from_file_location("ptodsl_flash_atten4_port_demo", demo_path)
+    expect(spec is not None and spec.loader is not None, f"unable to create import spec for {demo_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    ptoas_bin = resolve_ptoas_binary()
+    demo = load_demo()
+
+    mlir_text = demo.flash_atten4_port_kernel.compile(
+        S0=128,
+        S1=256,
+        HEAD_DIM=128,
+        CUBE_S0=64,
+        CUBE_S1=64,
+        TILE_S1=128,
+        QK_PRELOAD=4,
+        CV_FIFO_SIZE=8,
+        CV_FIFO_CONS_SYNC_PERIOD=4,
+        FIFO_MODE=1,
+        CAUSAL=False,
+    ).mlir_text()
+
+    frontend_text = run_ptoas_frontend_verify(
+        ptoas_bin,
+        mlir_text,
+        "flash_atten4_port PTODSL artifact",
+    )
+    expect(
+        "func.func @flash_atten4_port_kernel" in frontend_text,
+        "frontend verification output should preserve the flash_atten4_port_kernel symbol",
+    )
+    expect(
+        frontend_text.count("pto.mad") == 2,
+        "frontend verification output should keep the two cube matmul stages visible",
+    )
+    expect(
+        "pto.tcvt" in frontend_text,
+        "frontend verification output should keep the P fp32->f16 conversion stage visible",
+    )
+    expect(
+        frontend_text.count("pto.get_buf") >= 4,
+        "frontend verification output should keep stage acquire lifecycle ops visible",
+    )
+    expect(
+        frontend_text.count("pto.rls_buf") >= 4,
+        "frontend verification output should keep stage release lifecycle ops visible",
+    )
+    expect(
+        frontend_text.count("pto.tload") >= 3,
+        "frontend verification output should keep required Q/O/scratch reloads visible in FIFO_MODE=1",
+    )
+    expect(
+        frontend_text.count("memref<?xui8, #pto.address_space<gm>>, ui8") >= 4,
+        "frontend verification output should keep CV communication stage marker stores visible",
+    )
+    expect(
+        all(marker in frontend_text for marker in ("arith.constant 10 : i8", "arith.constant 20 : i8", "arith.constant 30 : i8")),
+        "frontend verification output should keep prologue/steady/epilogue schedule markers visible",
+    )
+    expect(
+        all(marker in frontend_text for marker in ("arith.constant 50 : i8", "arith.constant 51 : i8", "arith.constant 52 : i8", "arith.constant 53 : i8")),
+        "frontend verification output should keep pending sync drain markers visible",
+    )
+    expect(
+        all(marker in frontend_text for marker in ("arith.constant 54 : i8", "arith.constant 55 : i8")),
+        "frontend verification output should keep pvUb drain and CV block end markers visible",
+    )
+    expect(
+        "arith.constant 61 : i8" in frontend_text,
+        "frontend verification output should keep FIFO_MODE=1 ALL_UB marker visible",
+    )
+    expect(
+        all(marker in frontend_text for marker in ("arith.constant 81 : i8", "arith.constant 83 : i8", "arith.constant 85 : i8")),
+        "frontend verification output should keep FIFO_MODE=1 UB handoff path markers visible",
+    )
+    expect(
+        "arith.constant 70 : i8" in frontend_text,
+        "frontend verification output should keep launch-core logical-block stride marker visible",
+    )
+    expect(
+        frontend_text.count("pto.sync.set <PIPE_FIX>") >= 8,
+        "frontend verification output should keep A5 FFTS producer/backpressure markers visible",
+    )
+    expect(
+        frontend_text.count("pto.sync.wait <PIPE_FIX>") >= 10,
+        "frontend verification output should keep A5 FFTS consumer/backpressure/drain markers visible",
+    )
+
+    causal_mlir_text = demo.flash_atten4_port_kernel.compile(
+        S0=64,
+        S1=128,
+        HEAD_DIM=128,
+        CUBE_S0=64,
+        CUBE_S1=64,
+        TILE_S1=64,
+        QK_PRELOAD=4,
+        CV_FIFO_SIZE=8,
+        CV_FIFO_CONS_SYNC_PERIOD=4,
+        FIFO_MODE=1,
+        CAUSAL=True,
+    ).mlir_text()
+    causal_frontend_text = run_ptoas_frontend_verify(
+        ptoas_bin,
+        causal_mlir_text,
+        "flash_atten4_port causal PTODSL artifact",
+    )
+    expect(
+        "0xFF800000" in causal_frontend_text and "arith.cmpi sgt" in causal_frontend_text,
+        "frontend verification output should preserve CAUSAL=True score masking",
+    )
+
+    for fifo_mode, marker, path_markers in (
+        (0, "arith.constant 60 : i8", ("arith.constant 80 : i8", "arith.constant 82 : i8", "arith.constant 84 : i8")),
+        (2, "arith.constant 62 : i8", ("arith.constant 81 : i8", "arith.constant 82 : i8", "arith.constant 85 : i8")),
+    ):
+        mode_mlir_text = demo.flash_atten4_port_kernel.compile(
+            S0=64,
+            S1=128,
+            HEAD_DIM=128,
+            CUBE_S0=64,
+            CUBE_S1=64,
+            TILE_S1=64,
+            QK_PRELOAD=4,
+            CV_FIFO_SIZE=8,
+            CV_FIFO_CONS_SYNC_PERIOD=4,
+            FIFO_MODE=fifo_mode,
+            CAUSAL=False,
+        ).mlir_text()
+        mode_frontend_text = run_ptoas_frontend_verify(
+            ptoas_bin,
+            mode_mlir_text,
+            f"flash_atten4_port FIFO_MODE={fifo_mode} PTODSL artifact",
+        )
+        expect(marker in mode_frontend_text, f"frontend output should preserve FIFO_MODE={fifo_mode} marker")
+        expect(
+            all(path_marker in mode_frontend_text for path_marker in path_markers),
+            f"frontend output should preserve FIFO_MODE={fifo_mode} handoff path markers",
+        )
+        if fifo_mode == 0:
+            expect(
+                mode_frontend_text.count("pto.tload") >= 7,
+                "FIFO_MODE=0 frontend output should keep all GM FIFO consumer reloads visible",
+            )
+
+    print("ptodsl_flash_atten4_port_frontend_verify: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a PTODSL compile/frontend port of the A5 flash_atten4 kernel
- Cover the ptr/tile-buffer handoff needed by A2/A3-compatible entry operands
- Add docs and PTODSL tests for CLI generation and frontend PTO IR emission

## Scope
- Runtime/backend lowering for softmax and remaining TileOps is intentionally out of scope
- A5/A3 hardware runtime validation is not included in this PR

## Validation
- Windows: python -m py_compile for the new example/tests
- Windows: git diff --check
- dev-481211: python3 ptodsl/tests/test_flash_atten4_port_compile.py
- dev-481211: python3 ptodsl/tests/test_flash_atten4_port_frontend_verify.py
- dev-481211: python3 ptodsl/examples/flash_atten4_port.py -o /tmp/fa4_doc_cli.mlir && ptoas /tmp/fa4_doc_cli.mlir --emit-pto-ir -o /tmp/fa4_doc_cli.pto