### PR TITLE
Draft: Port hw-native flash attention example to PTODSL

### DIFF
--- a/docs/designs/hw_native_flash_attention_ptodsl_port_zh.md
+++ b/docs/designs/hw_native_flash_attention_ptodsl_port_zh.md
@@ -2,19 +2,21 @@
 
 ## 来源
 
-实际迁移来源是：
+实际迁移来源：
 
 ```text
 https://github.com/hw-native-sys/pto-isa/tree/main/kernels/python/flash_atten
 ```
 
-核心文件是：
+核心参考文件：
 
 ```text
 kernels/python/flash_atten/kernels/fa_builder.py
 ```
 
-该实现使用的是旧的外部 `huawei-csl/pto-dsl` 包，不是 PTOAS 仓内当前的 `ptodsl/` API。本迁移的目标是把它的 Python DSL kernel 表达改写成当前 PTOAS PTODSL 表面。
+源实现使用的是旧的外部 `huawei-csl/pto-dsl` 包，不是 PTOAS 仓内当前的
+`ptodsl/` API。本迁移的目标是把它的 Python DSL kernel 表达改写成当前
+PTOAS PTODSL 表面。
 
 ## 当前文件
 
@@ -22,72 +24,93 @@ kernels/python/flash_atten/kernels/fa_builder.py
 ptodsl/examples/hw_native_flash_attention.py
 ```
 
-这个文件按 `fa_builder.py` 的结构组织，作为独立迁移示例存在；原有 PTOAS `flash_attention_sketch.py` 保持不动，避免把教学 sketch 和 hw-native port 混在一起。
+这个文件按 `fa_builder.py` 的结构组织，作为独立迁移示例存在；原有
+PTOAS `flash_attention_sketch.py` 保持不动，避免把教学 sketch 和
+hw-native port 混在一起。
 
 保留的源实现结构：
 
 ```text
-compute_qk  : Cube 侧 Q/K matmul，写 QK GM slot
-compute_p   : SIMD 侧 streaming softmax，写 P GM slot
-compute_pv  : Cube 侧 P/V matmul，写 PV GM slot
+compute_qk  : Cube 侧 Q/K matmul，产生 QK stage
+compute_p   : SIMD 侧 streaming softmax，产生 P stage
+compute_pv  : Cube 侧 P/V matmul，产生 PV stage
 compute_gu  : SIMD 侧使用未归一化 running O 语义更新 O
 finalize    : 最后用 running_sum 归一化 O
 ```
 
-当前已补齐的 PTO-DSL/frontend 表达：
+当前已经补齐的 PTO-DSL/frontend 表达：
 
 ```text
-QK_PRELOAD prologue / steady / epilogue shadow schedule
+QK_PRELOAD prologue / steady / epilogue schedule
+A5 local pipe surface for QK/P/PV stage boundaries
 Vec_S0 row-slice 状态数组
 exp_max_ring 按 preload slot 和 row-slice 保存
 P slot 先按 [Vec_S0, S1_TILE] 生产，再按 [S0, CUBE_S1] 消费
 block_idx/block_num 的 Q block 分发
 ```
 
-## API 映射
+## 当前 pipe 状态
+
+之前文档里写的“PTODSL 前端不能写出 tpush/tpop/tfree”已经过期。
+
+当前 FA 代码已经使用 PTOAS PTODSL 的 pipe surface：
 
 ```text
-旧 to_ir_module_with_meta(...)       -> @pto.jit(...).compile(...).mlir_text()
-旧 TensorType/SubTensorType 全局类型 -> pto.ptr + pto.make_tensor_view + pto.partition_view
-旧 declare_global + FIFO entry       -> 显式 GM slot tensor view
-旧 pto.load/pto.store                -> pto.tile.load / pto.tile.store
-旧 tile.matmul / matmul_acc          -> @pto.cube + pto.mad / pto.mad_acc
-旧 vector row-reduce softmax/GU      -> @pto.simd + tile row/reduce/expand ops
+pto.reserve_buffer(...)
+pto.pipe.c2v_local(...)
+pto.pipe.v2c_local(...)
+pipe.init_cube()
+pipe.init_simd()
+pipe.push(...)
+pipe.pop(...)
+pipe.free(...)
 ```
 
-## 接口差距清单
+在生成的 MLIR 里，FA 已能看到这些 frontend pipe op：
 
-下面这张表按“`fa_builder.py` 里已有、但当前 PTOAS PTODSL 前端还没有直接等价接口”的方式列差距。
+```text
+pto.aic_initialize_pipe
+pto.aiv_initialize_pipe
+pto.tpush_to_aiv
+pto.tpop_from_aic
+pto.tpush_to_aic
+pto.tpop_from_aiv
+pto.tfree_from_aic
+pto.tfree_from_aiv
+```
 
-| 旧实现接口 | 当前 PTODSL 状态 | 库内是否已有接近实现 | 影响 |
-| --- | --- | --- | --- |
-| `initialize_l2g2l_pipe(...)` | 无同名公开 API | 有，IR/EmitC/transform 已有 `pto.initialize_l2g2l_pipe` | 只能把 FIFO 语义压成 shadow schedule，不能直出真实 pipe |
-| `declare_global(...)` | 无同名公开 API | 有 `pto.declare_global` / `pto.declare_tile` 的 IR 侧设计 | 不能直接表达 global entry descriptor |
-| `talloc/tpush/tpop/tfree` | 无同名公开 API | 有 `pto.talloc* / pto.tpush* / pto.tpop* / pto.tfree*` 及 lowerer | Python 前端还不能写出这条流水协议 |
-| `TensorType/SubTensorType` | 仅有 `ptr + make_tensor_view + partition_view` | 有更底层的 `tile_buf` / `tensor_view` 类型体系 | 类型层能描述，但前端不够贴近原始写法 |
-| `pto.func / pto.call` | 当前主要靠 `@pto.jit` 和 Python trace | 库内有 module/kernel kind / section 体系 | 可组织 kernel，但不等于原 builder 的显式函数调度 |
-| `section.cube/vector` | PTODSL 有 `@pto.cube/@pto.simd/@pto.simt` 辅助 | 有 `pto.section.cube/vector` 和 `pto.kernel_kind` | 能分流，但不是 `fa_builder.py` 的完整执行流建模 |
-| `ffts_type / set_ffts` | 无公开对应 | 内部存在更底层的 pipe / sync / target 相关实现 | 目前只能做部分同步面表达 |
+也就是说，`tpop` 不是当前 FA 前端的缺失项了。现在的限制是：FA 的 pipe
+transaction 已经能在 PTODSL/frontend MLIR 里表达，但 runtime 正确性和性能
+benchmark 仍需要后端/runtime 继续完成真实 FIFO 调度、生命周期和 A5/A3 运行验证。
 
-结论是：**库里不是没有接近实现，而是接近实现主要存在于 PTO dialect、verify、lowering 和 EmitC 层，当前 PTODSL 公共 Python 面还没把这些能力完整抬上来。**
+## API 映射
 
-## 库内已有的接近实现
+| 旧实现接口 | 当前 PTODSL 表达 | 当前状态 |
+| --- | --- | --- |
+| `to_ir_module_with_meta(...)` | `@pto.jit(...).compile(...).mlir_text()` | 已迁移 |
+| `TensorType/SubTensorType` | `pto.ptr + pto.make_tensor_view + pto.partition_view` | 已迁移 |
+| `declare_global(...)` | 显式 GM slot tensor view | 已迁移为 frontend slot 表达 |
+| `pto.load/pto.store` | `pto.tile.load / pto.tile.store` | 已迁移 |
+| `tile.matmul / matmul_acc` | `@pto.cube + pto.mad / pto.mad_acc` | 已迁移 |
+| vector row-reduce softmax/GU | `@pto.simd + tile row/reduce/expand ops` | 已迁移 |
+| `initialize_l2g2l_pipe` | `pto.pipe.c2v_local / v2c_local + reserve_buffer` | A5 local pipe surface 已接入 |
+| `talloc/tpush/tpop/tfree` | `pipe.push / pipe.pop / pipe.free` | frontend transaction 已接入 |
+| `ffts_type / set_ffts` | 暂无同名 PTODSL API | 真实 runtime 调度仍属后端/runtime 工作 |
 
-这部分是前面容易漏看的地方，也是这次分析里要单独说明的结论。
+## 和 `fa_builder.py` 的剩余差距
 
-1. `include/PTO/IR/PTOOps.td` 和 `lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp` 已经有 `initialize_l2g2l_pipe`、`talloc`、`tpush`、`tpop`、`tfree` 这一整条前端 pipe 协议，以及对应的 lowerer。
+剩余差距不再是“PTODSL 没有 tpop API”，而是下面这些更低层的问题：
 
-2. `include/PTO/IR/PTOOps.td` 和 `lib/PTO/Transforms/PTOWrapFunctionsInSectionsPass.cpp`、`lib/PTO/Transforms/VPTOSplitCVModule.cpp` 已经有 `pto.section.cube/vector`、`pto.kernel_kind` 以及 cube/vector 模块拆分能力。
-
-3. `include/PTO/IR/PTOAttrs.td`、`lib/PTO/Transforms/PTOToEmitC.cpp`、`lib/PTO/Transforms/PTOPlanMemory.cpp`、`lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp` 也已经有对应的属性、同步、pipe、PlanMemory 和 reserved buffer 管线。
-
-4. 但这些能力当前不是 `ptodsl/ptodsl/pto.py` 暴露出来的 `fa_builder.py` 风格 API。当前公开面更像是：
-   - `@pto.jit(kernel_kind=...)`
-   - `@pto.cube/@pto.simd/@pto.simt`
-   - `pto.pipe_barrier / pto.get_buf / pto.rls_buf`
-   - `pto.set_cross_flag / pto.wait_cross_flag`
-
-   它们能覆盖一部分语义，但还不能直接复刻 `fa_builder.py` 的 FIFO allocate/free/record/wait 代码形态。
+- `fa_builder.py` 的旧 FIFO runtime 协议包含真实 allocate/free/record/wait、
+  backpressure 和生命周期闭环；当前 PTODSL FA 只把 stage boundary 表达为
+  frontend pipe init/push/pop/free transaction。
+- 当前 FA 仍是 compile/frontend artifact，不是可直接作为性能 benchmark 的
+  runtime 版本。
+- 真实 cube/vector core 并行执行流、TSyncCVID 生命周期、host launch、
+  workspace 分配和 torch/torch_npu 对拍，还需要后端/runtime 配合。
+- `test_flash_attention_frontend_verify.py` 目前会把已知 `PTOPlanMemory`
+  缺口标记为 `KNOWN_BACKEND_GAP`，避免把后端 PlanMemory 问题误判成
+  frontend 迁移失败。
 
 ## 形状和约束
 
@@ -130,30 +153,28 @@ python3 ptodsl/tests/test_flash_attention_demo_compile.py
 python3 ptodsl/tests/test_flash_attention_frontend_verify.py
 ```
 
-`test_flash_attention_frontend_verify.py` 会先验证 PTODSL 生成的 MLIR 本身可 parse/verify；随后调用 `ptoas --emit-pto-ir`。当前后端在低层 `pto.tile_buf_addr` 上会触发已知 `PTOPlanMemory` 缺口，测试会明确标记为 `KNOWN_BACKEND_GAP`，避免把 frontend 迁移问题和后端 PlanMemory 支撑问题混在一起。
+`test_flash_attention_demo_compile.py` 会检查 FA 生成的 MLIR 中包含 pipe
+surface transaction，包括 `tpush_to_aiv`、`tpop_from_aic`、`tpush_to_aic`
+和 `tpop_from_aiv`。
 
 ## 当前边界
 
 这是 PTO-DSL/frontend 级迁移，不包含 A3/A5 runtime launch。
 
-补充确认一下：PTOAS 库里已经有接近 `fa_builder.py` 的底层实现，主要落在 PTO dialect、verify 和 lowering 上；只是当前 `ptodsl/ptodsl/` 的 Python 公共面还没有把这套能力完整暴露出来。
-
-旧实现里的 `initialize_l2g2l_pipe`、`talloc`、`tpush`、`tpop_into`、`tfree` 是真实 FIFO/runtime 调度语义。当前 PTOAS PTODSL 前端没有同名稳定 API，因此本迁移先把 QK/P/PV 的 GM slot 地址、shape、row-slice 状态、`QK_PRELOAD` 三段 shadow schedule 和阶段数据流显式写进 MLIR；真实 FIFO allocate/free/record/wait、消费反压和生命周期闭环仍需要后端/runtime 配合。
-
-因此，这个版本适合做：
+这个版本适合做：
 
 - PTODSL API review
 - MLIR/frontend compile 验证
 - 后续后端 FIFO lowering 的输入样例
 
-不适合直接作为性能 benchmark 或 runtime 正确性验证版本。
+还不适合直接作为：
 
-## 距离性能 benchmark / 正确性验证版本的剩余工作
+- runtime 正确性验证版本
+- 性能 benchmark 版本
 
-剩余主要不是 Python frontend 结构问题，而是缺少 runtime/API 支撑：
+要进入 correctness / benchmark 阶段，还需要：
 
-- 需要 PTOAS 后端/runtime 提供真实 GM staged FIFO 的 allocate/free/record/wait 语义。
-- 需要真实 cube/vector core 并行执行流，而不是当前单 JIT 内的 shadow schedule。
-- 需要 PTOAS 后端 PlanMemory 支持当前 PTODSL 为 cube `mad` 生成的 `pto.tile_buf_addr` 形态。
-- 需要接入 host launch、workspace 分配、输入输出布局约定和 torch/torch_npu 对拍。
-- 需要在 A3/A5 环境分别做 correctness 和性能 benchmark。
+- 后端/runtime 完成真实 FIFO 调度和生命周期语义。
+- 解决当前 FA frontend artifact 在后端 PlanMemory 中的已知缺口。
+- 接入 host launch、workspace 分配和输入输出布局约定。
+- 在 A5/A3 环境分别做 correctness 和性能验证。

