### PR TITLE
fix(ptoas): declare TileLang daemon POSIX symbols

### DIFF
--- a/tools/ptoas/TilelangDaemon.cpp
+++ b/tools/ptoas/TilelangDaemon.cpp
@@ -12,9 +12,12 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <chrono>
-#include <thread>
-#include <signal.h>
 #include <cstdlib>
+#include <signal.h>
+#include <thread>
+#include <unistd.h>
+
+extern char **environ;
 
 namespace ptoas {
 


### PR DESCRIPTION
## Summary
- add an explicit `<unistd.h>` include for `getpid()` in `TilelangDaemon.cpp`
- declare `extern char **environ;` so daemon env forwarding builds reliably across Linux environments

## Validation
- `g++ -std=c++17 -fsyntax-only -xc++ /dev/stdin <<< $'#include <string>\n#include <unistd.h>\nextern char **environ;\nstd::string f(){ return std::to_string(::getpid()); }\nint main(){ for(char **e = environ; *e; ++e){} }\n'`
- `cmake --build /home/zhangzhendong/ptoas-workspace/PTOAS/build --target ptoas -j4`

Fixes #450