--- a/docs/designs/hw_native_flash_attention_ptodsl_port_zh.md
+++ b/docs/designs/hw_native_flash_attention_ptodsl_port_zh.md
@@ -1,0 +1,159 @@
+# hw-native Python Flash Attention 到 PTOAS PTODSL 的迁移说明
+
+## 来源
+
+实际迁移来源是：
+
+```text
+https://github.com/hw-native-sys/pto-isa/tree/main/kernels/python/flash_atten
+```
+
+核心文件是：
+
+```text
+kernels/python/flash_atten/kernels/fa_builder.py
+```
+
+该实现使用的是旧的外部 `huawei-csl/pto-dsl` 包，不是 PTOAS 仓内当前的 `ptodsl/` API。本迁移的目标是把它的 Python DSL kernel 表达改写成当前 PTOAS PTODSL 表面。
+
+## 当前文件
+
+```text
+ptodsl/examples/hw_native_flash_attention.py
+```
+
+这个文件按 `fa_builder.py` 的结构组织，作为独立迁移示例存在；原有 PTOAS `flash_attention_sketch.py` 保持不动，避免把教学 sketch 和 hw-native port 混在一起。
+
+保留的源实现结构：
+
+```text
+compute_qk  : Cube 侧 Q/K matmul，写 QK GM slot
+compute_p   : SIMD 侧 streaming softmax，写 P GM slot
+compute_pv  : Cube 侧 P/V matmul，写 PV GM slot
+compute_gu  : SIMD 侧使用未归一化 running O 语义更新 O
+finalize    : 最后用 running_sum 归一化 O
+```
+
+当前已补齐的 PTO-DSL/frontend 表达：
+
+```text
+QK_PRELOAD prologue / steady / epilogue shadow schedule
+Vec_S0 row-slice 状态数组
+exp_max_ring 按 preload slot 和 row-slice 保存
+P slot 先按 [Vec_S0, S1_TILE] 生产，再按 [S0, CUBE_S1] 消费
+block_idx/block_num 的 Q block 分发
+```
+
+## API 映射
+
+```text
+旧 to_ir_module_with_meta(...)       -> @pto.jit(...).compile(...).mlir_text()
+旧 TensorType/SubTensorType 全局类型 -> pto.ptr + pto.make_tensor_view + pto.partition_view
+旧 declare_global + FIFO entry       -> 显式 GM slot tensor view
+旧 pto.load/pto.store                -> pto.tile.load / pto.tile.store
+旧 tile.matmul / matmul_acc          -> @pto.cube + pto.mad / pto.mad_acc
+旧 vector row-reduce softmax/GU      -> @pto.simd + tile row/reduce/expand ops
+```
+
+## 接口差距清单
+
+下面这张表按“`fa_builder.py` 里已有、但当前 PTOAS PTODSL 前端还没有直接等价接口”的方式列差距。
+
+| 旧实现接口 | 当前 PTODSL 状态 | 库内是否已有接近实现 | 影响 |
+| --- | --- | --- | --- |
+| `initialize_l2g2l_pipe(...)` | 无同名公开 API | 有，IR/EmitC/transform 已有 `pto.initialize_l2g2l_pipe` | 只能把 FIFO 语义压成 shadow schedule，不能直出真实 pipe |
+| `declare_global(...)` | 无同名公开 API | 有 `pto.declare_global` / `pto.declare_tile` 的 IR 侧设计 | 不能直接表达 global entry descriptor |
+| `talloc/tpush/tpop/tfree` | 无同名公开 API | 有 `pto.talloc* / pto.tpush* / pto.tpop* / pto.tfree*` 及 lowerer | Python 前端还不能写出这条流水协议 |
+| `TensorType/SubTensorType` | 仅有 `ptr + make_tensor_view + partition_view` | 有更底层的 `tile_buf` / `tensor_view` 类型体系 | 类型层能描述，但前端不够贴近原始写法 |
+| `pto.func / pto.call` | 当前主要靠 `@pto.jit` 和 Python trace | 库内有 module/kernel kind / section 体系 | 可组织 kernel，但不等于原 builder 的显式函数调度 |
+| `section.cube/vector` | PTODSL 有 `@pto.cube/@pto.simd/@pto.simt` 辅助 | 有 `pto.section.cube/vector` 和 `pto.kernel_kind` | 能分流，但不是 `fa_builder.py` 的完整执行流建模 |
+| `ffts_type / set_ffts` | 无公开对应 | 内部存在更底层的 pipe / sync / target 相关实现 | 目前只能做部分同步面表达 |
+
+结论是：**库里不是没有接近实现，而是接近实现主要存在于 PTO dialect、verify、lowering 和 EmitC 层，当前 PTODSL 公共 Python 面还没把这些能力完整抬上来。**
+
+## 库内已有的接近实现
+
+这部分是前面容易漏看的地方，也是这次分析里要单独说明的结论。
+
+1. `include/PTO/IR/PTOOps.td` 和 `lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp` 已经有 `initialize_l2g2l_pipe`、`talloc`、`tpush`、`tpop`、`tfree` 这一整条前端 pipe 协议，以及对应的 lowerer。
+
+2. `include/PTO/IR/PTOOps.td` 和 `lib/PTO/Transforms/PTOWrapFunctionsInSectionsPass.cpp`、`lib/PTO/Transforms/VPTOSplitCVModule.cpp` 已经有 `pto.section.cube/vector`、`pto.kernel_kind` 以及 cube/vector 模块拆分能力。
+
+3. `include/PTO/IR/PTOAttrs.td`、`lib/PTO/Transforms/PTOToEmitC.cpp`、`lib/PTO/Transforms/PTOPlanMemory.cpp`、`lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp` 也已经有对应的属性、同步、pipe、PlanMemory 和 reserved buffer 管线。
+
+4. 但这些能力当前不是 `ptodsl/ptodsl/pto.py` 暴露出来的 `fa_builder.py` 风格 API。当前公开面更像是：
+   - `@pto.jit(kernel_kind=...)`
+   - `@pto.cube/@pto.simd/@pto.simt`
+   - `pto.pipe_barrier / pto.get_buf / pto.rls_buf`
+   - `pto.set_cross_flag / pto.wait_cross_flag`
+
+   它们能覆盖一部分语义，但还不能直接复刻 `fa_builder.py` 的 FIFO allocate/free/record/wait 代码形态。
+
+## 形状和约束
+
+当前迁移保持源实现的主要约束：
+
+```text
+HEAD = 128
+S0 = 128
+CUBE_S1 = 128
+S1_TILE = 256 或 512
+QK_PRELOAD = 3 或 4
+SLOT_NUM = 8
+仅非 causal
+```
+
+## 使用
+
+生成 MLIR：
+
+```bash
+python3 ptodsl/examples/hw_native_flash_attention.py \
+  --head-dim 128 \
+  --s1-tile 256 \
+  --qk-preload 3 \
+  -o /tmp/hw_native_flash_attention_ptodsl.mlir
+```
+
+走 PTOAS frontend：
+
+```bash
+build/tools/ptoas/ptoas /tmp/hw_native_flash_attention_ptodsl.mlir \
+  --emit-pto-ir \
+  -o /tmp/hw_native_flash_attention_ptodsl.pto
+```
+
+运行测试：
+
+```bash
+python3 ptodsl/tests/test_flash_attention_demo_compile.py
+python3 ptodsl/tests/test_flash_attention_frontend_verify.py
+```
+
+`test_flash_attention_frontend_verify.py` 会先验证 PTODSL 生成的 MLIR 本身可 parse/verify；随后调用 `ptoas --emit-pto-ir`。当前后端在低层 `pto.tile_buf_addr` 上会触发已知 `PTOPlanMemory` 缺口，测试会明确标记为 `KNOWN_BACKEND_GAP`，避免把 frontend 迁移问题和后端 PlanMemory 支撑问题混在一起。
+
+## 当前边界
+
+这是 PTO-DSL/frontend 级迁移，不包含 A3/A5 runtime launch。
+
+补充确认一下：PTOAS 库里已经有接近 `fa_builder.py` 的底层实现，主要落在 PTO dialect、verify 和 lowering 上；只是当前 `ptodsl/ptodsl/` 的 Python 公共面还没有把这套能力完整暴露出来。
+
+旧实现里的 `initialize_l2g2l_pipe`、`talloc`、`tpush`、`tpop_into`、`tfree` 是真实 FIFO/runtime 调度语义。当前 PTOAS PTODSL 前端没有同名稳定 API，因此本迁移先把 QK/P/PV 的 GM slot 地址、shape、row-slice 状态、`QK_PRELOAD` 三段 shadow schedule 和阶段数据流显式写进 MLIR；真实 FIFO allocate/free/record/wait、消费反压和生命周期闭环仍需要后端/runtime 配合。
+
+因此，这个版本适合做：
+
+- PTODSL API review
+- MLIR/frontend compile 验证
+- 后续后端 FIFO lowering 的输入样例
+
+不适合直接作为性能 benchmark 或 runtime 正确性验证版本。
+
+## 距离性能 benchmark / 正确性验证版本的剩余工作
+
+剩余主要不是 Python frontend 结构问题，而是缺少 runtime/API 支撑：
+
+- 需要 PTOAS 后端/runtime 提供真实 GM staged FIFO 的 allocate/free/record/wait 语义。
+- 需要真实 cube/vector core 并行执行流，而不是当前单 JIT 内的 shadow schedule。
+- 需要 PTOAS 后端 PlanMemory 支持当前 PTODSL 为 cube `mad` 生成的 `pto.tile_buf_addr` 形态。
+- 需要接入 host launch、workspace 分配、输入输出布局约定和 torch/torch_npu 对拍。
+- 需要在 A3/A5 环境分别做 correctness 和性能 benchmark。

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -11390,11 +11390,32 @@ void TMatmulMxBiasOp::getEffects(SmallVectorImpl<SideEffects::EffectInstance<Mem
 }
 
 static bool isInsideSectionCube(Operation *op) {
-  return op->getParentOfType<pto::SectionCubeOp>() != nullptr;
+  for (Operation *parent = op; parent; parent = parent->getParentOp())
+    if (parent->getName().getStringRef() == pto::SectionCubeOp::getOperationName())
+      return true;
+  return false;
 }
 
 static bool isInsideSectionVector(Operation *op) {
-  return op->getParentOfType<pto::SectionVectorOp>() != nullptr;
+  for (Operation *parent = op; parent; parent = parent->getParentOp())
+    if (parent->getName().getStringRef() ==
+        pto::SectionVectorOp::getOperationName())
+      return true;
+  return false;
+}
+
+static std::optional<FunctionKernelKind>
+getEnclosingModuleKernelKind(Operation *op) {
+  for (Operation *parent = op; parent; parent = parent->getParentOp()) {
+    auto moduleOp = dyn_cast<ModuleOp>(parent);
+    if (!moduleOp)
+      continue;
+    auto kernelKindAttr = moduleOp->getAttrOfType<FunctionKernelKindAttr>(
+        FunctionKernelKindAttr::name);
+    if (kernelKindAttr)
+      return kernelKindAttr.getKernelKind();
+  }
+  return std::nullopt;
 }
 
 static std::optional<FunctionKernelKind>
@@ -11414,7 +11435,8 @@ getEnclosingFunctionKernelKind(Operation *op) {
 
 static bool isInsideSectionOrAttributedKernel(Operation *op) {
   return isInsideSectionCube(op) || isInsideSectionVector(op) ||
-         getEnclosingFunctionKernelKind(op).has_value();
+         getEnclosingFunctionKernelKind(op).has_value() ||
+         getEnclosingModuleKernelKind(op).has_value();
 }
 
 static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
@@ -11426,7 +11448,17 @@ static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
 static LogicalResult verifyFrontendKernelKind(Operation *op,
                                               FunctionKernelKind expected,
                                               StringRef kernelName) {
-  auto kernelKind = getEnclosingFunctionKernelKind(op);
+  if ((expected == FunctionKernelKind::Cube && isInsideSectionCube(op)) ||
+      (expected == FunctionKernelKind::Vector && isInsideSectionVector(op))) {
+    return success();
+  }
+
+  std::optional<FunctionKernelKind> kernelKind =
+      getEnclosingFunctionKernelKind(op);
+  if (!kernelKind)
+    kernelKind = getEnclosingModuleKernelKind(op);
+  if (!kernelKind)
+    return success();
   if (!kernelKind || *kernelKind != expected) {
     return op->emitOpError("must be inside a ")
            << kernelName << " kernel function";
@@ -11708,18 +11740,14 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
 
   unsigned sameIdInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
-    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
-      if (aic.getId() == op.getId())
+    if (auto sameSideInit = dyn_cast<InitOpT>(candidate)) {
+      if (sameSideInit.getId() == op.getId())
         ++sameIdInitCount;
-      return;
     }
-    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate))
-      if (aiv.getId() == op.getId())
-        ++sameIdInitCount;
   });
   if (sameIdInitCount > 1) {
     return op.emitOpError(
-        "requires 'id' to be unique across frontend initialize_pipe ops in the function");
+        "requires 'id' to be unique across same-side frontend initialize_pipe ops in the function");
   }
 
   int8_t dirMask = op.getDirMask();
@@ -11748,14 +11776,22 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
         op.getOperation(), op.getGmSlotTensor(), dirMask, op.getSlotSize());
   }
 
-  if (hasC2vConsumerBuf != hasV2cConsumerBuf) {
+  if (!hasC2vConsumerBuf && !hasV2cConsumerBuf) {
     return op.emitOpError(
-        "expects 'c2v_consumer_buf' and 'v2c_consumer_buf' to be provided together");
+        "expects local pipe init to provide at least one consumer buffer "
+        "operand; use 'gm_slot_tensor' for globaltensor pipe entries");
   }
-  if (!hasC2vConsumerBuf) {
+  if (dirMask == 1 && !hasC2vConsumerBuf) {
     return op.emitOpError(
-        "expects local pipe init to provide 'c2v_consumer_buf' and "
-        "'v2c_consumer_buf'; use 'gm_slot_tensor' for globaltensor pipe entries");
+        "expects 'c2v_consumer_buf' when dir_mask is 1");
+  }
+  if (dirMask == 2 && !hasV2cConsumerBuf) {
+    return op.emitOpError(
+        "expects 'v2c_consumer_buf' when dir_mask is 2");
+  }
+  if (dirMask == 3 && (!hasC2vConsumerBuf || !hasV2cConsumerBuf)) {
+    return op.emitOpError(
+        "expects both 'c2v_consumer_buf' and 'v2c_consumer_buf' when dir_mask is 3");
   }
 
   if (auto localSlotNumAttr = op.getLocalSlotNumAttr()) {
@@ -11860,37 +11896,41 @@ LogicalResult ImportReservedBufferOp::verify() {
   return success();
 }
 
-static FailureOr<Operation *> lookupFrontendInitOpById(Operation *op,
-                                                       func::FuncOp funcOp,
-                                                       int32_t id) {
+static FailureOr<Operation *>
+lookupFrontendInitOpById(Operation *op, func::FuncOp funcOp, int32_t id,
+                         FunctionKernelKind expected) {
   Operation *matchedInit = nullptr;
   unsigned matchedInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
-    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
+    if (expected == FunctionKernelKind::Cube) {
+      auto aic = dyn_cast<AicInitializePipeOp>(candidate);
+      if (!aic)
+        return WalkResult::advance();
       if (aic.getId() == static_cast<uint32_t>(id)) {
         matchedInit = candidate;
         ++matchedInitCount;
       }
       return WalkResult::advance();
     }
-    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate)) {
-      if (aiv.getId() == static_cast<uint32_t>(id)) {
-        matchedInit = candidate;
-        ++matchedInitCount;
-      }
+
+    auto aiv = dyn_cast<AivInitializePipeOp>(candidate);
+    if (!aiv)
       return WalkResult::advance();
+    if (aiv.getId() == static_cast<uint32_t>(id)) {
+      matchedInit = candidate;
+      ++matchedInitCount;
     }
     return WalkResult::advance();
   });
 
   if (matchedInitCount == 0) {
     op->emitOpError() << "expects 'id' = " << id
-                      << " to match a frontend initialize_pipe op in the same function";
+                      << " to match a same-side frontend initialize_pipe op in the same function";
     return failure();
   }
   if (matchedInitCount > 1) {
     op->emitOpError() << "expects 'id' = " << id
-                      << " to match exactly one frontend initialize_pipe op in the same function";
+                      << " to match exactly one same-side frontend initialize_pipe op in the same function";
     return failure();
   }
   return matchedInit;
@@ -11908,10 +11948,10 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   return verifySplitAttr(op, split);
 }
 
-static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
-                                                       func::FuncOp funcOp,
-                                                       int32_t id) {
-  auto initOr = lookupFrontendInitOpById(op, funcOp, id);
+static FailureOr<int8_t>
+lookupFrontendInitDirMaskById(Operation *op, func::FuncOp funcOp, int32_t id,
+                              FunctionKernelKind expected) {
+  auto initOr = lookupFrontendInitOpById(op, funcOp, id, expected);
   if (failed(initOr))
     return failure();
   if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr))
@@ -11920,12 +11960,13 @@ static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
 }
 
 static LogicalResult verifyFrontendDataOpDirection(Operation *op, int32_t id,
-                                                   bool expectC2V) {
+                                                   bool expectC2V,
+                                                   FunctionKernelKind expected) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
   if (!funcOp)
     return op->emitOpError("must be nested under a func.func");
 
-  auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id);
+  auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id, expected);
   if (failed(dirMaskOr))
     return failure();
 
@@ -11951,7 +11992,8 @@ static Value getFrontendInitGmSlotTensor(Operation *initOp) {
 
 static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
                                                           int32_t id,
-                                                          Type entryTy) {
+                                                          Type entryTy,
+                                                          FunctionKernelKind expected) {
   auto entryViewTy = dyn_cast<TensorViewType>(entryTy);
   if (!entryViewTy)
     return success();
@@ -11960,7 +12002,7 @@ static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
   if (!funcOp)
     return op->emitOpError("must be nested under a func.func");
 
-  auto initOr = lookupFrontendInitOpById(op, funcOp, id);
+  auto initOr = lookupFrontendInitOpById(op, funcOp, id, expected);
   if (failed(initOr))
     return failure();
   Value gmSlotTensor = getFrontendInitGmSlotTensor(*initOr);
@@ -12007,10 +12049,11 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
                                    op.getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(op.getOperation(), op.getId(),
-                                           expectC2V)))
+                                           expectC2V, expected)))
     return failure();
   if (failed(verifyFrontendTensorEntryMatchesInit(op.getOperation(), op.getId(),
-                                                  op.getTile().getType())))
+                                                  op.getTile().getType(),
+                                                  expected)))
     return failure();
 
   bool hasValidRow = static_cast<bool>(op.getValidRow());
@@ -12414,10 +12457,12 @@ LogicalResult TAllocToAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Cube)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getEntry().getType());
+                                              getEntry().getType(),
+                                              FunctionKernelKind::Cube);
 }
 
 LogicalResult TAllocToAicOp::verify() {
@@ -12425,10 +12470,12 @@ LogicalResult TAllocToAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Vector)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getEntry().getType());
+                                              getEntry().getType(),
+                                              FunctionKernelKind::Vector);
 }
 
 LogicalResult TPushToAivOp::verify() {
@@ -12436,10 +12483,12 @@ LogicalResult TPushToAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Cube)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getTile().getType());
+                                              getTile().getType(),
+                                              FunctionKernelKind::Cube);
 }
 
 LogicalResult TPushToAicOp::verify() {
@@ -12447,10 +12496,12 @@ LogicalResult TPushToAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Vector)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getTile().getType());
+                                              getTile().getType(),
+                                              FunctionKernelKind::Vector);
 }
 
 LogicalResult TPopFromAicOp::verify() {
@@ -12468,11 +12519,13 @@ LogicalResult TFreeFromAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Vector)))
     return failure();
   if (getEntry())
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                                getEntry().getType());
+                                                getEntry().getType(),
+                                                FunctionKernelKind::Vector);
   return success();
 }
 
@@ -12481,11 +12534,13 @@ LogicalResult TFreeFromAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Cube)))
     return failure();
   if (getEntry())
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                                getEntry().getType());
+                                                getEntry().getType(),
+                                                FunctionKernelKind::Cube);
   return success();
 }
 

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -47,7 +47,12 @@ struct FrontendPipeHandles {
   Operation *anchorOp = nullptr;
 };
 
-using FrontendPipeHandleMap = llvm::DenseMap<int32_t, FrontendPipeHandles>;
+static int64_t frontendPipeHandleKey(int32_t id, FunctionKernelKind side) {
+  return static_cast<int64_t>(id) * 2 +
+         (side == FunctionKernelKind::Cube ? 0 : 1);
+}
+
+using FrontendPipeHandleMap = llvm::DenseMap<int64_t, FrontendPipeHandles>;
 
 template <typename InitOpT>
 static LogicalResult requireFrontendGmSlotBuffer(InitOpT initOp) {
@@ -269,31 +274,31 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
                                                            IRRewriter &rewriter) {
   FrontendPipeHandleMap handlesById;
   SmallVector<Operation *> frontendInitOps;
-  llvm::DenseMap<int32_t, Operation *> initOpById;
+  llvm::DenseMap<int64_t, Operation *> initOpByKey;
   bool hasDuplicateId = false;
-  bool hasAicInit = false;
-  bool hasAivInit = false;
 
   funcOp.walk([&](Operation *op) {
     if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
-      hasAicInit = true;
       frontendInitOps.push_back(op);
-      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      int64_t key =
+          frontendPipeHandleKey(init.getId(), FunctionKernelKind::Cube);
+      auto [it, inserted] = initOpByKey.try_emplace(key, op);
       if (!inserted) {
         op->emitOpError()
-            << "requires unique initialize_pipe id in function (duplicate id = "
+            << "requires unique same-side initialize_pipe id in function (duplicate id = "
             << init.getId() << ")";
         hasDuplicateId = true;
       }
       return WalkResult::advance();
     }
     if (auto init = dyn_cast<AivInitializePipeOp>(op)) {
-      hasAivInit = true;
       frontendInitOps.push_back(op);
-      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      int64_t key =
+          frontendPipeHandleKey(init.getId(), FunctionKernelKind::Vector);
+      auto [it, inserted] = initOpByKey.try_emplace(key, op);
       if (!inserted) {
         op->emitOpError()
-            << "requires unique initialize_pipe id in function (duplicate id = "
+            << "requires unique same-side initialize_pipe id in function (duplicate id = "
             << init.getId() << ")";
         hasDuplicateId = true;
       }
@@ -305,19 +310,14 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
   if (hasDuplicateId)
     return failure();
 
-  if (hasAicInit && hasAivInit) {
-    funcOp.emitOpError("cannot mix pto.aic_initialize_pipe and "
-                       "pto.aiv_initialize_pipe in one function");
-    return failure();
-  }
-
   for (Operation *op : frontendInitOps) {
     if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
       int32_t id = init.getId();
       auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
       if (failed(loweredOr))
         return failure();
-      handlesById.try_emplace(id, *loweredOr);
+      handlesById.try_emplace(
+          frontendPipeHandleKey(id, FunctionKernelKind::Cube), *loweredOr);
       continue;
     }
 
@@ -326,7 +326,8 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
     auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
     if (failed(loweredOr))
       return failure();
-    handlesById.try_emplace(id, *loweredOr);
+    handlesById.try_emplace(
+        frontendPipeHandleKey(id, FunctionKernelKind::Vector), *loweredOr);
   }
 
   return handlesById;
@@ -357,12 +358,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
       frontendOps.push_back(op);
   });
 
-  auto lookupHandles = [&](Operation *op, int32_t id)
+  auto lookupHandles = [&](Operation *op, int32_t id,
+                           FunctionKernelKind side)
       -> FailureOr<const FrontendPipeHandles *> {
-    auto it = handlesById.find(id);
+    auto it = handlesById.find(frontendPipeHandleKey(id, side));
     if (it == handlesById.end()) {
       op->emitOpError()
-          << "requires matching frontend initialize_pipe(id = " << id
+          << "requires matching same-side frontend initialize_pipe(id = " << id
           << ") in the same function";
       return failure();
     }
@@ -379,7 +381,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     rewriter.setInsertionPoint(op);
 
     if (auto alloc = dyn_cast<TAllocToAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, alloc.getId());
+      auto handlesOr =
+          lookupHandles(op, alloc.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -398,7 +401,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto alloc = dyn_cast<TAllocToAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, alloc.getId());
+      auto handlesOr =
+          lookupHandles(op, alloc.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -417,7 +421,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto push = dyn_cast<TPushToAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, push.getId());
+      auto handlesOr =
+          lookupHandles(op, push.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -432,7 +437,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto push = dyn_cast<TPushToAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, push.getId());
+      auto handlesOr =
+          lookupHandles(op, push.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -447,7 +453,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, pop.getId());
+      auto handlesOr =
+          lookupHandles(op, pop.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -478,7 +485,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, pop.getId());
+      auto handlesOr =
+          lookupHandles(op, pop.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -509,7 +517,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto free = dyn_cast<TFreeFromAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, free.getId());
+      auto handlesOr =
+          lookupHandles(op, free.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -525,7 +534,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     auto free = cast<TFreeFromAivOp>(op);
-    auto handlesOr = lookupHandles(op, free.getId());
+    auto handlesOr =
+        lookupHandles(op, free.getId(), FunctionKernelKind::Cube);
     if (failed(handlesOr))
       return failure();
     const FrontendPipeHandles &handles = **handlesOr;

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -999,3 +999,317 @@ def qk_matmul(q_tile, k_tile, q_l0a, k_l0b, s_acc, s_tile):
 ```
 
 At the cube micro-op boundary, PTODSL currently uses explicit typed pointers. `tile.as_ptr()` materializes the pointer view for UB and cube-local scratch buffers, while the surrounding sub-kernel surface still uses `Tile` values for metadata such as `valid_shape`.
+
+## 7.6 Pipe Communication (Cube ↔ Vector FIFO)
+
+Pipe communication is the mechanism for Cube and Vector sub-kernels to exchange
+data through hardware FIFO channels. PTODSL provides a high-level `pto.pipe`
+API that presents pipes as logical declarations plus direction-aware
+transactions.
+
+### 7.6.1 Pipe Constructors
+
+#### `pto.pipe.c2v_global(gm_slot_tensor, *, id=None, slot_size=None, nosplit=None)`
+
+Creates a logical Cube-to-Vector pipe whose entries are GlobalTensor-like GM
+FIFO slots.
+
+Global-entry pipes model the A2/A3 L2G2L path. On A5, use a local FIFO pipe
+with `reserve_buffer` / `import_reserved_buffer` and tile-entry transactions.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `gm_slot_tensor` | `TensorView` | Required. Describes one FIFO slot entry. |
+| `id` | `int` | Optional. Pipe identifier. If omitted the frontend synthesises a stable id. |
+| `slot_size` | `int` | Optional. Defaults to the byte size of one slot of `gm_slot_tensor`. |
+| `nosplit` | `bool` | Optional. Override-only metadata; not required in the common path. |
+
+The returned pipe object exposes C2V-producer methods (`init_cube`, `alloc`,
+`push`) on the Cube side and C2V-consumer methods (`init_simd`, `pop`, `free`)
+on the Vector side.
+
+#### `pto.pipe.v2c_global(gm_slot_tensor, *, id=None, slot_size=None, nosplit=None)`
+
+Creates a logical Vector-to-Cube pipe. Same contract as `c2v_global`, but
+reversed direction: the Vector side is the producer and the Cube side is the
+consumer.
+
+#### `pto.pipe.c2v_local(*, slot_size, consumer_buf, gm_slot_buffer=None, id=None, local_slot_num=None, nosplit=None)`
+
+Creates a logical local-FIFO C2V pipe.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `slot_size` | `int` | Required. Logical slot size in bytes. |
+| `consumer_buf` | varies | Required. On the producer side: buffer reserved with `pto.reserve_buffer`. On the consumer side: buffer imported with `pto.import_reserved_buffer`. |
+| `gm_slot_buffer` | `PtrType` | Optional. GM slot buffer pointer (A2/A3 path). |
+| `id` | `int` | Optional. Pipe identifier. |
+| `local_slot_num` | `int` | Optional. Local FIFO slot count override. |
+| `nosplit` | `bool` | Optional. No-split pipe mode. |
+
+`consumer_buf` is singular because the direction is already fixed by the
+`c2v_local` constructor. The high-level surface does not require users to spell
+`c2v_consumer_buf` versus `v2c_consumer_buf`.
+
+#### `pto.pipe.v2c_local(*, slot_size, consumer_buf, gm_slot_buffer=None, id=None, local_slot_num=None, nosplit=None)`
+
+Same contract as `c2v_local`, but reversed direction.
+
+#### `pto.pipe.bidirectional_local(*, slot_size, c2v_consumer_buf, v2c_consumer_buf, gm_slot_buffer=None, id=None, local_slot_num=None, nosplit=None)`
+
+Creates a bidirectional local pipe. Accepts both `c2v_consumer_buf` and
+`v2c_consumer_buf` since the pipe carries traffic in both directions.
+
+### 7.6.2 Pipe Methods
+
+Every logical pipe object exposes only the methods that make sense for its
+direction.
+
+**Producer-side methods** (Cube side for C2V, Vector side for V2C):
+
+| Method | Description |
+|--------|-------------|
+| `init_cube()` | Initialise the pipe on the Cube side. |
+| `init_simd()` | Initialise the pipe on the Vector (SIMD) side. |
+| `alloc(split=0)` | Allocate the next FIFO slot. Global-entry pipes only. Returns an entry descriptor. |
+| `push(entry_or_tile, split=0)` | Push a filled GlobalTensor entry or local tile to the consumer. Notifies the consumer side. |
+
+**Consumer-side methods** (Vector side for C2V, Cube side for V2C):
+
+| Method | Description |
+|--------|-------------|
+| `init_cube()` | Initialise the pipe on the Cube side. |
+| `init_simd()` | Initialise the pipe on the Vector (SIMD) side. |
+| `pop(split=0, result_type=None, valid_shape=None)` | Pop the next entry from the producer. For global-entry pipes, `result_type` defaults to the pipe's `entry_type`; for local/tile-entry pipes it must be provided. |
+| `free(entry=None, split=0)` | Release the consumed slot back to the producer. |
+
+**Read-only properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_type` | type | The entry descriptor type for this pipe. |
+| `id` | `int` | The compile-time pipe identifier. |
+| `slot_size` | `int` | The logical slot size in bytes. |
+
+Rules:
+
+- `split` is a compile-time integer: `0` = no split, `1` = up/down split,
+  `2` = left/right split.
+- For global-entry pipes, `push` and `pop` do not implicitly perform
+  `tstore`/`tload`; callers must move data explicitly before `push` or after
+  `pop`.
+- For global-entry pipes, `result_type` on `pop()` defaults to the pipe's
+  `entry_type`.
+- For local/tile-entry pipes, there is no `alloc()`. The producer pushes an
+  existing tile directly. The consumer pops into a newly declared tile of
+  `result_type`.
+- For local/tile-entry pipes, `result_type` may be either a tile type or a tile
+  value whose type should be reused. `valid_shape=[rows, cols]` can be supplied
+  when the popped tile needs runtime valid-shape metadata.
+- `entry` on `free()` may be omitted for tile-entry pipes. For global-entry
+  pipes it must carry the entry descriptor returned by the matching `pop()`.
+
+### 7.6.3 Global-Entry C2V Pipe
+
+Declaration (shared between Cube and Vector sides):
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_declaration","symbol":"pipe_communication_c2v_global_declaration_probe","compile":{}} -->
+```python
+c2v = pto.pipe.c2v_global(gm_slots, id=0)
+```
+
+Cube (producer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_producer","symbol":"pipe_communication_c2v_global_producer_probe","compile":{}} -->
+```python
+@pto.cube
+def producer(src_tile):
+    c2v.init_cube()
+    entry = c2v.alloc(split=0)
+    entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+    pto.tile.store(src_tile, entry_part)
+    c2v.push(entry, split=0)
+```
+
+Vector (consumer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_consumer","symbol":"pipe_communication_c2v_global_consumer_probe","compile":{}} -->
+```python
+@pto.simd
+def consumer(dst_tile):
+    c2v.init_simd()
+    entry = c2v.pop(split=0, result_type=c2v.entry_type)
+    entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+    pto.tile.load(entry_part, dst_tile)
+    c2v.free(entry, split=0)
+```
+
+The Cube side initialises the pipe, allocates a GM FIFO slot, stores the tile
+data into that slot via `tile.store`, then pushes the entry to notify the
+consumer. The Vector side initialises the pipe, pops the next ready entry, loads
+the data into a local tile via `tile.load`, then frees the slot.
+
+### 7.6.4 Global-Entry V2C Pipe
+
+Declaration:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_declaration","symbol":"pipe_communication_v2c_global_declaration_probe","compile":{}} -->
+```python
+v2c = pto.pipe.v2c_global(gm_slots, id=0)
+```
+
+Vector (producer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_producer","symbol":"pipe_communication_v2c_global_producer_probe","compile":{}} -->
+```python
+@pto.simd
+def producer(src_tile):
+    v2c.init_simd()
+    entry = v2c.alloc(split=0)
+    pto.tile.store(src_tile, pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16]))
+    v2c.push(entry, split=0)
+```
+
+Cube (consumer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_consumer","symbol":"pipe_communication_v2c_global_consumer_probe","compile":{}} -->
+```python
+@pto.cube
+def consumer(dst_tile):
+    v2c.init_cube()
+    entry = v2c.pop(split=0, result_type=v2c.entry_type)
+    pto.tile.load(pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16]), dst_tile)
+    v2c.free(entry, split=0)
+```
+
+### 7.6.5 Local FIFO C2V Pipe
+
+Vector (consumer) side reserves the local buffer:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_declaration","symbol":"pipe_communication_c2v_local_declaration_probe","compile":{}} -->
+```python
+c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+c2v = pto.pipe.c2v_local(
+    slot_size=1024,
+    consumer_buf=c2v_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+Cube (producer) side imports the peer buffer:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_import","symbol":"pipe_communication_c2v_local_import_probe","compile":{}} -->
+```python
+c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
+c2v_peer = pto.pipe.c2v_local(
+    slot_size=1024,
+    consumer_buf=c2v_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+Cube (producer) transaction:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_producer","symbol":"pipe_communication_c2v_local_producer_probe","compile":{}} -->
+```python
+@pto.cube
+def producer(src_tile):
+    c2v_peer.init_cube()
+    c2v_peer.push(src_tile, split=0)
+```
+
+Vector (consumer) transaction:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_consumer","symbol":"pipe_communication_c2v_local_consumer_probe","compile":{}} -->
+```python
+@pto.simd
+def consumer(dst_part):
+    c2v.init_simd()
+    tile = c2v.pop(result_type=dst_tile, split=0)
+    pto.tile.store(tile, dst_part)
+    c2v.free(split=0)
+```
+
+The local form is the A5-facing form used when Cube and Vector exchange UB/MAT
+tiles through a local FIFO. `push(tile)` emits a tile-entry `tpush`; `pop()`
+emits a tile-entry `tpop`; `free()` can omit the entry because no GM FIFO slot
+descriptor was allocated by the frontend.
+
+### 7.6.6 Bidirectional Local Pipe
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.bidirectional_local_declaration","symbol":"pipe_communication_bidirectional_local_declaration_probe","compile":{}} -->
+```python
+bidi = pto.pipe.bidirectional_local(
+    slot_size=1024,
+    c2v_consumer_buf=c2v_buf,
+    v2c_consumer_buf=v2c_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+For bidirectional local pipes, the C2V consumer buffer lives in `VEC` and the V2C consumer buffer lives in `MAT`.
+
+The two-buffer shape only appears where the pipe is genuinely bidirectional.
+
+### 7.6.7 Complete Example: C2V Global-Entry Pipe
+
+This is a complete two-kernel C2V pipe example with `@pto.jit` entry points
+and `gm_slots` expressed via `pto.make_tensor_view`:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global","symbol":"pipe_communication_c2v_global_probe","compile":{"BLOCK":128}} -->
+```python
+@pto.jit(target="a3")
+def cube_producer(
+    gm_slot_buffer: pto.gm_ptr(pto.f32),
+    src: pto.gm_ptr(pto.f32),
+    *,
+    BLOCK: pto.constexpr = 128,
+):
+    gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+    c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+    a_part = pto.partition_view(
+        pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+        offsets=[0, 0], sizes=[16, 16])
+    a_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+    @pto.cube
+    def cube_kernel():
+        pto.tile.load(a_part, a_tile)
+        c2v.init_cube()
+        entry = c2v.alloc(split=0)
+        entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+        pto.tile.store(a_tile, entry_part)
+        c2v.push(entry, split=0)
+
+@pto.jit(target="a3")
+def vector_consumer(
+    gm_slot_buffer: pto.gm_ptr(pto.f32),
+    dst: pto.gm_ptr(pto.f32),
+    *,
+    BLOCK: pto.constexpr = 128,
+):
+    gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+    c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+    b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+    b_part = pto.partition_view(
+        pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+        offsets=[0, 0], sizes=[16, 16])
+
+    @pto.simd
+    def vector_kernel():
+        c2v.init_simd()
+        entry = c2v.pop(split=0, result_type=c2v.entry_type)
+        entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+        pto.tile.load(entry_part, b_tile)
+        c2v.free(entry, split=0)
+        pto.tile.store(b_tile, b_part)
+```

--- a/ptodsl/examples/hw_native_flash_attention.py
+++ b/ptodsl/examples/hw_native_flash_attention.py
@@ -1,0 +1,654 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+"""
+PTOAS PTODSL port of the hw-native Python Flash Attention example.
+
+Source implementation:
+
+    https://github.com/hw-native-sys/pto-isa/tree/main/kernels/python/flash_atten
+
+The source is authored against the older external ``huawei-csl/pto-dsl``
+package.  This file ports the authored kernel shape and dataflow to the current
+PTOAS in-tree PTODSL surface.  It is intentionally frontend/compile focused:
+it emits PTO MLIR that exposes the same high-level stages and slot layout, but
+does not implement the old runtime FIFO protocol in Python.
+
+Ported source structure:
+
+    old fa_builder.py module/to_ir_module    -> @pto.jit(...).compile(...)
+    old TensorType/SubTensorType globals     -> pto.ptr + make_tensor_view
+    old declare_global + l2g2l FIFO entries  -> GM slot tensor views
+    old pto.load/store                       -> pto.tile.load/store
+    old tile.matmul/matmul_acc               -> @pto.cube + pto.mad/mad_acc
+    old vector row-reduce softmax/GU         -> @pto.simd tile ops
+
+The source four-stage pipeline is preserved in the authored surface:
+
+    compute_qk  (Cube): Q/K -> QK slot
+    compute_p   (SIMD): QK slot -> streaming softmax -> P slot
+    compute_pv  (Cube): P/V -> PV slot
+    compute_gu  (SIMD): PV slot -> unnormalized running O
+
+Current boundary:
+
+* True talloc/tpush/tpop/tfree FIFO scheduling is a backend/runtime concern.
+  This port represents the slot addresses and stage dataflow in frontend MLIR
+  using explicit GM slot tensor views.
+* The source example targets non-causal HEAD=128 FA.  This port keeps that
+  contract and rejects unsupported specialization knobs early.
+* Runtime launch, torch_npu validation, and A3/A5 performance checks are not
+  part of this compile/frontend artifact.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "ptodsl" / "__init__.py").exists():
+            sys.path.insert(0, str(candidate))
+            break
+    else:
+        raise RuntimeError("Unable to locate the PTODSL Python package root")
+
+from ptodsl import pto, scalar
+
+
+HW_NATIVE_FLASH_ATTEN_SOURCE = (
+    "https://github.com/hw-native-sys/pto-isa/tree/main/"
+    "kernels/python/flash_atten"
+)
+
+S0 = 128
+HEAD = 128
+CUBE_S1 = 128
+DEFAULT_S1_TILE = 256
+DEFAULT_QK_PRELOAD = 3
+SLOT_NUM = 8
+
+SPLIT_UP_DOWN = 1
+VEC_CORES = 2
+
+
+def _validate_specialization(*, head_dim: int, s1_tile: int, qk_preload: int, causal: bool) -> None:
+    if head_dim != HEAD:
+        raise ValueError(f"hw-native flash_atten port currently requires head_dim={HEAD}, got {head_dim}")
+    if s1_tile not in (256, 512):
+        raise ValueError(f"s1_tile must be 256 or 512, got {s1_tile}")
+    if s1_tile % CUBE_S1 != 0:
+        raise ValueError(f"s1_tile={s1_tile} must be a multiple of CUBE_S1={CUBE_S1}")
+    if qk_preload not in (3, 4):
+        raise ValueError(f"qk_preload must be 3 or 4, got {qk_preload}")
+    if causal:
+        raise ValueError("hw-native flash_atten source port is non-causal; causal=True is not supported yet")
+
+
+def describe_hw_native_flash_attention_port():
+    s1_tile = DEFAULT_S1_TILE
+    tile_factor = s1_tile // CUBE_S1
+    vec_s0 = S0 // VEC_CORES // tile_factor
+    return {
+        "source": HW_NATIVE_FLASH_ATTEN_SOURCE,
+        "ported_file": "kernels/python/flash_atten/kernels/fa_builder.py",
+        "ported_surface": {
+            "entry": "@pto.jit(target='a5', mode='explicit')",
+            "old_module_builder": "to_ir_module_with_meta(...)",
+            "new_module_builder": "flash_attention_kernel.compile(...).mlir_text()",
+            "old_tensor_types": "TensorType/SubTensorType module globals",
+            "new_tensor_views": "pto.ptr + pto.make_tensor_view + pto.partition_view",
+            "old_fifo": "initialize_l2g2l_pipe + talloc/tpush/tpop/tfree",
+            "new_frontend_slots": "explicit GM slot tensor views; runtime FIFO remains backend work",
+        },
+        "source_constants": {
+            "S0": S0,
+            "HEAD": HEAD,
+            "CUBE_S1": CUBE_S1,
+            "S1_TILE": s1_tile,
+            "TILE_FACTOR": tile_factor,
+            "Vec_S0": vec_s0,
+            "QK_PRELOAD": DEFAULT_QK_PRELOAD,
+            "SLOT_NUM": SLOT_NUM,
+        },
+        "dataflow": ["compute_qk", "compute_p", "compute_pv", "compute_gu"],
+        "frontend_features": [
+            "QK_PRELOAD prologue/steady/epilogue shadow schedule",
+            "Vec_S0 row-slice state arrays",
+            "exp_max_ring per preload slot and row-slice",
+            "wide P slot producer/consumer",
+            "block_idx/block_num Q block distribution",
+        ],
+    }
+
+
+def emit_flash_attention_mlir(
+    *,
+    head_dim: int = HEAD,
+    s1_tile: int = DEFAULT_S1_TILE,
+    qk_preload: int = DEFAULT_QK_PRELOAD,
+    causal: bool = False,
+    q_rows: int = S0,
+):
+    _validate_specialization(
+        head_dim=head_dim,
+        s1_tile=s1_tile,
+        qk_preload=qk_preload,
+        causal=causal,
+    )
+    compiled = flash_attention_kernel.compile(
+        HEAD_DIM=head_dim,
+        S1_TILE=s1_tile,
+        QK_PRELOAD=qk_preload,
+        CAUSAL=causal,
+        Q_ROWS=q_rows,
+    )
+    return compiled.mlir_text()
+
+
+@pto.jit(target="a5", mode="explicit")
+def flash_attention_kernel(
+    gm_slot_buffer: pto.ptr(pto.f32, "gm"),
+    gm_slot_buffer_fp16: pto.ptr(pto.f16, "gm"),
+    gm_q: pto.ptr(pto.f16, "gm"),
+    gm_k: pto.ptr(pto.f16, "gm"),
+    gm_v: pto.ptr(pto.f16, "gm"),
+    gm_o: pto.ptr(pto.f32, "gm"),
+    s0: pto.i32,
+    s1: pto.i32,
+    *,
+    HEAD_DIM: pto.constexpr = HEAD,
+    S1_TILE: pto.constexpr = DEFAULT_S1_TILE,
+    QK_PRELOAD: pto.constexpr = DEFAULT_QK_PRELOAD,
+    CAUSAL: pto.constexpr = False,
+    Q_ROWS: pto.constexpr = S0,
+):
+    """
+    Launchable PTODSL entry for the hw-native FA Python example.
+
+    The signature mirrors the source ``call_both`` shape after replacing the
+    old FFTS/runtime handle with a compile-only JIT entry.  ``gm_slot_buffer``
+    and ``gm_slot_buffer_fp16`` model the source GM-staged QK/P/PV slots.
+    """
+    if HEAD_DIM != HEAD:
+        raise ValueError("flash_attention_kernel requires HEAD_DIM=128")
+    if CAUSAL:
+        raise ValueError("causal masking is not part of the hw-native source port yet")
+
+    c0 = 0
+    c1 = 1
+    cS0 = S0
+    cHEAD = HEAD
+    cCUBE_S1 = CUBE_S1
+    cS1_TILE = S1_TILE
+    cQK_PRELOAD = QK_PRELOAD
+    cSLOT_NUM = SLOT_NUM
+
+    tile_factor = S1_TILE // CUBE_S1
+    vec_s0 = S0 // VEC_CORES // tile_factor
+    row_slice_count = VEC_CORES * tile_factor
+
+    slot_size_qk_f32 = S0 * S1_TILE
+    slot_size_pv_f32 = S0 * HEAD
+    slot_size_p_f16 = S0 * S1_TILE
+    gm_pv_off_f32 = slot_size_qk_f32 * SLOT_NUM
+    gm_p_off_f32 = gm_pv_off_f32 + slot_size_pv_f32 * SLOT_NUM
+
+    s1_index = scalar.index_cast(s1)
+    q_view = pto.make_tensor_view(gm_q, shape=[s0, cHEAD], strides=[cHEAD, c1])
+    k_view = pto.make_tensor_view(gm_k, shape=[cHEAD, s1_index], strides=[c1, cHEAD])
+    v_view = pto.make_tensor_view(gm_v, shape=[s1_index, cHEAD], strides=[cHEAD, c1])
+    o_view = pto.make_tensor_view(gm_o, shape=[s0, cHEAD], strides=[cHEAD, c1])
+
+    qk_slots = pto.make_tensor_view(
+        gm_slot_buffer,
+        shape=[cSLOT_NUM * cS0, cS1_TILE],
+        strides=[cS1_TILE, c1],
+    )
+    pv_slot_row_offset = gm_pv_off_f32 // HEAD
+    pv_workspace = pto.make_tensor_view(
+        gm_slot_buffer,
+        shape=[pv_slot_row_offset + cSLOT_NUM * cS0, cHEAD],
+        strides=[cHEAD, c1],
+    )
+    pv_slots = pto.partition_view(
+        pv_workspace,
+        offsets=[pv_slot_row_offset, c0],
+        sizes=[cSLOT_NUM * cS0, cHEAD],
+    )
+    p_slot_row_offset = (gm_p_off_f32 * 2) // S1_TILE
+    p_workspace = pto.make_tensor_view(
+        gm_slot_buffer_fp16,
+        shape=[p_slot_row_offset + cSLOT_NUM * cS0, cS1_TILE],
+        strides=[cS1_TILE, c1],
+    )
+    p_slots = pto.partition_view(
+        p_workspace,
+        offsets=[p_slot_row_offset, c0],
+        sizes=[cSLOT_NUM * cS0, cS1_TILE],
+    )
+
+    q_mat = pto.alloc_tile(shape=[S0, HEAD], dtype=pto.f16, memory_space="mat")
+    q_left = pto.alloc_tile(shape=[S0, HEAD], dtype=pto.f16, memory_space="left")
+
+    k_mat = pto.alloc_tile(
+        shape=[HEAD, CUBE_S1],
+        dtype=pto.f16,
+        memory_space="mat",
+        blayout="RowMajor",
+        slayout="ColMajor",
+    )
+    k_right = pto.alloc_tile(shape=[HEAD, CUBE_S1], dtype=pto.f16, memory_space="right")
+    qk_acc = pto.alloc_tile(shape=[S0, CUBE_S1], dtype=pto.f32, memory_space="acc")
+    qk_tile = pto.alloc_tile(shape=[S0, CUBE_S1], dtype=pto.f32)
+
+    p_recv = pto.alloc_tile(shape=[S0, CUBE_S1], dtype=pto.f16, memory_space="mat")
+    p_left = pto.alloc_tile(shape=[S0, CUBE_S1], dtype=pto.f16, memory_space="left")
+    v_mat = pto.alloc_tile(shape=[CUBE_S1, HEAD], dtype=pto.f16, memory_space="mat")
+    v_right = pto.alloc_tile(shape=[CUBE_S1, HEAD], dtype=pto.f16, memory_space="right")
+    pv_acc = pto.alloc_tile(shape=[S0, HEAD], dtype=pto.f32, memory_space="acc")
+    pv_tile = pto.alloc_tile(shape=[S0, HEAD], dtype=pto.f32)
+
+    qk_vec = pto.alloc_tile(shape=[vec_s0, S1_TILE], dtype=pto.f32)
+    p_fp32 = pto.alloc_tile(shape=[vec_s0, S1_TILE], dtype=pto.f32)
+    p_fp16 = pto.alloc_tile(shape=[vec_s0, S1_TILE], dtype=pto.f16)
+    softmax_tmp = pto.alloc_tile(shape=[vec_s0, S1_TILE], dtype=pto.f32)
+    pv_vec = pto.alloc_tile(shape=[vec_s0, HEAD], dtype=pto.f32)
+
+    running_max = [
+        pto.alloc_tile(shape=[vec_s0, 8], dtype=pto.f32, valid_shape=[vec_s0, 1])
+        for _ in range(row_slice_count)
+    ]
+    running_sum = [
+        pto.alloc_tile(shape=[vec_s0, 8], dtype=pto.f32, valid_shape=[vec_s0, 1])
+        for _ in range(row_slice_count)
+    ]
+    local_max = [
+        pto.alloc_tile(shape=[vec_s0, 8], dtype=pto.f32, valid_shape=[vec_s0, 1])
+        for _ in range(row_slice_count)
+    ]
+    local_sum = [
+        pto.alloc_tile(shape=[vec_s0, 8], dtype=pto.f32, valid_shape=[vec_s0, 1])
+        for _ in range(row_slice_count)
+    ]
+    exp_max_ring = [
+        [
+            pto.alloc_tile(shape=[vec_s0, 8], dtype=pto.f32, valid_shape=[vec_s0, 1])
+            for _ in range(row_slice_count)
+        ]
+        for _ in range(QK_PRELOAD)
+    ]
+    o_tile = [
+        pto.alloc_tile(shape=[vec_s0, HEAD], dtype=pto.f32)
+        for _ in range(row_slice_count)
+    ]
+
+    total_q_blocks = Q_ROWS // S0
+    num_tiles_s1 = s1_index // cS1_TILE
+    steady_tiles = num_tiles_s1 - cQK_PRELOAD
+
+    block_num = scalar.index_cast(pto.get_block_num())
+    block_idx = scalar.index_cast(pto.get_block_idx())
+    floor_div = total_q_blocks // block_num
+    extra = total_q_blocks % block_num
+    fat_start = block_idx * (floor_div + c1)
+    thin_start = extra * (floor_div + c1) + (block_idx - extra) * floor_div
+    qb_start = scalar.select(block_idx < extra, fat_start, thin_start)
+    per_core = scalar.select(block_idx < extra, floor_div + c1, floor_div)
+    qb_end = qb_start + per_core
+
+    def compute_qk_stage(tile_id):
+        slot_id = tile_id % cSLOT_NUM
+        tile_base = tile_id * cS1_TILE
+        with pto.for_(0, tile_factor, step=1) as sub:
+            s1_sub = tile_base + sub * cCUBE_S1
+            qk_slot_part = pto.partition_view(
+                qk_slots,
+                offsets=[slot_id * cS0, sub * cCUBE_S1],
+                sizes=[cS0, cCUBE_S1],
+            )
+            compute_qk(
+                q_left,
+                k_view,
+                qk_slot_part,
+                k_mat,
+                k_right,
+                qk_acc,
+                qk_tile,
+                s1_sub,
+            )
+
+    def compute_softmax_stage(tile_id, ring_id, is_init):
+        slot_id = tile_id % cSLOT_NUM
+        with pto.for_(0, row_slice_count, step=1) as row_slice:
+            row_off = row_slice * vec_s0
+            qk_slot_part = pto.partition_view(
+                qk_slots,
+                offsets=[slot_id * cS0 + row_off, c0],
+                sizes=[vec_s0, cS1_TILE],
+            )
+            p_slot_part = pto.partition_view(
+                p_slots,
+                offsets=[slot_id * cS0 + row_off, c0],
+                sizes=[vec_s0, cS1_TILE],
+            )
+
+            # row_slice_count and QK_PRELOAD are constexpr.  The source keeps
+            # one state tuple per row-slice and ring slot; this dispatch keeps
+            # the same authored ownership even though the current frontend does
+            # not have dynamic Python-list indexing by SSA values.
+            for static_row_slice in range(row_slice_count):
+                with pto.if_(row_slice == static_row_slice) as br:
+                    with br.then_:
+                        for static_ring in range(QK_PRELOAD):
+                            if isinstance(ring_id, int):
+                                if ring_id != static_ring:
+                                    continue
+                                compute_p(
+                                    qk_slot_part,
+                                    p_slot_part,
+                                    qk_vec,
+                                    p_fp32,
+                                    p_fp16,
+                                    softmax_tmp,
+                                    running_max[static_row_slice],
+                                    running_sum[static_row_slice],
+                                    local_max[static_row_slice],
+                                    local_sum[static_row_slice],
+                                    exp_max_ring[static_ring][static_row_slice],
+                                    is_init=is_init,
+                                )
+                            else:
+                                with pto.if_(ring_id == static_ring) as ring_br:
+                                    with ring_br.then_:
+                                        compute_p(
+                                            qk_slot_part,
+                                            p_slot_part,
+                                            qk_vec,
+                                            p_fp32,
+                                            p_fp16,
+                                            softmax_tmp,
+                                            running_max[static_row_slice],
+                                            running_sum[static_row_slice],
+                                            local_max[static_row_slice],
+                                            local_sum[static_row_slice],
+                                            exp_max_ring[static_ring][static_row_slice],
+                                            is_init=is_init,
+                                        )
+
+    def compute_pv_stage(tile_id):
+        slot_id = tile_id % cSLOT_NUM
+        with pto.for_(0, tile_factor, step=1) as sub:
+            s1_sub = tile_id * cS1_TILE + sub * cCUBE_S1
+            p_slot_part = pto.partition_view(
+                p_slots,
+                offsets=[slot_id * cS0, sub * cCUBE_S1],
+                sizes=[cS0, cCUBE_S1],
+            )
+            pv_slot_part = pto.partition_view(
+                pv_slots,
+                offsets=[slot_id * cS0, c0],
+                sizes=[cS0, cHEAD],
+            )
+            compute_pv(
+                p_slot_part,
+                v_view,
+                pv_slot_part,
+                p_recv,
+                p_left,
+                v_mat,
+                v_right,
+                pv_acc,
+                pv_tile,
+                s1_sub,
+                is_first_sub=(sub == c0),
+            )
+
+    def compute_gu_stage(tile_id, ring_id, is_init):
+        slot_id = tile_id % cSLOT_NUM
+        with pto.for_(0, row_slice_count, step=1) as row_slice:
+            row_off = row_slice * vec_s0
+            pv_slot_part = pto.partition_view(
+                pv_slots,
+                offsets=[slot_id * cS0 + row_off, c0],
+                sizes=[vec_s0, cHEAD],
+            )
+            for static_row_slice in range(row_slice_count):
+                with pto.if_(row_slice == static_row_slice) as br:
+                    with br.then_:
+                        for static_ring in range(QK_PRELOAD):
+                            if isinstance(ring_id, int):
+                                if ring_id != static_ring:
+                                    continue
+                                compute_gu(
+                                    pv_slot_part,
+                                    pv_vec,
+                                    o_tile[static_row_slice],
+                                    exp_max_ring[static_ring][static_row_slice],
+                                    is_init=is_init,
+                                )
+                            else:
+                                with pto.if_(ring_id == static_ring) as ring_br:
+                                    with ring_br.then_:
+                                        compute_gu(
+                                            pv_slot_part,
+                                            pv_vec,
+                                            o_tile[static_row_slice],
+                                            exp_max_ring[static_ring][static_row_slice],
+                                            is_init=is_init,
+                                        )
+
+    with pto.for_(qb_start, qb_end, step=1) as qb:
+        q_part = pto.partition_view(q_view, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
+        pto.tile.load(q_part, q_mat)
+        pto.tile.mov(q_mat, q_left)
+
+        for row_slice in range(row_slice_count):
+            running_max[row_slice].fill(float("-inf"))
+            running_sum[row_slice].fill(0.0)
+            o_tile[row_slice].fill(0.0)
+
+        for kp in range(QK_PRELOAD):
+            compute_qk_stage(kp)
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+        for kp in range(QK_PRELOAD):
+            compute_softmax_stage(
+                kp,
+                kp,
+                is_init=(kp == 0),
+            )
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+        with pto.for_(0, steady_tiles, step=1) as tile_id:
+            compute_pv_stage(tile_id)
+            compute_gu_stage(tile_id, tile_id % cQK_PRELOAD, is_init=(tile_id == c0))
+            compute_qk_stage(tile_id + cQK_PRELOAD)
+            compute_softmax_stage(
+                tile_id + cQK_PRELOAD,
+                (tile_id + cQK_PRELOAD) % cQK_PRELOAD,
+                is_init=False,
+            )
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+        for k in range(QK_PRELOAD):
+            drain_tile = steady_tiles + k
+            compute_pv_stage(drain_tile)
+            compute_gu_stage(drain_tile, drain_tile % cQK_PRELOAD, is_init=(drain_tile == c0))
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+        for row_slice in range(row_slice_count):
+            row_off = row_slice * vec_s0
+            pto.tile.rowexpanddiv(o_tile[row_slice], running_sum[row_slice], o_tile[row_slice])
+            o_part = pto.partition_view(
+                o_view,
+                offsets=[qb * cS0 + row_off, c0],
+                sizes=[vec_s0, cHEAD],
+            )
+            pto.tile.store(o_tile[row_slice], o_part)
+
+
+@pto.cube
+def compute_qk(
+    q_left: pto.Tile,
+    k_view: pto.TensorView,
+    qk_slot_part: pto.PartitionTensorView,
+    k_mat: pto.Tile,
+    k_right: pto.Tile,
+    qk_acc: pto.Tile,
+    qk_tile: pto.Tile,
+    s1_sub: pto.index,
+):
+    k_part = pto.partition_view(k_view, offsets=[0, s1_sub], sizes=[HEAD, CUBE_S1])
+    pto.tile.load(k_part, k_mat)
+    pto.tile.mov(k_mat, k_right)
+    pto.mad(q_left.as_ptr(), k_right.as_ptr(), qk_acc.as_ptr(), S0, CUBE_S1, HEAD)
+    pto.mte_l0c_ub(qk_acc.as_ptr(), qk_tile.as_ptr(), S0, CUBE_S1, CUBE_S1, CUBE_S1, 0)
+    pto.tile.store(qk_tile, qk_slot_part)
+
+
+@pto.simd
+def compute_p(
+    qk_slot_part: pto.PartitionTensorView,
+    p_slot_part: pto.PartitionTensorView,
+    qk_tile: pto.Tile,
+    p_fp32: pto.Tile,
+    p_fp16: pto.Tile,
+    tmp: pto.Tile,
+    running_max: pto.Tile,
+    running_sum: pto.Tile,
+    local_max: pto.Tile,
+    local_sum: pto.Tile,
+    exp_max: pto.Tile,
+    is_init: pto.i1,
+):
+    pto.tile.load(qk_slot_part, qk_tile)
+    pto.tile.rowmax(qk_tile, local_max, tmp=tmp)
+
+    def init_softmax_state():
+        pto.tile.mov(local_max, running_max)
+        pto.tile.rowexpandsub(qk_tile, running_max, p_fp32)
+        pto.tile.muls(p_fp32, 0.08838834764831845, p_fp32)
+        pto.tile.exp(p_fp32, p_fp32)
+        pto.tile.rowsum(p_fp32, running_sum, tmp=tmp)
+        exp_max.fill(1.0)
+
+    def update_softmax_state():
+        pto.tile.max(local_max, running_max, local_max)
+        pto.tile.sub(running_max, local_max, exp_max)
+        pto.tile.mov(local_max, running_max)
+        pto.tile.muls(exp_max, 0.08838834764831845, exp_max)
+        pto.tile.exp(exp_max, exp_max)
+        pto.tile.rowexpandsub(qk_tile, running_max, p_fp32)
+        pto.tile.muls(p_fp32, 0.08838834764831845, p_fp32)
+        pto.tile.exp(p_fp32, p_fp32)
+        pto.tile.mul(running_sum, exp_max, running_sum)
+        pto.tile.rowsum(p_fp32, local_sum, tmp=tmp)
+        pto.tile.add(running_sum, local_sum, running_sum)
+
+    if isinstance(is_init, bool):
+        if is_init:
+            init_softmax_state()
+        else:
+            update_softmax_state()
+    else:
+        with pto.if_(is_init) as branch:
+            with branch.then_:
+                init_softmax_state()
+            with branch.else_:
+                update_softmax_state()
+
+    pto.tile.cvt(p_fp32, p_fp16)
+    pto.tile.store(p_fp16, p_slot_part)
+
+
+@pto.cube
+def compute_pv(
+    p_slot_part: pto.PartitionTensorView,
+    v_view: pto.TensorView,
+    pv_slot_part: pto.PartitionTensorView,
+    p_recv: pto.Tile,
+    p_left: pto.Tile,
+    v_mat: pto.Tile,
+    v_right: pto.Tile,
+    pv_acc: pto.Tile,
+    pv_tile: pto.Tile,
+    s1_sub: pto.index,
+    is_first_sub: pto.i1,
+):
+    pto.tile.load(p_slot_part, p_recv)
+    pto.tile.mov(p_recv, p_left)
+
+    v_part = pto.partition_view(v_view, offsets=[s1_sub, 0], sizes=[CUBE_S1, HEAD])
+    pto.tile.load(v_part, v_mat)
+    pto.tile.mov(v_mat, v_right)
+
+    with pto.if_(is_first_sub) as branch:
+        with branch.then_:
+            pto.mad(p_left.as_ptr(), v_right.as_ptr(), pv_acc.as_ptr(), S0, HEAD, CUBE_S1)
+        with branch.else_:
+            pto.mad_acc(p_left.as_ptr(), v_right.as_ptr(), pv_acc.as_ptr(), S0, HEAD, CUBE_S1)
+
+    pto.mte_l0c_ub(pv_acc.as_ptr(), pv_tile.as_ptr(), S0, HEAD, HEAD, HEAD, 0)
+    pto.tile.store(pv_tile, pv_slot_part)
+
+
+@pto.simd
+def compute_gu(
+    pv_slot_part: pto.PartitionTensorView,
+    pv_tile: pto.Tile,
+    o_tile: pto.Tile,
+    exp_max: pto.Tile,
+    is_init: pto.i1,
+):
+    pto.tile.load(pv_slot_part, pv_tile)
+    if isinstance(is_init, bool):
+        if is_init:
+            pto.tile.mov(pv_tile, o_tile)
+        else:
+            pto.tile.rowexpandmul(o_tile, exp_max, o_tile)
+            pto.tile.add(o_tile, pv_tile, o_tile)
+    else:
+        with pto.if_(is_init) as branch:
+            with branch.then_:
+                pto.tile.mov(pv_tile, o_tile)
+            with branch.else_:
+                pto.tile.rowexpandmul(o_tile, exp_max, o_tile)
+                pto.tile.add(o_tile, pv_tile, o_tile)
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Emit PTOAS PTODSL MLIR for the hw-native Python flash_atten port."
+    )
+    parser.add_argument("--head-dim", type=int, default=HEAD)
+    parser.add_argument("--s1-tile", type=int, default=DEFAULT_S1_TILE)
+    parser.add_argument("--qk-preload", type=int, default=DEFAULT_QK_PRELOAD)
+    parser.add_argument("--q-rows", type=int, default=S0)
+    parser.add_argument("--causal", action="store_true")
+    parser.add_argument("-o", "--output", default="-", help="output MLIR path, or '-' for stdout")
+    return parser
+
+
+def main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    mlir_text = emit_flash_attention_mlir(
+        head_dim=args.head_dim,
+        s1_tile=args.s1_tile,
+        qk_preload=args.qk_preload,
+        causal=args.causal,
+        q_rows=args.q_rows,
+    )
+    if args.output == "-":
+        print(mlir_text)
+        return
+    Path(args.output).write_text(mlir_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/examples/hw_native_flash_attention.py
+++ b/ptodsl/examples/hw_native_flash_attention.py
@@ -15,14 +15,15 @@ Source implementation:
 The source is authored against the older external ``huawei-csl/pto-dsl``
 package.  This file ports the authored kernel shape and dataflow to the current
 PTOAS in-tree PTODSL surface.  It is intentionally frontend/compile focused:
-it emits PTO MLIR that exposes the same high-level stages and slot layout, but
-does not implement the old runtime FIFO protocol in Python.
+it emits PTO MLIR that exposes the same high-level stages, slot layout, and
+Cube/Vector pipe transaction boundaries, but does not implement the old runtime
+FIFO protocol in Python.
 
 Ported source structure:
 
     old fa_builder.py module/to_ir_module    -> @pto.jit(...).compile(...)
     old TensorType/SubTensorType globals     -> pto.ptr + make_tensor_view
-    old declare_global + l2g2l FIFO entries  -> GM slot tensor views
+    old declare_global + l2g2l FIFO entries  -> GM slot tensor views + local pipe surface
     old pto.load/store                       -> pto.tile.load/store
     old tile.matmul/matmul_acc               -> @pto.cube + pto.mad/mad_acc
     old vector row-reduce softmax/GU         -> @pto.simd tile ops
@@ -36,9 +37,10 @@ The source four-stage pipeline is preserved in the authored surface:
 
 Current boundary:
 
-* True talloc/tpush/tpop/tfree FIFO scheduling is a backend/runtime concern.
-  This port represents the slot addresses and stage dataflow in frontend MLIR
-  using explicit GM slot tensor views.
+* True FIFO scheduling, TSyncCVID lifetime management, and runtime backpressure
+  are backend/runtime concerns.  This port represents the slot addresses and
+  stage dataflow in frontend MLIR using explicit GM slot tensor views plus
+  PTODSL local pipe init/push/pop/free transactions.
 * The source example targets non-causal HEAD=128 FA.  This port keeps that
   contract and rejects unsupported specialization knobs early.
 * Runtime launch, torch_npu validation, and A3/A5 performance checks are not
@@ -72,6 +74,9 @@ CUBE_S1 = 128
 DEFAULT_S1_TILE = 256
 DEFAULT_QK_PRELOAD = 3
 SLOT_NUM = 8
+QK_C2V_PIPE_ID = 0
+P_V2C_PIPE_ID = 1
+PV_C2V_PIPE_ID = 2
 
 SPLIT_UP_DOWN = 1
 VEC_CORES = 2
@@ -104,7 +109,7 @@ def describe_hw_native_flash_attention_port():
             "old_tensor_types": "TensorType/SubTensorType module globals",
             "new_tensor_views": "pto.ptr + pto.make_tensor_view + pto.partition_view",
             "old_fifo": "initialize_l2g2l_pipe + talloc/tpush/tpop/tfree",
-            "new_frontend_slots": "explicit GM slot tensor views; runtime FIFO remains backend work",
+            "new_frontend_slots": "explicit GM slot tensor views + A5 local pipe surface; runtime FIFO remains backend work",
         },
         "source_constants": {
             "S0": S0,
@@ -118,7 +123,8 @@ def describe_hw_native_flash_attention_port():
         },
         "dataflow": ["compute_qk", "compute_p", "compute_pv", "compute_gu"],
         "frontend_features": [
-            "QK_PRELOAD prologue/steady/epilogue shadow schedule",
+            "QK_PRELOAD prologue/steady/epilogue schedule",
+            "A5 local pipe surface for QK/P/PV stage boundaries",
             "Vec_S0 row-slice state arrays",
             "exp_max_ring per preload slot and row-slice",
             "wide P slot producer/consumer",
@@ -196,6 +202,9 @@ def flash_attention_kernel(
     slot_size_qk_f32 = S0 * S1_TILE
     slot_size_pv_f32 = S0 * HEAD
     slot_size_p_f16 = S0 * S1_TILE
+    qk_pipe_slot_bytes = S0 * CUBE_S1 * 4
+    p_pipe_slot_bytes = vec_s0 * S1_TILE * 2
+    pv_pipe_slot_bytes = S0 * HEAD * 4
     gm_pv_off_f32 = slot_size_qk_f32 * SLOT_NUM
     gm_p_off_f32 = gm_pv_off_f32 + slot_size_pv_f32 * SLOT_NUM
 
@@ -231,6 +240,42 @@ def flash_attention_kernel(
         p_workspace,
         offsets=[p_slot_row_offset, c0],
         sizes=[cSLOT_NUM * cS0, cS1_TILE],
+    )
+    qk_c2v_buf = pto.reserve_buffer(
+        "fa_qk_c2v_fifo",
+        size=qk_pipe_slot_bytes * SLOT_NUM,
+        location="vec",
+    )
+    p_v2c_buf = pto.reserve_buffer(
+        "fa_p_v2c_fifo",
+        size=p_pipe_slot_bytes * SLOT_NUM,
+        location="mat",
+    )
+    pv_c2v_buf = pto.reserve_buffer(
+        "fa_pv_c2v_fifo",
+        size=pv_pipe_slot_bytes * SLOT_NUM,
+        location="vec",
+    )
+    qk_c2v_pipe = pto.pipe.c2v_local(
+        slot_size=qk_pipe_slot_bytes,
+        consumer_buf=qk_c2v_buf,
+        id=QK_C2V_PIPE_ID,
+        local_slot_num=SLOT_NUM,
+        nosplit=True,
+    )
+    p_v2c_pipe = pto.pipe.v2c_local(
+        slot_size=p_pipe_slot_bytes,
+        consumer_buf=p_v2c_buf,
+        id=P_V2C_PIPE_ID,
+        local_slot_num=SLOT_NUM,
+        nosplit=True,
+    )
+    pv_c2v_pipe = pto.pipe.c2v_local(
+        slot_size=pv_pipe_slot_bytes,
+        consumer_buf=pv_c2v_buf,
+        id=PV_C2V_PIPE_ID,
+        local_slot_num=SLOT_NUM,
+        nosplit=True,
     )
 
     q_mat = pto.alloc_tile(shape=[S0, HEAD], dtype=pto.f16, memory_space="mat")
@@ -316,6 +361,7 @@ def flash_attention_kernel(
                 q_left,
                 k_view,
                 qk_slot_part,
+                qk_c2v_pipe,
                 k_mat,
                 k_right,
                 qk_acc,
@@ -352,6 +398,8 @@ def flash_attention_kernel(
                                 compute_p(
                                     qk_slot_part,
                                     p_slot_part,
+                                    qk_c2v_pipe,
+                                    p_v2c_pipe,
                                     qk_vec,
                                     p_fp32,
                                     p_fp16,
@@ -369,6 +417,8 @@ def flash_attention_kernel(
                                         compute_p(
                                             qk_slot_part,
                                             p_slot_part,
+                                            qk_c2v_pipe,
+                                            p_v2c_pipe,
                                             qk_vec,
                                             p_fp32,
                                             p_fp16,
@@ -399,6 +449,8 @@ def flash_attention_kernel(
                 p_slot_part,
                 v_view,
                 pv_slot_part,
+                p_v2c_pipe,
+                pv_c2v_pipe,
                 p_recv,
                 p_left,
                 v_mat,
@@ -427,6 +479,7 @@ def flash_attention_kernel(
                                     continue
                                 compute_gu(
                                     pv_slot_part,
+                                    pv_c2v_pipe,
                                     pv_vec,
                                     o_tile[static_row_slice],
                                     exp_max_ring[static_ring][static_row_slice],
@@ -437,6 +490,7 @@ def flash_attention_kernel(
                                     with ring_br.then_:
                                         compute_gu(
                                             pv_slot_part,
+                                            pv_c2v_pipe,
                                             pv_vec,
                                             o_tile[static_row_slice],
                                             exp_max_ring[static_ring][static_row_slice],
@@ -444,6 +498,9 @@ def flash_attention_kernel(
                                         )
 
     with pto.for_(qb_start, qb_end, step=1) as qb:
+        init_fa_cube_pipes(qk_c2v_pipe, p_v2c_pipe, pv_c2v_pipe)
+        init_fa_vector_pipes(qk_c2v_pipe, p_v2c_pipe, pv_c2v_pipe)
+
         q_part = pto.partition_view(q_view, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
         pto.tile.load(q_part, q_mat)
         pto.tile.mov(q_mat, q_left)
@@ -494,10 +551,25 @@ def flash_attention_kernel(
 
 
 @pto.cube
+def init_fa_cube_pipes(qk_c2v_pipe, p_v2c_pipe, pv_c2v_pipe):
+    qk_c2v_pipe.init_cube()
+    p_v2c_pipe.init_cube()
+    pv_c2v_pipe.init_cube()
+
+
+@pto.simd
+def init_fa_vector_pipes(qk_c2v_pipe, p_v2c_pipe, pv_c2v_pipe):
+    qk_c2v_pipe.init_simd()
+    p_v2c_pipe.init_simd()
+    pv_c2v_pipe.init_simd()
+
+
+@pto.cube
 def compute_qk(
     q_left: pto.Tile,
     k_view: pto.TensorView,
     qk_slot_part: pto.PartitionTensorView,
+    qk_pipe,
     k_mat: pto.Tile,
     k_right: pto.Tile,
     qk_acc: pto.Tile,
@@ -510,12 +582,15 @@ def compute_qk(
     pto.mad(q_left.as_ptr(), k_right.as_ptr(), qk_acc.as_ptr(), S0, CUBE_S1, HEAD)
     pto.mte_l0c_ub(qk_acc.as_ptr(), qk_tile.as_ptr(), S0, CUBE_S1, CUBE_S1, CUBE_S1, 0)
     pto.tile.store(qk_tile, qk_slot_part)
+    qk_pipe.push(qk_tile, split=0)
 
 
 @pto.simd
 def compute_p(
     qk_slot_part: pto.PartitionTensorView,
     p_slot_part: pto.PartitionTensorView,
+    qk_pipe,
+    p_pipe,
     qk_tile: pto.Tile,
     p_fp32: pto.Tile,
     p_fp16: pto.Tile,
@@ -527,6 +602,8 @@ def compute_p(
     exp_max: pto.Tile,
     is_init: pto.i1,
 ):
+    _ = qk_pipe.pop(result_type=qk_tile, split=0)
+    qk_pipe.free(split=0)
     pto.tile.load(qk_slot_part, qk_tile)
     pto.tile.rowmax(qk_tile, local_max, tmp=tmp)
 
@@ -565,6 +642,7 @@ def compute_p(
 
     pto.tile.cvt(p_fp32, p_fp16)
     pto.tile.store(p_fp16, p_slot_part)
+    p_pipe.push(p_fp16, split=0)
 
 
 @pto.cube
@@ -572,6 +650,8 @@ def compute_pv(
     p_slot_part: pto.PartitionTensorView,
     v_view: pto.TensorView,
     pv_slot_part: pto.PartitionTensorView,
+    p_pipe,
+    pv_pipe,
     p_recv: pto.Tile,
     p_left: pto.Tile,
     v_mat: pto.Tile,
@@ -581,6 +661,8 @@ def compute_pv(
     s1_sub: pto.index,
     is_first_sub: pto.i1,
 ):
+    _ = p_pipe.pop(result_type=p_recv, split=0)
+    p_pipe.free(split=0)
     pto.tile.load(p_slot_part, p_recv)
     pto.tile.mov(p_recv, p_left)
 
@@ -596,16 +678,20 @@ def compute_pv(
 
     pto.mte_l0c_ub(pv_acc.as_ptr(), pv_tile.as_ptr(), S0, HEAD, HEAD, HEAD, 0)
     pto.tile.store(pv_tile, pv_slot_part)
+    pv_pipe.push(pv_tile, split=0)
 
 
 @pto.simd
 def compute_gu(
     pv_slot_part: pto.PartitionTensorView,
+    pv_pipe,
     pv_tile: pto.Tile,
     o_tile: pto.Tile,
     exp_max: pto.Tile,
     is_init: pto.i1,
 ):
+    _ = pv_pipe.pop(result_type=pv_tile, split=0)
+    pv_pipe.free(split=0)
     pto.tile.load(pv_slot_part, pv_tile)
     if isinstance(is_init, bool):
         if is_init:

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -53,6 +53,7 @@ from ._types import (
     _isinstance_pto_type,
     _integer_signedness,
     _materialize_integer_literal,
+    _normalize_address_space,
     _resolve,
     _strip_integer_signedness,
     mask_type,
@@ -3247,6 +3248,33 @@ def wait_flag(src: str, dst: str, *, event_id: int = 0):
     _pto.wait_flag_dyn(_pipe_attr(src), _pipe_attr(dst), event_operand)
 
 
+def reserve_buffer(name, *, size, location, auto=True, base=None):
+    """``pto.reserve_buffer(name, size, location, auto=True, base=None)``."""
+    space = _normalize_address_space(location)
+    if space not in (_pto.AddressSpace.VEC, _pto.AddressSpace.MAT):
+        raise ValueError(
+            "reserve_buffer(location=...) expects 'vec' or 'mat' address space"
+        )
+    op = _pto.ReserveBufferOp(
+        name,
+        size,
+        _pto.AddressSpaceAttr.get(space),
+        bool(auto),
+        base=base,
+    )
+    return wrap_surface_value(op.result)
+
+
+def import_reserved_buffer(name, *, peer_func):
+    """``pto.import_reserved_buffer(name, peer_func=...)``."""
+    if not isinstance(peer_func, str):
+        peer_func = getattr(getattr(peer_func, "spec", None), "symbol_name", None) \
+            or getattr(peer_func, "__name__", None) \
+            or str(peer_func)
+    op = _pto.ImportReservedBufferOp(name, peer_func)
+    return wrap_surface_value(op.result)
+
+
 __all__ = [
     "const",
     "castptr", "addptr",
@@ -3299,4 +3327,5 @@ __all__ = [
     "pipe_barrier", "get_buf", "rls_buf",
     "set_cross_flag", "wait_cross_flag", "set_intra_flag", "wait_intra_flag",
     "set_flag", "wait_flag",
+    "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/_pipe_namespace.py
+++ b/ptodsl/ptodsl/_pipe_namespace.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+"""High-level PTODSL pipe surface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from ._ops import (
+    _coerce_index,
+    _element_bytewidth,
+    _pto,
+    unwrap_surface_value,
+    wrap_surface_value,
+)
+
+
+def _require_pipe_id(id, *, context: str) -> int:
+    if id is None:
+        raise TypeError(f"{context} requires an explicit stable id")
+    return int(id)
+
+
+def _infer_global_slot_size(gm_slot_tensor) -> int:
+    surface_shape = getattr(gm_slot_tensor, "shape", None)
+    value = unwrap_surface_value(gm_slot_tensor)
+    tensor_type = value.type
+    if not _pto.TensorViewType.isinstance(tensor_type):
+        raise TypeError(
+            "pipe.c2v_global/v2c_global expects gm_slot_tensor to be !pto.tensor_view"
+        )
+
+    tensor_view_type = _pto.TensorViewType(tensor_type)
+    shape = tuple(surface_shape) if surface_shape is not None else tuple(tensor_view_type.shape)
+    if any(dim < 0 for dim in shape):
+        raise ValueError(
+            "pipe.c2v_global/v2c_global cannot infer slot_size from a dynamic gm_slot_tensor shape"
+        )
+    count = 1
+    for dim in shape:
+        count *= int(dim)
+    return count * _element_bytewidth(tensor_view_type.element_type)
+
+
+def _as_int(value, *, context: str):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    return _coerce_index(value, context=context)
+
+
+def _normalize_entry_value(value):
+    if value is None:
+        return None
+    return unwrap_surface_value(value)
+
+
+def _normalize_result_type(value, *, context: str):
+    if value is None:
+        return None
+    unwrapped = unwrap_surface_value(value)
+    return getattr(unwrapped, "type", unwrapped)
+
+
+def _normalize_valid_shape(valid_shape, *, valid_row, valid_col):
+    if valid_shape is not None:
+        if valid_row is not None or valid_col is not None:
+            raise TypeError("pipe.pop(...) accepts either valid_shape or valid_row/valid_col, not both")
+        if len(valid_shape) == 1:
+            valid_row, valid_col = 1, valid_shape[0]
+        elif len(valid_shape) == 2:
+            valid_row, valid_col = valid_shape
+        else:
+            raise TypeError("pipe.pop(valid_shape=...) expects one or two dimensions")
+    if (valid_row is None) != (valid_col is None):
+        raise TypeError("pipe.pop(...) requires valid_row and valid_col to be provided together")
+    if valid_row is None:
+        return None, None
+    return (
+        _coerce_index(valid_row, context="pipe.pop(..., valid_row=...)"),
+        _coerce_index(valid_col, context="pipe.pop(..., valid_col=...)"),
+    )
+
+
+@dataclass(frozen=True)
+class _PipeDescriptor:
+    kind: str
+    direction: str
+    id: int
+    slot_size: int
+    entry_type: object | None
+    gm_slot_tensor: object | None = None
+    gm_slot_buffer: object | None = None
+    c2v_consumer_buf: object | None = None
+    v2c_consumer_buf: object | None = None
+    local_slot_num: int | None = None
+    nosplit: bool | None = None
+
+
+class _PipeSurface:
+    """Direction-aware logical pipe object."""
+
+    def __init__(self, descriptor: _PipeDescriptor):
+        self._descriptor = descriptor
+
+    @property
+    def entry_type(self):
+        return self._descriptor.entry_type
+
+    @property
+    def id(self):
+        return self._descriptor.id
+
+    @property
+    def slot_size(self):
+        return self._descriptor.slot_size
+
+    @property
+    def c2v(self):
+        if self._descriptor.direction != "both":
+            raise TypeError("c2v endpoint is only available on bidirectional local pipes")
+        return _PipeSurface(
+            replace(
+                self._descriptor,
+                kind="c2v_local",
+                direction="c2v",
+                v2c_consumer_buf=None,
+            )
+        )
+
+    @property
+    def v2c(self):
+        if self._descriptor.direction != "both":
+            raise TypeError("v2c endpoint is only available on bidirectional local pipes")
+        return _PipeSurface(
+            replace(
+                self._descriptor,
+                kind="v2c_local",
+                direction="v2c",
+                c2v_consumer_buf=None,
+            )
+        )
+
+    def init_cube(self):
+        self._emit_init("cube")
+
+    def init_simd(self):
+        self._emit_init("simd")
+
+    def alloc(self, split=0):
+        if self._descriptor.kind != "global":
+            raise TypeError("alloc() is only available on global-entry pipes")
+        split = _as_int(split, context="pipe.alloc(..., split=...)")
+        entry_type = self.entry_type
+        if entry_type is None:
+            raise RuntimeError("global-entry pipe is missing entry_type metadata")
+        if self._descriptor.direction == "c2v":
+            op = _pto.TAllocToAivOp(entry_type, split, id=self.id)
+        else:
+            op = _pto.TAllocToAicOp(entry_type, split, id=self.id)
+        return wrap_surface_value(op.result)
+
+    def push(self, entry, split=0):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous push direction")
+        split = _as_int(split, context="pipe.push(..., split=...)")
+        if entry is None:
+            raise TypeError("push() requires an entry value")
+        entry_value = _normalize_entry_value(entry)
+        if self._descriptor.direction == "c2v":
+            _pto.TPushToAivOp(entry_value, split, id=self.id)
+        else:
+            _pto.TPushToAicOp(entry_value, split, id=self.id)
+
+    def pop(self, split=0, result_type=None, *, valid_shape=None, valid_row=None, valid_col=None):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous pop direction")
+        split = _as_int(split, context="pipe.pop(..., split=...)")
+        if result_type is None:
+            result_type = self.entry_type
+        result_type = _normalize_result_type(result_type, context="pipe.pop(..., result_type=...)")
+        if result_type is None:
+            raise TypeError("pop() requires result_type for local/tile-entry pipes")
+        valid_row, valid_col = _normalize_valid_shape(
+            valid_shape,
+            valid_row=valid_row,
+            valid_col=valid_col,
+        )
+        if self._descriptor.direction == "c2v":
+            op = self._emit_pop_from_aic(result_type, split, valid_row, valid_col)
+        else:
+            op = self._emit_pop_from_aiv(result_type, split, valid_row, valid_col)
+        return wrap_surface_value(op.result)
+
+    def free(self, entry=None, split=0):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous free direction")
+        split = _as_int(split, context="pipe.free(..., split=...)")
+        if self._descriptor.kind == "global" and entry is None:
+            raise TypeError("free() requires an entry value for global-entry pipes")
+        entry_value = _normalize_entry_value(entry)
+        if self._descriptor.direction == "c2v":
+            _pto.TFreeFromAicOp(split, entry=entry_value, id=self.id)
+        else:
+            _pto.TFreeFromAivOp(split, entry=entry_value, id=self.id)
+
+    def _emit_pop_from_aic(self, result_type, split, valid_row, valid_col):
+        if valid_row is None:
+            return _pto.TPopFromAicOp(result_type, split, id=self.id)
+        return _pto.TPopFromAicOp(
+            result_type,
+            split,
+            valid_row=valid_row,
+            valid_col=valid_col,
+            id=self.id,
+        )
+
+    def _emit_pop_from_aiv(self, result_type, split, valid_row, valid_col):
+        if valid_row is None:
+            return _pto.TPopFromAivOp(result_type, split, id=self.id)
+        return _pto.TPopFromAivOp(
+            result_type,
+            split,
+            valid_row=valid_row,
+            valid_col=valid_col,
+            id=self.id,
+        )
+
+    def _emit_init(self, side: str):
+        desc = self._descriptor
+        init_kwargs = {
+            "id": desc.id,
+        }
+
+        if desc.kind == "global":
+            init_kwargs["gm_slot_tensor"] = desc.gm_slot_tensor
+            init_kwargs["nosplit"] = desc.nosplit
+        elif desc.kind == "c2v_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
+        elif desc.kind == "v2c_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
+        else:
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+
+        if desc.kind == "bidirectional_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
+            init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
+
+        init_kwargs = {key: value for key, value in init_kwargs.items() if value is not None}
+
+        if side == "cube":
+            _pto.AicInitializePipeOp(
+                1 if desc.direction == "c2v" else 2 if desc.direction == "v2c" else 3,
+                desc.slot_size,
+                **init_kwargs,
+            )
+            return
+
+        _pto.AivInitializePipeOp(
+            1 if desc.direction == "c2v" else 2 if desc.direction == "v2c" else 3,
+            desc.slot_size,
+            **init_kwargs,
+        )
+
+
+class _PipeNamespace:
+    def c2v_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
+        id = _require_pipe_id(id, context="pipe.c2v_global(...)")
+        if slot_size is None:
+            slot_size = _infer_global_slot_size(gm_slot_tensor)
+        descriptor = _PipeDescriptor(
+            kind="global",
+            direction="c2v",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=unwrap_surface_value(gm_slot_tensor).type,
+            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def v2c_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
+        id = _require_pipe_id(id, context="pipe.v2c_global(...)")
+        if slot_size is None:
+            slot_size = _infer_global_slot_size(gm_slot_tensor)
+        descriptor = _PipeDescriptor(
+            kind="global",
+            direction="v2c",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=unwrap_surface_value(gm_slot_tensor).type,
+            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def c2v_local(
+        self,
+        *,
+        slot_size,
+        consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.c2v_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="c2v_local",
+            direction="c2v",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            c2v_consumer_buf=_normalize_entry_value(consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def v2c_local(
+        self,
+        *,
+        slot_size,
+        consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.v2c_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="v2c_local",
+            direction="v2c",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            v2c_consumer_buf=_normalize_entry_value(consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def bidirectional_local(
+        self,
+        *,
+        slot_size,
+        c2v_consumer_buf,
+        v2c_consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.bidirectional_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="bidirectional_local",
+            direction="both",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            c2v_consumer_buf=_normalize_entry_value(c2v_consumer_buf),
+            v2c_consumer_buf=_normalize_entry_value(v2c_consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+
+pipe = _PipeNamespace()

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -121,6 +121,16 @@ class TraceSession:
     def lower_inline_subkernel(self, subkernel, *args, **kwargs):
         """Lower one inline PTODSL subkernel call through the shared session."""
         with self.enter_subkernel(subkernel):
+            role = subkernel.spec.role.value
+            if role in {"cube", "simd"}:
+                section = (
+                    _pto.SectionCubeOp()
+                    if role == "cube"
+                    else _pto.SectionVectorOp()
+                )
+                section_block = section.body.blocks.append()
+                with InsertionPoint(section_block):
+                    return subkernel.emit_body(*args, **kwargs)
             return subkernel.emit_body(*args, **kwargs)
 
     def begin_carry_loop(self, start, stop, step, state_items):

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -95,6 +95,7 @@ from ._ops import (             # noqa: F401
     get_buf, rls_buf,
     set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
     set_flag, wait_flag,
+    reserve_buffer, import_reserved_buffer,
 )
 
 # ── Control flow ──────────────────────────────────────────────────────────────
@@ -106,8 +107,13 @@ from ._control_flow import (    # noqa: F401
 # ── Decorator ─────────────────────────────────────────────────────────────────
 from ._jit import jit, KernelHandle, merge_jit_modules      # noqa: F401
 from ._subkernels import cube, simd, simt     # noqa: F401
+from ._pipe_namespace import pipe  # noqa: F401
 
 # ── Shorthand dtype aliases ───────────────────────────────────────────────────
+def gm_ptr(elem):
+    return ptr(elem, "gm")
+
+
 f32 = float32
 f16 = float16
 i1 = int1

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -1803,4 +1803,300 @@ FRAGMENT_FIXTURES = {
         {SNIPPET_PLACEHOLDER}
         """
     ),
+    "pipe_communication.c2v_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+            a_part = pto.partition_view(
+                pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+            a_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+            b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+            b_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+
+            src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+
+            dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_import": _fixture(
+        f"""
+        @pto.simt
+        def vector_kernel():
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+
+
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_import_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            vector_kernel()
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_producer": _fixture(
+        f"""
+        @pto.simt
+        def vector_kernel():
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+
+
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            vector_kernel()
+            c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
+            c2v_peer = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
+            src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_consumer": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_consumer_probe(
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            c2v = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
+            dst_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+            dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.bidirectional_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_bidirectional_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global": _fixture(
+        f"""
+        {SNIPPET_PLACEHOLDER}
+
+
+        pipe_communication_c2v_global_probe = vector_consumer
+        """
+    ),
+    "pipe_communication.c2v_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+            a_part = pto.partition_view(
+                pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+            a_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+            b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+            b_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+            src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+            src_part = pto.partition_view(
+                pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+            dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+            dst_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_import": _fixture(
+        f"""
+        @pto.simt
+        def vector_kernel():
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+
+
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_import_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            vector_kernel()
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.bidirectional_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_bidirectional_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
 }

--- a/ptodsl/tests/test_flash_attention_demo_compile.py
+++ b/ptodsl/tests/test_flash_attention_demo_compile.py
@@ -10,6 +10,7 @@
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 import sys
+import tempfile
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
@@ -36,15 +37,15 @@ def expect_parse_roundtrip_and_verify(text: str, label: str) -> None:
 
 def load_flash_attention_demo():
     demo_candidates = [
-        REPO_ROOT / "ptodsl" / "examples" / "flash_attention_sketch.py",
-        REPO_ROOT / "ptodsl" / "demos" / "flash_attention_sketch.py",
+        REPO_ROOT / "ptodsl" / "examples" / "hw_native_flash_attention.py",
+        REPO_ROOT / "ptodsl" / "demos" / "hw_native_flash_attention.py",
     ]
     for demo_path in demo_candidates:
         if demo_path.is_file():
             break
     else:
         raise AssertionError(
-            "canonical flash attention demo is missing: "
+            "canonical hw-native flash attention demo is missing: "
             + ", ".join(str(path) for path in demo_candidates)
         )
 
@@ -60,30 +61,83 @@ def main() -> None:
 
     expect(hasattr(demo, "emit_flash_attention_mlir"), "flash attention demo should export emit_flash_attention_mlir(...)")
     expect(hasattr(demo, "flash_attention_kernel"), "flash attention demo should export flash_attention_kernel")
+    expect(hasattr(demo, "build_arg_parser"), "flash attention demo should expose a CLI argument parser")
+    expect(
+        hasattr(demo, "describe_hw_native_flash_attention_port"),
+        "flash attention demo should describe the hw-native source port",
+    )
+    port_info = demo.describe_hw_native_flash_attention_port()
+    expect(
+        "hw-native-sys/pto-isa" in port_info["source"],
+        f"unexpected source mapping: {port_info!r}",
+    )
+    expect(
+        port_info["dataflow"] == ["compute_qk", "compute_p", "compute_pv", "compute_gu"],
+        f"unexpected FA dataflow mapping: {port_info!r}",
+    )
+    expect(
+        port_info["ported_file"] == "kernels/python/flash_atten/kernels/fa_builder.py",
+        f"unexpected source file mapping: {port_info!r}",
+    )
+    for feature in [
+        "QK_PRELOAD prologue/steady/epilogue shadow schedule",
+        "Vec_S0 row-slice state arrays",
+        "exp_max_ring per preload slot and row-slice",
+        "wide P slot producer/consumer",
+        "block_idx/block_num Q block distribution",
+    ]:
+        expect(feature in port_info["frontend_features"], f"missing frontend feature marker: {feature}")
 
-    wrapper_text = demo.emit_flash_attention_mlir(head_dim=128, causal=False, block_q=128, block_kv=128)
+    wrapper_text = demo.emit_flash_attention_mlir(
+        head_dim=128,
+        causal=False,
+        s1_tile=256,
+        qk_preload=3,
+    )
     expect_parse_roundtrip_and_verify(wrapper_text, "flash attention wrapper-emitted MLIR")
     expect("func.func @flash_attention_kernel" in wrapper_text, "wrapper compile should emit the flash_attention_kernel entry")
     expect('pto.mode = "explicit"' in wrapper_text, "flash attention wrapper compile should carry explicit mode metadata")
-    expect("func.func @materialize_tile_bounds" in wrapper_text, "wrapper compile should emit the SIMT helper function")
-    expect("pto.store_vfsimt_info" in wrapper_text, "wrapper compile should materialize SIMT caller metadata setup")
     expect("pto.barrier <PIPE_ALL>" in wrapper_text, "demo phase boundaries should lower to pipe_barrier(Pipe.ALL)")
+    expect(wrapper_text.count("pto.mad") >= 2, "wrapper compile should keep the QK and PV cube matmul stages")
+    expect("pto.mad_acc" in wrapper_text, "wrapper compile should keep the PV accumulation stage")
+    expect("pto.trowmax" in wrapper_text, "wrapper compile should keep tile row-max softmax")
+    expect("pto.texp" in wrapper_text, "wrapper compile should keep tile exp softmax")
+    expect("pto.trowexpandmul" in wrapper_text, "wrapper compile should keep GU rescale")
+    expect("pto.trowexpanddiv" in wrapper_text, "wrapper compile should keep final normalization")
+    expect("pto.make_tensor_view" in wrapper_text, "QK/P/PV GM slots should be explicit tensor views")
+    expect("%c256" in wrapper_text, "S1_TILE=256 should appear in slot tensor view shape operands")
+    expect("32x256xf32" in wrapper_text, "S1_TILE=256 should use Vec_S0=32 row-slice tiles")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cli_output = Path(tmpdir) / "flash_attention_hw_native_port.mlir"
+        demo.main([
+            "--head-dim", "128",
+            "--s1-tile", "512",
+            "--qk-preload", "4",
+            "-o", str(cli_output),
+        ])
+        cli_text = cli_output.read_text(encoding="utf-8")
+        expect_parse_roundtrip_and_verify(cli_text, "flash attention CLI-emitted MLIR")
+        expect("func.func @flash_attention_kernel" in cli_text, "CLI output should contain the kernel entry")
+        expect("%c512" in cli_text, "CLI S1_TILE=512 should specialize QK/P slot shape operands")
+        expect("16x512xf32" in cli_text, "CLI S1_TILE=512 should use Vec_S0=16 row-slice tiles")
 
     compiled = demo.flash_attention_kernel.compile(
-        BLOCK_Q=64,
-        BLOCK_KV=128,
         HEAD_DIM=128,
-        CAUSAL=True,
+        S1_TILE=256,
+        QK_PRELOAD=3,
+        CAUSAL=False,
+        Q_ROWS=128,
     )
     compiled.verify()
 
     expect(
         compiled.constexpr_bindings == {
-            "BLOCK_Q": 64,
-            "BLOCK_KV": 128,
             "HEAD_DIM": 128,
-            "CAUSAL": True,
-            "NUM_STAGES": 2,
+            "S1_TILE": 256,
+            "QK_PRELOAD": 3,
+            "CAUSAL": False,
+            "Q_ROWS": 128,
         },
         f"unexpected constexpr bindings: {compiled.constexpr_bindings!r}",
     )
@@ -92,8 +146,8 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(specialized_text, "flash attention specialized MLIR")
     expect("func.func @flash_attention_kernel" in specialized_text, "direct compile should emit the flash_attention_kernel entry")
     expect('pto.mode = "explicit"' in specialized_text, "direct compile should carry explicit mode metadata")
-    expect("!pto.tile_buf<mat, 64x128xf32" in specialized_text, "BLOCK_Q=64 specialization should change the physical Q tile shape")
-    expect("func.call @materialize_tile_bounds" in specialized_text, "direct compile should still route SIMT helpers through func.call")
+    expect("!pto.tile_buf<mat, 128x128xf16" in specialized_text, "direct compile should keep source Q MAT tile shape")
+    expect("pto.trowmax" in specialized_text, "direct compile should keep the softmax stage")
 
     cached = demo.flash_attention_kernel.cached_specializations()
     expect(len(cached) >= 2, "wrapper compile plus explicit compile should populate at least two cached specializations")

--- a/ptodsl/tests/test_flash_attention_demo_compile.py
+++ b/ptodsl/tests/test_flash_attention_demo_compile.py
@@ -80,7 +80,8 @@ def main() -> None:
         f"unexpected source file mapping: {port_info!r}",
     )
     for feature in [
-        "QK_PRELOAD prologue/steady/epilogue shadow schedule",
+        "QK_PRELOAD prologue/steady/epilogue schedule",
+        "A5 local pipe surface for QK/P/PV stage boundaries",
         "Vec_S0 row-slice state arrays",
         "exp_max_ring per preload slot and row-slice",
         "wide P slot producer/consumer",
@@ -105,6 +106,12 @@ def main() -> None:
     expect("pto.trowexpandmul" in wrapper_text, "wrapper compile should keep GU rescale")
     expect("pto.trowexpanddiv" in wrapper_text, "wrapper compile should keep final normalization")
     expect("pto.make_tensor_view" in wrapper_text, "QK/P/PV GM slots should be explicit tensor views")
+    expect("pto.aic_initialize_pipe" in wrapper_text, "FA should initialize local pipes on the Cube side")
+    expect("pto.aiv_initialize_pipe" in wrapper_text, "FA should initialize local pipes on the Vector side")
+    expect("pto.tpush_to_aiv" in wrapper_text, "FA should push Cube-produced stages to Vector through pipe surface")
+    expect("pto.tpop_from_aic" in wrapper_text, "FA should pop Cube-produced stages on Vector through pipe surface")
+    expect("pto.tpush_to_aic" in wrapper_text, "FA should push Vector-produced P stage to Cube through pipe surface")
+    expect("pto.tpop_from_aiv" in wrapper_text, "FA should pop Vector-produced P stage on Cube through pipe surface")
     expect("%c256" in wrapper_text, "S1_TILE=256 should appear in slot tensor view shape operands")
     expect("32x256xf32" in wrapper_text, "S1_TILE=256 should use Vec_S0=32 row-slice tiles")
 

--- a/ptodsl/tests/test_flash_attention_frontend_verify.py
+++ b/ptodsl/tests/test_flash_attention_frontend_verify.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
+
+from ptodsl._bootstrap import make_context
+from mlir.ir import Module
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def resolve_ptoas_binary() -> Path:
+    candidates = [
+        REPO_ROOT / "build" / "tools" / "ptoas" / "ptoas",
+        REPO_ROOT / "install" / "bin" / "ptoas",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    from_path = shutil.which("ptoas")
+    if from_path:
+        return Path(from_path)
+
+    raise FileNotFoundError("unable to locate a ptoas binary under build/, install/, or PATH")
+
+
+def run_ptoas_frontend_verify(ptoas_bin: Path, mlir_text: str, label: str) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False, encoding="utf-8") as handle:
+        handle.write(mlir_text)
+        input_path = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [str(ptoas_bin), str(input_path), "--emit-pto-ir", "-o", "-"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        known_backend_gap = (
+            "PlanMemory Fail : Unrecognized type of Operation touches local buffer!" in result.stderr
+            and "pto.tile_buf_addr" in mlir_text
+        )
+        expect(
+            known_backend_gap,
+            f"{label} should pass PTOAS frontend verification.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        print("ptodsl_flash_attention_frontend_verify: KNOWN_BACKEND_GAP PlanMemory tile_buf_addr")
+        return mlir_text
+    expect(result.stdout.strip(), f"{label} should emit non-empty PTO IR after PTOAS frontend passes")
+    return result.stdout
+
+
+def load_demo():
+    demo_path = REPO_ROOT / "ptodsl" / "examples" / "hw_native_flash_attention.py"
+    expect(demo_path.is_file(), f"missing flash attention demo: {demo_path}")
+
+    spec = spec_from_file_location("ptodsl_flash_attention_demo", demo_path)
+    expect(spec is not None and spec.loader is not None, f"unable to create import spec for {demo_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    ptoas_bin = resolve_ptoas_binary()
+    demo = load_demo()
+
+    mlir_text = demo.emit_flash_attention_mlir(
+        head_dim=128,
+        causal=False,
+        s1_tile=256,
+        qk_preload=3,
+    )
+    with make_context() as ctx:
+        parsed = Module.parse(mlir_text, ctx)
+        parsed.operation.verify()
+
+    frontend_text = run_ptoas_frontend_verify(
+        ptoas_bin,
+        mlir_text,
+        "hw-native flash_attention PTODSL artifact",
+    )
+    expect(
+        "func.func @flash_attention_kernel" in frontend_text,
+        "frontend output should preserve the flash_attention_kernel symbol",
+    )
+    expect(frontend_text.count("pto.mad") >= 2, "frontend output should keep QK and PV matmul stages")
+    expect("pto.trowmax" in frontend_text, "frontend output should keep row-wise softmax rowmax")
+    expect("pto.texp" in frontend_text, "frontend output should keep row-wise softmax exp")
+    expect("pto.trowexpandmul" in frontend_text, "frontend output should keep the GU rescale stage")
+    expect("pto.trowexpanddiv" in frontend_text, "frontend output should keep final normalization")
+    expect("pto.barrier <PIPE_ALL>" in frontend_text, "frontend output should keep explicit phase barriers")
+
+    print("ptodsl_flash_attention_frontend_verify: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -17,7 +17,10 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ptodsl"))
 
 import ptodsl._ops as _ops
+import ptodsl._pipe_namespace as _pipe_namespace
+from ptodsl._bootstrap import make_context
 from ptodsl import pto
+from mlir.ir import F32Type
 
 
 def _identity(value):
@@ -381,6 +384,244 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         sync_set_op.assert_not_called()
         sync_wait_op.assert_not_called()
+
+    def test_pipe_namespace_and_buffer_helpers_are_exposed(self):
+        names = [
+            "c2v_global", "v2c_global",
+            "c2v_local", "v2c_local", "bidirectional_local",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(pto.pipe, name), name)
+
+        for name in ["reserve_buffer", "import_reserved_buffer"]:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(pto, name), name)
+
+        self.assertTrue(hasattr(pto, "gm_ptr"), "gm_ptr")
+
+    def test_global_pipe_methods_dispatch_to_matching_frontend_ops(self):
+        alloc_entry = object()
+        pop_entry = object()
+
+        with make_context():
+            gm_slot_type = _pipe_namespace._pto.TensorViewType.get([16, 16], F32Type.get())
+        gm_slot = SimpleNamespace(type=gm_slot_type)
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
+            pipe = pto.pipe.c2v_global(gm_slot, id=7)
+
+        self.assertEqual(pipe.id, 7)
+        self.assertEqual(pipe.slot_size, 1024)
+        self.assertEqual(pipe.entry_type, gm_slot_type)
+
+        with patch.object(_pipe_namespace._pto, "AicInitializePipeOp") as aic_init, \
+             patch.object(_pipe_namespace._pto, "AivInitializePipeOp") as aiv_init, \
+             patch.object(_pipe_namespace._pto, "TAllocToAivOp", return_value=SimpleNamespace(result=alloc_entry)) as alloc_op, \
+             patch.object(_pipe_namespace._pto, "TPushToAivOp") as push_op, \
+             patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=pop_entry)) as pop_op, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAicOp") as free_op, \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity):
+            pipe.init_cube()
+            pipe.init_simd()
+            alloc_result = pipe.alloc()
+            pipe.push(alloc_result, split=1)
+            pop_result = pipe.pop()
+            pipe.free(pop_result, split=2)
+
+        aic_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
+        aiv_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
+        alloc_op.assert_called_once_with(gm_slot_type, 0, id=7)
+        push_op.assert_called_once_with(alloc_entry, 1, id=7)
+        pop_op.assert_called_once_with(gm_slot_type, 0, id=7)
+        free_op.assert_called_once_with(2, entry=pop_entry, id=7)
+        self.assertIs(alloc_result, alloc_entry)
+        self.assertIs(pop_result, pop_entry)
+
+    def test_local_pipe_constructors_route_consumer_buffers(self):
+        c2v_buf = object()
+        v2c_buf = object()
+        gm_slot_buffer = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=3,
+                local_slot_num=2,
+                nosplit=True,
+            )
+            v2c = pto.pipe.v2c_local(
+                slot_size=2048,
+                consumer_buf=v2c_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=4,
+                local_slot_num=5,
+            )
+            bidi = pto.pipe.bidirectional_local(
+                slot_size=4096,
+                c2v_consumer_buf=c2v_buf,
+                v2c_consumer_buf=v2c_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=5,
+            )
+
+        self.assertIsNone(c2v.entry_type)
+        self.assertIsNone(v2c.entry_type)
+        self.assertIsNone(bidi.entry_type)
+
+        with patch.object(_pipe_namespace._pto, "AicInitializePipeOp") as aic_init, \
+             patch.object(_pipe_namespace._pto, "AivInitializePipeOp") as aiv_init:
+            c2v.init_cube()
+            c2v.init_simd()
+            v2c.init_cube()
+            bidi.init_simd()
+
+        self.assertEqual(aic_init.call_args_list[0].args, (1, 1024))
+        self.assertEqual(aic_init.call_args_list[0].kwargs, {
+            "id": 3,
+            "local_slot_num": 2,
+            "nosplit": True,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+        })
+        self.assertEqual(aiv_init.call_args_list[0].args, (1, 1024))
+        self.assertEqual(aiv_init.call_args_list[0].kwargs, {
+            "id": 3,
+            "local_slot_num": 2,
+            "nosplit": True,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+        })
+        self.assertEqual(aic_init.call_args_list[1].args, (2, 2048))
+        self.assertEqual(aic_init.call_args_list[1].kwargs, {
+            "id": 4,
+            "local_slot_num": 5,
+            "gm_slot_buffer": gm_slot_buffer,
+            "v2c_consumer_buf": v2c_buf,
+        })
+        self.assertEqual(aiv_init.call_args_list[1].args, (3, 4096))
+        self.assertEqual(aiv_init.call_args_list[1].kwargs, {
+            "id": 5,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+            "v2c_consumer_buf": v2c_buf,
+        })
+
+    def test_local_pipe_transactions_dispatch_to_tile_entry_frontend_ops(self):
+        c2v_buf = object()
+        v2c_buf = object()
+        c2v_tile = object()
+        v2c_tile = object()
+        c2v_result = object()
+        v2c_result = object()
+        c2v_type = "c2v_tile_ty"
+        v2c_type = "v2c_tile_ty"
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=6)
+            v2c = pto.pipe.v2c_local(slot_size=2048, consumer_buf=v2c_buf, id=7)
+
+        with patch.object(_pipe_namespace._pto, "TPushToAivOp") as c2v_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=c2v_result)) as c2v_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAicOp") as c2v_free, \
+             patch.object(_pipe_namespace._pto, "TPushToAicOp") as v2c_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAivOp", return_value=SimpleNamespace(result=v2c_result)) as v2c_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAivOp") as v2c_free, \
+             patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v.push(c2v_tile, split=1)
+            c2v_output = c2v.pop(result_type=c2v_type, split=2)
+            c2v.free(split=0)
+
+            v2c.push(v2c_tile, split=2)
+            v2c_output = v2c.pop(result_type=v2c_type, split=1)
+            v2c.free(split=0)
+
+        c2v_push.assert_called_once_with(c2v_tile, 1, id=6)
+        c2v_pop.assert_called_once_with(c2v_type, 2, id=6)
+        c2v_free.assert_called_once_with(0, entry=None, id=6)
+        self.assertIs(c2v_output, c2v_result)
+
+        v2c_push.assert_called_once_with(v2c_tile, 2, id=7)
+        v2c_pop.assert_called_once_with(v2c_type, 1, id=7)
+        v2c_free.assert_called_once_with(0, entry=None, id=7)
+        self.assertIs(v2c_output, v2c_result)
+
+    def test_local_pipe_pop_can_carry_runtime_valid_shape(self):
+        c2v_buf = object()
+        c2v_type = "c2v_tile_ty"
+        row = object()
+        col = object()
+        result = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=8)
+
+        with patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=result)) as pop_op, \
+             patch.object(_pipe_namespace, "_coerce_index", side_effect=lambda value, *, context: value), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            output = c2v.pop(result_type=c2v_type, valid_shape=[row, col])
+
+        pop_op.assert_called_once_with(
+            c2v_type,
+            0,
+            valid_row=row,
+            valid_col=col,
+            id=8,
+        )
+        self.assertIs(output, result)
+
+    def test_pipe_surface_rejects_ambiguous_or_invalid_transactions(self):
+        c2v_buf = object()
+        v2c_buf = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=9)
+            bidi = pto.pipe.bidirectional_local(
+                slot_size=1024,
+                c2v_consumer_buf=c2v_buf,
+                v2c_consumer_buf=v2c_buf,
+                id=10,
+            )
+
+        with self.assertRaises(TypeError):
+            c2v.alloc()
+        with self.assertRaises(TypeError):
+            c2v.pop()
+        with self.assertRaises(TypeError):
+            bidi.push(object())
+        with self.assertRaises(TypeError):
+            bidi.pop(result_type="tile_ty")
+        with self.assertRaises(TypeError):
+            bidi.free()
+
+    def test_reserved_buffer_helpers_normalize_location_and_peer_func(self):
+        with make_context():
+            with patch.object(_ops._pto, "ReserveBufferOp", return_value=SimpleNamespace(result=object())) as reserve_op, \
+                 patch.object(_ops._pto, "ImportReservedBufferOp", return_value=SimpleNamespace(result=object())) as import_op, \
+                 patch.object(_ops, "wrap_surface_value", side_effect=_identity):
+                reserve_result = _ops.reserve_buffer("fifo", size=8192, location="vec")
+                import_result = _ops.import_reserved_buffer(
+                    "fifo",
+                    peer_func=SimpleNamespace(spec=SimpleNamespace(symbol_name="vector_kernel")),
+                )
+
+        self.assertIsNotNone(reserve_result)
+        self.assertIsNotNone(import_result)
+        self.assertEqual(reserve_op.call_args.args[0], "fifo")
+        self.assertEqual(reserve_op.call_args.args[1], 8192)
+        self.assertEqual(str(reserve_op.call_args.args[2]), "#pto.address_space<vec>")
+        self.assertEqual(reserve_op.call_args.args[3], True)
+        self.assertEqual(import_op.call_args.args, ("fifo", "vector_kernel"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Port the hw-native Python flash-attention example idea to the PTODSL API in this PTOAS repo
- Document the old pto-dsl -> current ptodsl API mapping and usage flow
- Add compile and PTOAS frontend verification coverage

## Scope
- Compile/frontend only
- No A5/A3 runtime launch or backend lowering changes
- Keeps the existing QK -> online softmax -> PV -> output blend dataflow

## Validation
- Windows: python -m py_compile for the updated example/tests
- Windows: git diff --check
- dev-481211: python3 ptodsl/tests/test_flash_attention_demo_compile.py
- dev-481211: python3 ptodsl/tests/test_flash_attention_frontend_verify.py
- dev-481211: python3 ptodsl/examples/flash_attention_sketch.py --block-q 64 --block-kv 128 -o /tmp/hwfa_ptodsl.mlir && ptoas /tmp/hwfa_ptodsl.mlir --emit-pto-ir -o /tmp/hwfa_ptodsl.pto