### PR TITLE
Add merge-axis TileLang element-wise templates

### DIFF
--- a/lib/TileOps/merge_axis.py
+++ b/lib/TileOps/merge_axis.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Shared helpers for full-axis merge-axis TileOp implementations."""
+
+import tilelang_dsl as pto
+
+
+def full_axis_constraint(**attrs):
+    """Match only full-axis tiles whose valid extents equal their allocation shape."""
+    matched_any_tile = False
+    for attr_name, shape in attrs.items():
+        if not attr_name.endswith("_shape") or attr_name.endswith("_valid_shape"):
+            continue
+        valid_shape = attrs.get(attr_name.replace("_shape", "_valid_shape"))
+        if valid_shape is None:
+            continue
+        matched_any_tile = True
+        if tuple(shape) != tuple(valid_shape):
+            return False
+    return matched_any_tile
+
+
+@pto.inline_proc
+def emit_unary_merge_axis(src: pto.Tile, dst: pto.Tile, compute):
+    """Lower a full-axis unary element-wise kernel through one linearized loop."""
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            result = compute(pto.vlds(in_tile, lane), mask)
+            pto.vsts(result, out_tile, lane, mask)
+
+
+@pto.inline_proc
+def emit_binary_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile, compute):
+    """Lower a full-axis binary element-wise kernel through one linearized loop."""
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            result = compute(pto.vlds(lhs_tile, lane), pto.vlds(rhs_tile, lane), mask)
+            pto.vsts(result, out_tile, lane, mask)

--- a/lib/TileOps/tabs_template.py
+++ b/lib/TileOps/tabs_template.py
@@ -9,6 +9,37 @@
 """TileLang DSL template for pto.tabs"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tabs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tabs_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vabs(vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tadd_template.py
+++ b/lib/TileOps/tadd_template.py
@@ -13,6 +13,55 @@ from pathlib import Path
 import tilelang_dsl as pto
 
 
+def _constraint_tadd_full_axis(
+    src0_shape=(),
+    src0_valid_shape=(),
+    src1_shape=(),
+    src1_valid_shape=(),
+    dst_shape=(),
+    dst_valid_shape=(),
+):
+    """Select the merged-axis fast path only for full-axis contiguous tiles."""
+    return (
+        src0_shape == src0_valid_shape
+        and src1_shape == src1_valid_shape
+        and dst_shape == dst_valid_shape
+    )
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tadd",
+    constraints=[_constraint_tadd_full_axis],
+    priority=100,
+    advanced=True,
+)
+def template_tadd_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    """Merged-axis full-tile version aligned with TBinOps_1D_NoPostUpdate."""
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            summed = pto.vadd(lhs, rhs, mask)
+            pto.vsts(summed, out_tile, lane, mask)
+    return
+
+
 @pto.vkernel(
     target="a5",
     op="pto.tadd"

--- a/lib/TileOps/tadds_template.py
+++ b/lib/TileOps/tadds_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tadds",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tadds_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vadds(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tand_template.py
+++ b/lib/TileOps/tand_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tand",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tand_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vand(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tands_template.py
+++ b/lib/TileOps/tands_template.py
@@ -19,6 +19,38 @@ Only supports tile, scalar order.
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tands",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tands_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vand(vec, scalar_vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tdiv_template.py
+++ b/lib/TileOps/tdiv_template.py
@@ -11,9 +11,48 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 # Import shared high-precision division algorithms
 from div_hp import _div_ieee754_f32_impl, _div_ieee754_f16_impl
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tdiv",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tdiv_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                if pto.constexpr(out_tile.element_type == pto.f32):
+                    result = _div_ieee754_f32_impl(lhs, rhs, mask)
+                else:
+                    result = _div_ieee754_f16_impl(lhs, rhs, mask)
+            else:
+                result = pto.vdiv(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tdivs_template.py
+++ b/lib/TileOps/tdivs_template.py
@@ -19,9 +19,86 @@ for improved accuracy with precision-sensitive, subnormal, and overflow boundary
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 # Import shared high-precision division algorithms
 from div_hp import _div_ieee754_f32_impl, _div_ieee754_f16_impl
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tdivs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tdivs_merge_axis_tile_scalar(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = src.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                if pto.constexpr(out_tile.element_type == pto.f32):
+                    result = _div_ieee754_f32_impl(vec, scalar_vec, mask)
+                else:
+                    result = _div_ieee754_f16_impl(vec, scalar_vec, mask)
+            else:
+                result = pto.vdiv(vec, scalar_vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tdivs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tdivs_merge_axis_scalar_tile(scalar: pto.AnyType, src: pto.Tile, dst: pto.Tile):
+    dtype = src.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                if pto.constexpr(out_tile.element_type == pto.f32):
+                    result = _div_ieee754_f32_impl(scalar_vec, vec, mask)
+                else:
+                    result = _div_ieee754_f16_impl(scalar_vec, vec, mask)
+            else:
+                result = pto.vdiv(scalar_vec, vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/texp_template.py
+++ b/lib/TileOps/texp_template.py
@@ -9,6 +9,7 @@
 """TileLang DSL template for pto.texp"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 from exp_hp import _tl_exp_precision
 
 @pto.inline_proc
@@ -38,6 +39,69 @@ def template_texp_impl(src: pto.Tile, dst: pto.Tile):
             result = pto.vexp(vinput, mask)
             pto.vsts(result, dst[row, col:], mask)
     return
+
+@pto.inline_proc
+def template_texp_merge_axis_hp_impl(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = _tl_exp_precision(vec, mask, out_tile.element_type)
+            pto.vsts(result, out_tile, lane, mask)
+    return
+
+
+@pto.inline_proc
+def template_texp_merge_axis_impl(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            result = pto.vexp(pto.vlds(in_tile, lane), mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.texp",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_texp_merge_axis(src: pto.Tile, dst: pto.Tile):
+    hp_mode = pto.get_op_attr("precision_mode")
+    if pto.constexpr(hp_mode == "HIGH_PRECISION"):
+        template_texp_merge_axis_hp_impl(src, dst)
+    else:
+        template_texp_merge_axis_impl(src, dst)
+    return
+
 
 @pto.vkernel(
     target="a5",

--- a/lib/TileOps/tlog_template.py
+++ b/lib/TileOps/tlog_template.py
@@ -9,6 +9,7 @@
 """TileLang DSL template for pto.tlog"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 
 @pto.inline_proc
@@ -47,6 +48,53 @@ def _tlog_default(src: pto.Tile, dst: pto.Tile, dtype, valid_rows, valid_cols):
             result = pto.vln(vinput, mask)
             pto.vsts(result, dst[row, col:], mask)
     return None
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tlog",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tlog_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+        if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+            if pto.constexpr(out_tile.element_type == pto.f16):
+                subnormal_threshold = pto.f16("0x03FF")
+                mul_factor = pto.f16("0x6400")
+                compensation = pto.f16(-6.931471805599453094172)
+            elif pto.constexpr(out_tile.element_type == pto.f32):
+                subnormal_threshold = pto.f32("0x007FFFFF")
+                mul_factor = pto.f32("0x4B000000")
+                compensation = pto.f32(-15.9423851528787421)
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                cmp_mask = pto.vcmps(vec, subnormal_threshold, mask, pto.CmpMode.LT)
+                scaled = pto.vmuls(vec, mul_factor, mask)
+                selected_input = pto.vsel(scaled, vec, cmp_mask)
+                log_result = pto.vln(selected_input, mask)
+                compensated = pto.vadds(log_result, compensation, mask)
+                result = pto.vsel(compensated, log_result, cmp_mask)
+            else:
+                result = pto.vln(vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tlrelu_template.py
+++ b/lib/TileOps/tlrelu_template.py
@@ -11,6 +11,41 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tlrelu",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tlrelu_merge_axis(src: pto.Tile, slope: pto.f32, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, slope, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        slope_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        if pto.constexpr(out_tile.element_type == pto.f16):
+            slope_scalar = pto.f16(slope_value)
+        else:
+            slope_scalar = slope_value
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vlrelu(vec, slope_scalar, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmax_template.py
+++ b/lib/TileOps/tmax_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmax",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmax_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vmax(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmaxs_template.py
+++ b/lib/TileOps/tmaxs_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmaxs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmaxs_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vmaxs(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmin_template.py
+++ b/lib/TileOps/tmin_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmin",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmin_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vmin(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmins_template.py
+++ b/lib/TileOps/tmins_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmins",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmins_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vmins(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmov_template.py
+++ b/lib/TileOps/tmov_template.py
@@ -17,6 +17,7 @@ different templates/implementation paths should be used.
 """
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 
 def _tmov_ub2ub_nd2nd_constraint(src: pto.Tile, dst: pto.Tile) -> bool:
@@ -58,6 +59,36 @@ def _tmov_ub2ub_nd2nd_constraint(src: pto.Tile, dst: pto.Tile) -> bool:
         return False
 
     return True
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmov",
+    constraints=[_tmov_ub2ub_nd2nd_constraint, full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmov_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = vec
+            pto.vsts(result, out_tile, lane, mask)
+    return None
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmul_template.py
+++ b/lib/TileOps/tmul_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmul",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmul_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vmul(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tmuls_template.py
+++ b/lib/TileOps/tmuls_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tmuls",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tmuls_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vmuls(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tneg_template.py
+++ b/lib/TileOps/tneg_template.py
@@ -9,6 +9,37 @@
 """TileLang DSL template for pto.tneg"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tneg",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tneg_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vneg(vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tnot_template.py
+++ b/lib/TileOps/tnot_template.py
@@ -9,6 +9,38 @@
 """TileLang DSL template for pto.tnot"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tnot",
+    dtypes=[(pto.AnyInt, pto.AnyInt)],
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tnot_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vnot(vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tor_template.py
+++ b/lib/TileOps/tor_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tor",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tor_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vor(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tors_template.py
+++ b/lib/TileOps/tors_template.py
@@ -19,6 +19,38 @@ Only supports tile, scalar order.
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tors",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tors_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vor(vec, scalar_vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tprelu_template.py
+++ b/lib/TileOps/tprelu_template.py
@@ -9,6 +9,41 @@
 """TileLang DSL template for pto.tprelu (Parametric ReLU)"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tprelu",
+    dtypes=[(pto.f16, pto.f16, pto.f16, pto.f16), (pto.f32, pto.f32, pto.f32, pto.f32),
+            (pto.f16, pto.f16, pto.i8, pto.f16), (pto.f32, pto.f32, pto.i8, pto.f32)],
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tprelu_merge_axis(src0: pto.Tile, src1: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vprelu(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/trecip_template.py
+++ b/lib/TileOps/trecip_template.py
@@ -13,9 +13,66 @@ High-precision mode uses IEEE 754 compliant division algorithms.
 """
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 # Import shared high-precision division algorithms
 from div_hp import _div_ieee754_f32_impl, _div_ieee754_f16_impl
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.trecip",
+    dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32)],
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_trecip_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    if pto.constexpr(dtype == pto.f32):
+        with pto.strict_vecscope(dst, src, pto.f32(1.0), total_elems, 0, total_elems, lanes) as (
+            out_tile,
+            in_tile,
+            one_value,
+            area,
+            lb,
+            ub,
+            step,
+        ):
+            precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+            remained = area
+            for lane in range(lb, ub, step):
+                mask, remained = pto.make_mask(out_tile.element_type, remained)
+                vec = pto.vlds(in_tile, lane)
+                if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                    result = _div_ieee754_f32_impl(pto.vbr(one_value), vec, mask)
+                else:
+                    result = pto.vdiv(pto.vbr(one_value), vec, mask)
+                pto.vsts(result, out_tile, lane, mask)
+    else:
+        with pto.strict_vecscope(dst, src, pto.f16(1.0), total_elems, 0, total_elems, lanes) as (
+            out_tile,
+            in_tile,
+            one_value,
+            area,
+            lb,
+            ub,
+            step,
+        ):
+            precision_mode = pto.get_op_attr("precision_mode", "DEFAULT")
+            remained = area
+            for lane in range(lb, ub, step):
+                mask, remained = pto.make_mask(out_tile.element_type, remained)
+                vec = pto.vlds(in_tile, lane)
+                if pto.constexpr(precision_mode == "HIGH_PRECISION"):
+                    result = _div_ieee754_f16_impl(pto.vbr(one_value), vec, mask)
+                else:
+                    result = pto.vdiv(pto.vbr(one_value), vec, mask)
+                pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/trelu_template.py
+++ b/lib/TileOps/trelu_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.trelu",
+    dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32), (pto.i32, pto.i32)],
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_trelu_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vrelu(vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/trsqrt_template.py
+++ b/lib/TileOps/trsqrt_template.py
@@ -9,8 +9,57 @@
 """TileLang DSL template for pto.trsqrt"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 
 # TODO: Add implementation for HIGH_PRECISION type
+@pto.vkernel(
+    target="a5",
+    op="pto.trsqrt",
+    dtypes=[(pto.f16, pto.f16), (pto.f32, pto.f32)],
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_trsqrt_merge_axis(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    if pto.constexpr(dtype == pto.f32):
+        with pto.strict_vecscope(dst, src, pto.f32(1.0), total_elems, 0, total_elems, lanes) as (
+            out_tile,
+            in_tile,
+            one_value,
+            area,
+            lb,
+            ub,
+            step,
+        ):
+            remained = area
+            for lane in range(lb, ub, step):
+                mask, remained = pto.make_mask(out_tile.element_type, remained)
+                vec = pto.vlds(in_tile, lane)
+                result = pto.vdiv(pto.vbr(one_value), pto.vsqrt(vec, mask), mask)
+                pto.vsts(result, out_tile, lane, mask)
+    else:
+        with pto.strict_vecscope(dst, src, pto.f16(1.0), total_elems, 0, total_elems, lanes) as (
+            out_tile,
+            in_tile,
+            one_value,
+            area,
+            lb,
+            ub,
+            step,
+        ):
+            remained = area
+            for lane in range(lb, ub, step):
+                mask, remained = pto.make_mask(out_tile.element_type, remained)
+                vec = pto.vlds(in_tile, lane)
+                result = pto.vdiv(pto.vbr(one_value), pto.vsqrt(vec, mask), mask)
+                pto.vsts(result, out_tile, lane, mask)
+    return
+
+
 @pto.vkernel(
     target="a5",
     op="pto.trsqrt",

--- a/lib/TileOps/tshl_template.py
+++ b/lib/TileOps/tshl_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tshl",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tshl_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vshl(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tshls_template.py
+++ b/lib/TileOps/tshls_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tshls",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tshls_merge_axis(src: pto.Tile, scalar: pto.i16, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vshls(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tshr_template.py
+++ b/lib/TileOps/tshr_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tshr",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tshr_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vshr(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tshrs_template.py
+++ b/lib/TileOps/tshrs_template.py
@@ -11,6 +11,38 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tshrs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tshrs_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vshrs(vec, scalar_value, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tsqrt_template.py
+++ b/lib/TileOps/tsqrt_template.py
@@ -9,6 +9,7 @@
 """TileLang DSL template for pto.tsqrt"""
 
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
 from sqrt_hp import _tl_sqrt_precision
 
 @pto.inline_proc
@@ -38,6 +39,69 @@ def template_tsqrt_impl(src: pto.Tile, dst: pto.Tile):
             result = pto.vsqrt(vinput, mask)
             pto.vsts(result, dst[row, col:], mask)
     return
+
+@pto.inline_proc
+def template_tsqrt_merge_axis_hp_impl(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = _tl_sqrt_precision(vec, mask, out_tile.element_type)
+            pto.vsts(result, out_tile, lane, mask)
+    return
+
+
+@pto.inline_proc
+def template_tsqrt_merge_axis_impl(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            result = pto.vsqrt(pto.vlds(in_tile, lane), mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tsqrt",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tsqrt_merge_axis(src: pto.Tile, dst: pto.Tile):
+    hp_mode = pto.get_op_attr("precision_mode")
+    if pto.constexpr(hp_mode == "HIGH_PRECISION"):
+        template_tsqrt_merge_axis_hp_impl(src, dst)
+    else:
+        template_tsqrt_merge_axis_impl(src, dst)
+    return
+
 
 @pto.vkernel(
     target="a5",

--- a/lib/TileOps/tsub_template.py
+++ b/lib/TileOps/tsub_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tsub",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tsub_merge_axis(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vsub(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/tsubs_template.py
+++ b/lib/TileOps/tsubs_template.py
@@ -17,6 +17,38 @@ TODO: Use vadds(vec, -scalar) when DSL supports unary negation on scalars.
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.tsubs",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_tsubs_merge_axis(src: pto.Tile, scalar: pto.AnyType, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vsub(vec, scalar_vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/txor_template.py
+++ b/lib/TileOps/txor_template.py
@@ -11,6 +11,39 @@
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.txor",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_txor_merge_axis(src0: pto.Tile, src1: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+
+    with pto.strict_vecscope(dst, src0, src1, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        lhs_tile,
+        rhs_tile,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            lhs = pto.vlds(lhs_tile, lane)
+            rhs = pto.vlds(rhs_tile, lane)
+            result = pto.vxor(lhs, rhs, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/lib/TileOps/txors_template.py
+++ b/lib/TileOps/txors_template.py
@@ -18,6 +18,38 @@ This template uses vbr + vxor to achieve element-wise bitwise XOR.
 import sys
 from pathlib import Path
 import tilelang_dsl as pto
+from merge_axis import emit_binary_merge_axis, emit_unary_merge_axis, full_axis_constraint
+
+
+@pto.vkernel(
+    target="a5",
+    op="pto.txors",
+    constraints=[full_axis_constraint],
+    priority=100,
+    advanced=True,
+)
+def template_txors_merge_axis(src: pto.Tile, scalar: pto.AnyType, tmp: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
+    total_elems = valid_rows * valid_cols
+    lanes = pto.get_lanes(dtype)
+    with pto.strict_vecscope(dst, src, scalar, total_elems, 0, total_elems, lanes) as (
+        out_tile,
+        in_tile,
+        scalar_value,
+        area,
+        lb,
+        ub,
+        step,
+    ):
+        scalar_vec = pto.vbr(scalar_value)
+        remained = area
+        for lane in range(lb, ub, step):
+            mask, remained = pto.make_mask(out_tile.element_type, remained)
+            vec = pto.vlds(in_tile, lane)
+            result = pto.vxor(vec, scalar_vec, mask)
+            pto.vsts(result, out_tile, lane, mask)
+    return
 
 
 @pto.vkernel(

--- a/test/tilelang_st/npu/a5/src/st/testcase/run_ptoas_to_file.cmake
+++ b/test/tilelang_st/npu/a5/src/st/testcase/run_ptoas_to_file.cmake
@@ -13,6 +13,14 @@ endif()
 get_filename_component(KERNEL_FATOBJ_DIR "${KERNEL_FATOBJ}" DIRECTORY)
 file(MAKE_DIRECTORY "${KERNEL_FATOBJ_DIR}")
 
+get_filename_component(
+    PTOAS_REPO_ROOT
+    "${CMAKE_CURRENT_LIST_DIR}/../../../../../../.."
+    ABSOLUTE
+)
+set(PTOAS_TILELANG_PATH "${PTOAS_REPO_ROOT}/lib/TileOps")
+set(PTOAS_TILELANG_PKG_PATH "${PTOAS_REPO_ROOT}/tilelang-dsl/python")
+
 if(NOT DEFINED PTOAS_ENABLE_INSERT_SYNC)
     set(PTOAS_ENABLE_INSERT_SYNC ON)
 endif()
@@ -27,6 +35,10 @@ if(DEFINED PTOAS_PTO_LEVEL AND NOT PTOAS_PTO_LEVEL STREQUAL "")
 endif()
 
 list(APPEND PTOAS_COMMAND --pto-backend=vpto)
+list(APPEND PTOAS_COMMAND
+    "--tilelang-path=${PTOAS_TILELANG_PATH}"
+    "--tilelang-pkg-path=${PTOAS_TILELANG_PKG_PATH}"
+)
 
 if(PTOAS_ENABLE_INSERT_SYNC)
     list(APPEND PTOAS_COMMAND --enable-insert-sync)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/cases.py
@@ -52,4 +52,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 1e-3,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/launch.cpp
@@ -39,3 +39,10 @@ extern "C" __global__ AICORE void TABS_f16_32x32(__gm__ uint16_t *a, __gm__ uint
 void LaunchTABS_f16_32x32(void *a, void *b, void *stream) {
     TABS_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TABS_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTABS_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TABS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTABS_f32_16x64(void *a, void *b, void *stream);
+void LaunchTABS_f32_merge_axis_16x72(void *a, void *b, void *stream);
+
 void LaunchTABS_f32_32x32(void *a, void *b, void *stream);
 void LaunchTABS_f16_16x64(void *a, void *b, void *stream);
 void LaunchTABS_f16_32x32(void *a, void *b, void *stream);
@@ -44,6 +46,7 @@ static const TestCase kCases[] = {
     {"f32_32x32", LaunchTABS_f32_32x32, 32, 32, 32, 32, sizeof(float)},
     {"f16_16x64", LaunchTABS_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
     {"f16_32x32", LaunchTABS_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+    {"f32_merge_axis_16x72", LaunchTABS_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tabs/tabs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tabs/tabs.pto
@@ -177,4 +177,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TABS_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tabs ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadd/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadd/cases.py
@@ -24,6 +24,13 @@ import numpy as np
 
 CASES = [
     {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
+    {
         "name": "f32_16x64",
         "dtype": np.float32,
         "shape": (16, 64),

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadd/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadd/launch.cpp
@@ -12,14 +12,21 @@
 #define AICORE [aicore]
 #endif
 
-// Case 0: f32 16x64
+// Case 0: f32 merge-axis full-axis 16x68
+extern "C" __global__ AICORE void TADD_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTADD_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream) {
+    TADD_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
+}
+
+// Case 1: f32 16x64
 extern "C" __global__ AICORE void TADD_f32_16x64(__gm__ float *a, __gm__ float *b, __gm__ float *c);
 
 void LaunchTADD_f32_16x64(float *a, float *b, float *c, void *stream) {
     TADD_f32_16x64<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
 }
 
-// Case 1: f32 32x32
+// Case 2: f32 32x32
 extern "C" __global__ AICORE void TADD_f32_32x32(__gm__ float *a, __gm__ float *b, __gm__ float *c);
 
 void LaunchTADD_f32_32x32(float *a, float *b, float *c, void *stream) {

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadd/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadd/main.cpp
@@ -22,6 +22,7 @@
 using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
+void LaunchTADD_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream);
 void LaunchTADD_f32_16x64(float *a, float *b, float *c, void *stream);
 void LaunchTADD_f32_32x32(float *a, float *b, float *c, void *stream);
 
@@ -38,6 +39,7 @@ struct TestCase {
 };
 
 static const TestCase kCases[] = {
+    {"f32_merge_axis_16x72", LaunchTADD_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
     {"f32_16x64", LaunchTADD_f32_16x64, 16, 64, 16, 64, sizeof(float)},
     {"f32_32x32", LaunchTADD_f32_32x32, 32, 32, 32, 32, sizeof(float)},
 };

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadd/tadd.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadd/tadd.pto
@@ -12,8 +12,63 @@
 // to produce a fatobj object.
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-  // Case 0: f32 16x64 (1024 elements)
-  func.func @TADD_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.kernel} {
+  // Case 0: f32 merge-axis full-axis 16x72 (1152 elements)
+  func.func @TADD_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c72   = arith.constant 72   : index
+    %c1152 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c72],
+      strides = [%c1152, %c1152, %c1152, %c72, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c72],
+      strides = [%c1152, %c1152, %c1152, %c72, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c72],
+      strides = [%c1152, %c1152, %c1152, %c72, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c72]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c72]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c72]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tadd ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
+
+  // Case 1: f32 16x64 (1024 elements)
+  func.func @TADD_f32_16x64(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
     %c0    = arith.constant 0    : index
     %c1    = arith.constant 1    : index
     %c16   = arith.constant 16   : index
@@ -67,8 +122,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
-  // Case 1: f32 32x32 (1024 elements)
-  func.func @TADD_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.kernel} {
+  // Case 2: f32 32x32 (1024 elements)
+  func.func @TADD_f32_32x32(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
     %c0    = arith.constant 0    : index
     %c1    = arith.constant 1    : index
     %c32   = arith.constant 32   : index

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadds/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadds/cases.py
@@ -66,4 +66,11 @@ CASES = [
         "valid_shape": (256, 16),
         "eps": 1e-6,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadds/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadds/launch.cpp
@@ -56,3 +56,10 @@ extern "C" __global__ AICORE void TADDS_f32_256x16(__gm__ float *src, __gm__ flo
 void LaunchTADDS_f32_256x16(float *src, float *dst, void *stream) {
     TADDS_f32_256x16<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TADDS_SCALAR_F32);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TADDS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+
+void LaunchTADDS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TADDS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TADDS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadds/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadds/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTADDS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTADDS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
+
 void LaunchTADDS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTADDS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTADDS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -46,6 +48,7 @@ static const TestCase kCases[] = {
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTADDS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
     {"f32_7x448",   (void (*)(void*,void*,void*))LaunchTADDS_f32_7x448,   7,   448, 7,   448, sizeof(float)},
     {"f32_256x16",  (void (*)(void*,void*,void*))LaunchTADDS_f32_256x16,  256, 16,  256, 16,  sizeof(float)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTADDS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tadds/tadds.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tadds/tadds.pto
@@ -253,4 +253,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TADDS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tadds ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tand/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tand/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 0,
     },
+    {
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tand/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tand/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TAND_i32_32x32(__gm__ int32_t *a, __gm__ int32
 void LaunchTAND_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream) {
     TAND_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TAND_i32_merge_axis_16x72(__gm__ int32_t *a, __gm__ int32_t *b, __gm__ int32_t *c);
+
+void LaunchTAND_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream) {
+    TAND_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tand/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tand/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTAND_i32_16x64(int32_t *a, int32_t *b, int32_t *c, void *stream);
+void LaunchTAND_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream);
+
 void LaunchTAND_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream);
 
 using LaunchFn = void (*)(int32_t *, int32_t *, int32_t *, void *);
@@ -40,6 +42,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"i32_16x64", LaunchTAND_i32_16x64, 16, 64, 16, 64, sizeof(int32_t)},
     {"i32_32x32", LaunchTAND_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i32_merge_axis_16x72", LaunchTAND_i32_merge_axis_16x72, 16, 72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tand/tand.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tand/tand.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
     return
   }
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TAND_i32_merge_axis_16x72(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>, %c_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tand ins(%a, %b : !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tands/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tands/cases.py
@@ -39,4 +39,11 @@ CASES = [
         "valid_shape": (15, 192),
         "eps": 0,
     },
+{
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tands/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tands/launch.cpp
@@ -43,3 +43,10 @@ extern "C" __global__ AICORE void TANDS_i16_15x192(__gm__ int16_t *src, __gm__ i
 void LaunchTANDS_i16_15x192(int16_t *src, int16_t *dst, void *stream) {
     TANDS_i16_15x192<<<1, nullptr, stream>>>((__gm__ int16_t *)src, (__gm__ int16_t *)dst, TANDS_SCALAR_I16);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TANDS_i32_merge_axis_16x72(__gm__ int32_t *src, __gm__ int32_t *dst, int32_t scalar);
+
+void LaunchTANDS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream) {
+    TANDS_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)src, (__gm__ int32_t *)dst, TANDS_SCALAR_I32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tands/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tands/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTANDS_i32_32x64(int32_t *src, int32_t *dst, void *stream);
+void LaunchTANDS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream);
 void LaunchTANDS_i16_63x64(int16_t *src, int16_t *dst, void *stream);
 void LaunchTANDS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTANDS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -42,6 +43,7 @@ static const TestCase kCases[] = {
     {"i16_63x64",   (void (*)(void*,void*,void*))LaunchTANDS_i16_63x64,   63,  64,  63,  64,  sizeof(int16_t)},
     {"i32_31x128",  (void (*)(void*,void*,void*))LaunchTANDS_i32_31x128,  31,  128, 31,  128, sizeof(int32_t)},
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTANDS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
+    {"i32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTANDS_i32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tands/tands.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tands/tands.pto
@@ -173,4 +173,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TANDS_i32_merge_axis_16x72(%src_ptr: !pto.ptr<i32>, %dst_ptr: !pto.ptr<i32>, %scalar: i32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tands ins(%src, %scalar : !pto.tile_buf<vec, 16x72xi32>, i32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdiv/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdiv/cases.py
@@ -203,4 +203,12 @@ CASES = [
         "test_pattern": "precision_sensitive",
         "ulp_tolerance": 1,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+        "test_pattern": "normal",
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdiv/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdiv/launch.cpp
@@ -131,3 +131,10 @@ extern "C" __global__ AICORE void TDIV_f16_2x32_hp(__gm__ void *a, __gm__ void *
 void LaunchTDIV_f16_2x32_hp(void *a, void *b, void *c, void *stream) {
     TDIV_f16_2x32_hp<<<1, nullptr, stream>>>(a, b, c);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TDIV_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTDIV_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream) {
+    TDIV_f32_merge_axis_16x72<<<1, nullptr, stream>>>(a, b, c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdiv/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdiv/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTDIV_f32_16x64(float *a, float *b, float *c, void *stream);
+void LaunchTDIV_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream);
 void LaunchTDIV_f32_32x32(float *a, float *b, float *c, void *stream);
 void LaunchTDIV_f32_64x64(float *a, float *b, float *c, void *stream);
 void LaunchTDIV_f16_16x256(void *a, void *b, void *c, void *stream);
@@ -71,6 +72,7 @@ static const TestCase kCases[] = {
     {"f16_16x64_hp_partial", (LaunchFn)LaunchTDIV_f16_16x64_hp_partial, 16, 64, 16, 63, 2},
     {"f32_2x16_hp", (LaunchFn)LaunchTDIV_f32_2x16_hp, 2, 16, 2, 16, 4},
     {"f16_2x32_hp", (LaunchFn)LaunchTDIV_f16_2x32_hp, 2, 32, 2, 32, 2},
+    {"f32_merge_axis_16x72", (LaunchFn)LaunchTDIV_f32_merge_axis_16x72, 16, 72, 16, 72, 4},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdiv/tdiv.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdiv/tdiv.pto
@@ -968,4 +968,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x2x32xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TDIV_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tdiv ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdivs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdivs/cases.py
@@ -242,4 +242,12 @@ CASES = [
         "direction": "scalar_src",
         "test_pattern": "overflow",
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+        "direction": "src_scalar",
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdivs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdivs/launch.cpp
@@ -149,3 +149,9 @@ extern "C" __global__ AICORE void TDIVS_f16_16x64_hp_overflow_scalar_src(__gm__ 
 void LaunchTDIVS_f16_16x64_hp_overflow_scalar_src(unsigned short *src, unsigned short *dst, void *stream) {
     TDIVS_f16_16x64_hp_overflow_scalar_src<<<1, nullptr, stream>>>((__gm__ unsigned short *)src, (__gm__ unsigned short *)dst, (unsigned short)0x7BEF);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TDIVS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+void LaunchTDIVS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TDIVS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TDIVS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdivs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdivs/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTDIVS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTDIVS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
 void LaunchTDIVS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTDIVS_f32_7x448(float *src, float *dst, void *stream);
 void LaunchTDIVS_f32_256x16(float *src, float *dst, void *stream);
@@ -77,6 +78,7 @@ static const TestCase kCases[] = {
     {"f16_16x64_hp_subnormal_scalar_src",  (void (*)(void*,void*,void*))LaunchTDIVS_f16_16x64_hp_subnormal_scalar_src,  16,  64,  16,  64,  sizeof(uint16_t)},
     {"f32_16x64_hp_overflow_scalar_src",   (void (*)(void*,void*,void*))LaunchTDIVS_f32_16x64_hp_overflow_scalar_src,   16,  64,  16,  64,  sizeof(float)},
     {"f16_16x64_hp_overflow_scalar_src",   (void (*)(void*,void*,void*))LaunchTDIVS_f16_16x64_hp_overflow_scalar_src,   16,  64,  16,  64,  sizeof(uint16_t)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTDIVS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tdivs/tdivs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tdivs/tdivs.pto
@@ -396,4 +396,26 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TDIVS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 16 : index
+    %c64 = arith.constant 72 : index
+    %c2048 = arith.constant 1152 : index
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c1, %c1, %c1, %c32, %c64], strides = [%c2048, %c2048, %c2048, %c64, %c1] : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c1, %c1, %c1, %c32, %c64], strides = [%c2048, %c2048, %c2048, %c64, %c1] : !pto.tensor_view<1x1x1x16x72xf32>
+    %src_part = pto.partition_view %src_view, offsets = [%c0, %c0, %c0, %c0, %c0], sizes = [%c1, %c1, %c1, %c32, %c64] : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0, %c0, %c0, %c0], sizes = [%c1, %c1, %c1, %c32, %c64] : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %src = pto.alloc_tile : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile : !pto.tile_buf<vec, 16x72xf32>
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>) outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tdivs ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32) outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>) outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/cases.py
@@ -74,4 +74,12 @@ CASES = [
         "eps": 1e-7,
         "high_precision": True,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+        "high_precision": False,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/launch.cpp
@@ -53,3 +53,10 @@ extern "C" __global__ AICORE void TEXP_f16_64x64_hp2(__gm__ uint16_t *a, __gm__ 
 void LaunchTEXP_f16_64x64_hp2(void *a, void *b, void *stream) {
     TEXP_f16_64x64_hp2<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TEXP_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTEXP_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TEXP_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTEXP_f32_16x64(void *a, void *b, void *stream);
+void LaunchTEXP_f32_merge_axis_16x72(void *a, void *b, void *stream);
 void LaunchTEXP_f32_32x32(void *a, void *b, void *stream);
 void LaunchTEXP_f16_16x64(void *a, void *b, void *stream);
 void LaunchTEXP_f16_32x32(void *a, void *b, void *stream);
@@ -48,6 +49,7 @@ static const TestCase kCases[] = {
     {"f16_32x32", LaunchTEXP_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
     {"f32_64x64_hp1", LaunchTEXP_f32_64x64_hp1, 64, 64, 64, 64, sizeof(float)},
     {"f16_64x64_hp2", LaunchTEXP_f16_64x64_hp2, 64, 64, 64, 64, sizeof(uint16_t)},
+    {"f32_merge_axis_16x72", LaunchTEXP_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/texp/texp.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/texp/texp.pto
@@ -261,4 +261,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TEXP_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.texp ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/cases.py
@@ -84,4 +84,11 @@ CASES = [
         "eps": 1e-3,
         "precision_mode": "HIGH_PRECISION",
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/launch.cpp
@@ -67,3 +67,10 @@ extern "C" __global__ AICORE void TLOG_f16_32x32_hp(__gm__ uint16_t *a, __gm__ u
 void LaunchTLOG_f16_32x32_hp(void *a, void *b, void *stream) {
     TLOG_f16_32x32_hp<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TLOG_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTLOG_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TLOG_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTLOG_f32_16x64(void *a, void *b, void *stream);
+void LaunchTLOG_f32_merge_axis_16x72(void *a, void *b, void *stream);
 void LaunchTLOG_f32_32x32(void *a, void *b, void *stream);
 void LaunchTLOG_f16_16x64(void *a, void *b, void *stream);
 void LaunchTLOG_f16_32x32(void *a, void *b, void *stream);
@@ -52,6 +53,7 @@ static const TestCase kCases[] = {
     {"f32_32x32_hp", LaunchTLOG_f32_32x32_hp, 32, 32, 32, 32, sizeof(float)},
     {"f16_16x64_hp", LaunchTLOG_f16_16x64_hp, 16, 64, 16, 64, sizeof(uint16_t)},
     {"f16_32x32_hp", LaunchTLOG_f16_32x32_hp, 32, 32, 32, 32, sizeof(uint16_t)},
+    {"f32_merge_axis_16x72", LaunchTLOG_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlog/tlog.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlog/tlog.pto
@@ -347,4 +347,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TLOG_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tlog ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/cases.py
@@ -62,4 +62,13 @@ CASES = [
         "dst_valid_shape": (256, 16),
         "eps": 1e-3,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "dst_shape": (16, 72),
+        "dst_valid_shape": (16, 72),
+        "eps": 1e-3,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/launch.cpp
@@ -39,3 +39,10 @@ extern "C" __global__ AICORE void TLRELU_f32_256x16_dst32(__gm__ float *src, __g
 void LaunchTLRELU_f32_256x16_dst32(float *src, float *dst, float slope, void *stream) {
     TLRELU_f32_256x16_dst32<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, slope);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TLRELU_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float slope);
+
+void LaunchTLRELU_f32_merge_axis_16x72(float *src, float *dst, float slope, void *stream) {
+    TLRELU_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, slope);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/main.cpp
@@ -24,6 +24,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTLRELU_f32_32x64_dst128(float *src, float *dst, float slope, void *stream);
+void LaunchTLRELU_f32_merge_axis_16x72(float *src, float *dst, float slope, void *stream);
+
 void LaunchTLRELU_f16_63x64_dst128(uint16_t *src, uint16_t *dst, float slope, void *stream);
 void LaunchTLRELU_f32_7x448_dst512(float *src, float *dst, float slope, void *stream);
 void LaunchTLRELU_f32_256x16_dst32(float *src, float *dst, float slope, void *stream);
@@ -48,6 +50,7 @@ static const TestCase kCases[] = {
     {"f16_63x64_dst128",    (LaunchFn)LaunchTLRELU_f16_63x64_dst128,    63,   64,   63,  128, 63,  64,  sizeof(uint16_t), true},
     {"f32_7x448_dst512",    (LaunchFn)LaunchTLRELU_f32_7x448_dst512,    7,    448,  7,   512, 7,   448, sizeof(float),  false},
     {"f32_256x16_dst32",    (LaunchFn)LaunchTLRELU_f32_256x16_dst32,    256,  16,   256, 32,  256, 16,  sizeof(float),  false},
+    {"f32_merge_axis_16x72", (LaunchFn)LaunchTLRELU_f32_merge_axis_16x72, 16, 72, 16, 72, 16, 72, sizeof(float), false},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/tlrelu.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tlrelu/tlrelu.pto
@@ -211,4 +211,55 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%dst_part : !pto.partition_tensor_view<1x1x1x256x16xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TLRELU_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %slope: f32) attributes {pto.aicore} {
+    %c0   = arith.constant 0    : index
+    %c1   = arith.constant 1    : index
+    %c32  = arith.constant 16   : index
+    %c64  = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    // Src GM view: 1x1x1x16x72
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    // Dst GM view: shape=valid_shape (16x72), strides based on dst allocation (16x72)
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    // Dst partition: sizes = valid_shape (16x72)
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    // Src UB tile: 16x72, valid 16x72
+    %src_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    // Dst UB tile: 16x72, valid 16x72
+    %dst_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src_tile : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tlrelu ins(%src_tile, %slope : !pto.tile_buf<vec, 16x72xf32>, f32)
+               outs(%dst_tile : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmax/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmax/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 1e-6,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmax/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmax/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TMAX_f32_32x32(__gm__ float *a, __gm__ float *
 void LaunchTMAX_f32_32x32(float *a, float *b, float *c, void *stream) {
     TMAX_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMAX_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTMAX_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream) {
+    TMAX_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmax/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmax/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMAX_f32_16x64(float *a, float *b, float *c, void *stream);
+void LaunchTMAX_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream);
 void LaunchTMAX_f32_32x32(float *a, float *b, float *c, void *stream);
 
 using LaunchFn = void (*)(float *, float *, float *, void *);
@@ -40,6 +41,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"f32_16x64", LaunchTMAX_f32_16x64, 16, 64, 16, 64, sizeof(float)},
     {"f32_32x32", LaunchTMAX_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f32_merge_axis_16x72", LaunchTMAX_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmax/tmax.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmax/tmax.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMAX_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tmax ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/cases.py
@@ -19,4 +19,5 @@ CASES = [
     {"name": "i16_15x192", "dtype": np.int16, "shape": (15, 192), "valid_shape": (15, 192), "eps": 0},
     {"name": "f32_7x448", "dtype": np.float32, "shape": (7, 448), "valid_shape": (7, 448), "eps": 1e-6},
     {"name": "f32_256x16", "dtype": np.float32, "shape": (256, 16), "valid_shape": (256, 16), "eps": 1e-6},
+{"name": "f32_merge_axis_16x72", "dtype": np.float32, "shape": (16, 72), "valid_shape": (16, 72), "eps": 1e-6},
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/launch.cpp
@@ -56,3 +56,10 @@ extern "C" __global__ AICORE void TMAXS_f32_256x16(__gm__ float *src, __gm__ flo
 void LaunchTMAXS_f32_256x16(float *src, float *dst, void *stream) {
     TMAXS_f32_256x16<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMAXS_SCALAR_F32);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMAXS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+
+void LaunchTMAXS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TMAXS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMAXS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMAXS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTMAXS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
 void LaunchTMAXS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTMAXS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTMAXS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -46,6 +47,7 @@ static const TestCase kCases[] = {
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTMAXS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
     {"f32_7x448",   (void (*)(void*,void*,void*))LaunchTMAXS_f32_7x448,   7,   448, 7,   448, sizeof(float)},
     {"f32_256x16",  (void (*)(void*,void*,void*))LaunchTMAXS_f32_256x16,  256, 16,  256, 16,  sizeof(float)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTMAXS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/tmaxs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmaxs/tmaxs.pto
@@ -253,4 +253,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMAXS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tmaxs ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmin/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmin/cases.py
@@ -79,4 +79,11 @@ CASES = [
         "valid_shape": (16, 200),
         "eps": 0,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmin/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmin/launch.cpp
@@ -67,3 +67,10 @@ extern "C" __global__ AICORE void TMIN_i16_20x512_v16x200(__gm__ int16_t *a, __g
 void LaunchTMIN_i16_20x512_v16x200(void *a, void *b, void *c, void *stream) {
     TMIN_i16_20x512_v16x200<<<1, nullptr, stream>>>((__gm__ int16_t *)a, (__gm__ int16_t *)b, (__gm__ int16_t *)c);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMIN_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTMIN_f32_merge_axis_16x72(void *a, void *b, void *c, void *stream) {
+    TMIN_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmin/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmin/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMIN_f32_64x64(void *a, void *b, void *c, void *stream);
+void LaunchTMIN_f32_merge_axis_16x72(void *a, void *b, void *c, void *stream);
 void LaunchTMIN_i32_64x64(void *a, void *b, void *c, void *stream);
 void LaunchTMIN_i16_64x64(void *a, void *b, void *c, void *stream);
 void LaunchTMIN_f16_64x64(void *a, void *b, void *c, void *stream);
@@ -52,6 +53,7 @@ static const TestCase kCases[] = {
     {"i32_64x64_v60x60", LaunchTMIN_i32_64x64_v60x60, 64, 64, 60, 60, sizeof(int32_t)},
     {"f16_2x4096_v1x3600", LaunchTMIN_f16_2x4096_v1x3600, 2, 4096, 1, 3600, sizeof(uint16_t)},
     {"i16_20x512_v16x200", LaunchTMIN_i16_20x512_v16x200, 20, 512, 16, 200, sizeof(int16_t)},
+    {"f32_merge_axis_16x72", LaunchTMIN_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmin/tmin.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmin/tmin.pto
@@ -447,4 +447,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x16x200xi16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMIN_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tmin ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmins/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmins/cases.py
@@ -19,4 +19,5 @@ CASES = [
     {"name": "i16_15x192", "dtype": np.int16, "shape": (15, 192), "valid_shape": (15, 192), "eps": 0},
     {"name": "f32_7x448", "dtype": np.float32, "shape": (7, 448), "valid_shape": (7, 448), "eps": 1e-6},
     {"name": "f32_256x16", "dtype": np.float32, "shape": (256, 16), "valid_shape": (256, 16), "eps": 1e-6},
+{"name": "f32_merge_axis_16x72", "dtype": np.float32, "shape": (16, 72), "valid_shape": (16, 72), "eps": 1e-6},
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmins/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmins/launch.cpp
@@ -56,3 +56,10 @@ extern "C" __global__ AICORE void TMINS_f32_256x16(__gm__ float *src, __gm__ flo
 void LaunchTMINS_f32_256x16(float *src, float *dst, void *stream) {
     TMINS_f32_256x16<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMINS_SCALAR_F32);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMINS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+
+void LaunchTMINS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TMINS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMINS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmins/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmins/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMINS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTMINS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
 void LaunchTMINS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTMINS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTMINS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -46,6 +47,7 @@ static const TestCase kCases[] = {
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTMINS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
     {"f32_7x448",   (void (*)(void*,void*,void*))LaunchTMINS_f32_7x448,   7,   448, 7,   448, sizeof(float)},
     {"f32_256x16",  (void (*)(void*,void*,void*))LaunchTMINS_f32_256x16,  256, 16,  256, 16,  sizeof(float)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTMINS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmins/tmins.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmins/tmins.pto
@@ -253,4 +253,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMINS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tmins ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmov/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmov/cases.py
@@ -95,4 +95,11 @@ CASES = [
         "valid_shape": (128, 128),
         "eps": 0,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmov/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmov/launch.cpp
@@ -81,3 +81,10 @@ extern "C" __global__ AICORE void TMOV_u8_128x128(__gm__ uint8_t *src, __gm__ ui
 void LaunchTMOV_u8_128x128(uint8_t *src, uint8_t *dst, void *stream) {
     TMOV_u8_128x128<<<1, nullptr, stream>>>((__gm__ uint8_t *)src, (__gm__ uint8_t *)dst);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMOV_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst);
+
+void LaunchTMOV_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TMOV_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmov/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmov/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMOV_f32_64x64(float *src, float *dst, void *stream);
+void LaunchTMOV_f32_merge_axis_16x72(float *src, float *dst, void *stream);
+
 void LaunchTMOV_f32_32x32(float *src, float *dst, void *stream);
 void LaunchTMOV_f32_128x128(float *src, float *dst, void *stream);
 void LaunchTMOV_f32_128x32(float *src, float *dst, void *stream);
@@ -54,6 +56,7 @@ static const TestCase kCases[] = {
     {"f16_128x128",  (void(*)(void*,void*,void*))LaunchTMOV_f16_128x128,  128,  128,  128,  128,  sizeof(uint16_t)},
     {"u8_64x64",     (void(*)(void*,void*,void*))LaunchTMOV_u8_64x64,     64,   64,   64,   64,   sizeof(uint8_t)},
     {"u8_128x128",   (void(*)(void*,void*,void*))LaunchTMOV_u8_128x128,   128,  128,  128,  128,  sizeof(uint8_t)},
+    {"f32_merge_axis_16x72", (void(*)(void*,void*,void*))LaunchTMOV_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmov/tmov.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmov/tmov.pto
@@ -404,4 +404,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%dst_part : !pto.partition_tensor_view<1x1x1x128x128xui8>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMOV_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0     : index
+    %c1    = arith.constant 1     : index
+    %c16   = arith.constant 16    : index
+    %c64   = arith.constant 72    : index
+    %c1024 = arith.constant 1152  : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tmov ins(%src : !pto.tile_buf<vec, 16x72xf32>)
+             outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmul/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmul/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 1e-6,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmul/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmul/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TMUL_f32_32x32(__gm__ float *a, __gm__ float *
 void LaunchTMUL_f32_32x32(float *a, float *b, float *c, void *stream) {
     TMUL_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMUL_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTMUL_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream) {
+    TMUL_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmul/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmul/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMUL_f32_16x64(float *a, float *b, float *c, void *stream);
+void LaunchTMUL_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream);
 void LaunchTMUL_f32_32x32(float *a, float *b, float *c, void *stream);
 
 using LaunchFn = void (*)(float *, float *, float *, void *);
@@ -40,6 +41,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"f32_16x64", LaunchTMUL_f32_16x64, 16, 64, 16, 64, sizeof(float)},
     {"f32_32x32", LaunchTMUL_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f32_merge_axis_16x72", LaunchTMUL_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmul/tmul.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmul/tmul.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMUL_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tmul ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmuls/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmuls/cases.py
@@ -66,4 +66,11 @@ CASES = [
         "valid_shape": (256, 16),
         "eps": 1e-6,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmuls/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmuls/launch.cpp
@@ -56,3 +56,10 @@ extern "C" __global__ AICORE void TMULS_f32_256x16(__gm__ float *src, __gm__ flo
 void LaunchTMULS_f32_256x16(float *src, float *dst, void *stream) {
     TMULS_f32_256x16<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMULS_SCALAR_F32);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TMULS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+
+void LaunchTMULS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TMULS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TMULS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmuls/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmuls/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTMULS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTMULS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
 void LaunchTMULS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTMULS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTMULS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -46,6 +47,7 @@ static const TestCase kCases[] = {
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTMULS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
     {"f32_7x448",   (void (*)(void*,void*,void*))LaunchTMULS_f32_7x448,   7,   448, 7,   448, sizeof(float)},
     {"f32_256x16",  (void (*)(void*,void*,void*))LaunchTMULS_f32_256x16,  256, 16,  256, 16,  sizeof(float)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTMULS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tmuls/tmuls.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tmuls/tmuls.pto
@@ -253,4 +253,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TMULS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tmuls ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/cases.py
@@ -66,4 +66,11 @@ CASES = [
         "valid_shape": (64, 16),
         "eps": 0,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/launch.cpp
@@ -53,3 +53,10 @@ extern "C" __global__ AICORE void TNEG_i16_64x16(__gm__ int16_t *a, __gm__ int16
 void LaunchTNEG_i16_64x16(void *a, void *b, void *stream) {
     TNEG_i16_64x16<<<1, nullptr, stream>>>((__gm__ int16_t *)a, (__gm__ int16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TNEG_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTNEG_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TNEG_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTNEG_f32_16x64(void *a, void *b, void *stream);
+void LaunchTNEG_f32_merge_axis_16x72(void *a, void *b, void *stream);
+
 void LaunchTNEG_f32_32x32(void *a, void *b, void *stream);
 void LaunchTNEG_f16_16x64(void *a, void *b, void *stream);
 void LaunchTNEG_f16_32x32(void *a, void *b, void *stream);
@@ -48,6 +50,7 @@ static const TestCase kCases[] = {
     {"f16_32x32", LaunchTNEG_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
     {"i32_32x32", LaunchTNEG_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
     {"i16_64x16", LaunchTNEG_i16_64x16, 64, 16, 64, 16, sizeof(int16_t)},
+    {"f32_merge_axis_16x72", LaunchTNEG_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tneg/tneg.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tneg/tneg.pto
@@ -260,4 +260,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x64x16xi16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TNEG_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tneg ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/cases.py
@@ -66,4 +66,11 @@ CASES = [
         "valid_shape": (60, 60), 
         "eps": 0
     },
+    {
+        "name": "int8_merge_axis_32x288",
+        "dtype": np.int8,
+        "shape": (32, 288),
+        "valid_shape": (32, 288),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/launch.cpp
@@ -53,3 +53,10 @@ extern "C" __global__ AICORE void TNOT_uint32_60x60(__gm__ uint32_t *a, __gm__ u
 void LaunchTNOT_uint32_60x60(void *a, void *b, void *stream) {
     TNOT_uint32_60x60<<<1, nullptr, stream>>>((__gm__ uint32_t *)a, (__gm__ uint32_t *)b);
 }
+
+// Merge-axis case: int8 merge axis 32x264
+extern "C" __global__ AICORE void TNOT_int8_merge_axis_32x288(__gm__ int8_t *a, __gm__ int8_t *b);
+
+void LaunchTNOT_int8_merge_axis_32x288(void *a, void *b, void *stream) {
+    TNOT_int8_merge_axis_32x288<<<1, nullptr, stream>>>((__gm__ int8_t *)a, (__gm__ int8_t *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTNOT_int8_64x64(void *a, void *b, void *stream);
+void LaunchTNOT_int8_merge_axis_32x288(void *a, void *b, void *stream);
+
 void LaunchTNOT_uint8_60x60(void *a, void *b, void *stream);
 void LaunchTNOT_int16_64x64(void *a, void *b, void *stream);
 void LaunchTNOT_uint16_60x60(void *a, void *b, void *stream);
@@ -48,6 +50,7 @@ static const TestCase kCases[] = {
     {"uint16_60x60", LaunchTNOT_uint16_60x60, 64, 64, 60, 60, sizeof(uint16_t)},
     {"int32_64x64",  LaunchTNOT_int32_64x64,  64, 64, 64, 64, sizeof(int32_t)},
     {"uint32_60x60", LaunchTNOT_uint32_60x60, 64, 64, 60, 60, sizeof(uint32_t)},
+    {"int8_merge_axis_32x288", LaunchTNOT_int8_merge_axis_32x288, 32, 288, 32, 288, sizeof(int8_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tnot/tnot.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tnot/tnot.pto
@@ -260,4 +260,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x60x60xui32>)
     return
   }
+
+
+
+
+  // Merge-axis case: int8 full-axis 32x288 (9216 elements)
+  func.func @TNOT_int8_merge_axis_32x288(%a_ptr: !pto.ptr<i8>, %b_ptr: !pto.ptr<i8>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 32   : index
+    %c288  = arith.constant 288  : index
+    %c9216 = arith.constant 9216 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c288],
+      strides = [%c9216, %c9216, %c9216, %c288, %c1]
+      : !pto.tensor_view<1x1x1x32x288xi8>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c288],
+      strides = [%c9216, %c9216, %c9216, %c288, %c1]
+      : !pto.tensor_view<1x1x1x32x288xi8>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c288]
+      : !pto.tensor_view<1x1x1x32x288xi8> -> !pto.partition_tensor_view<1x1x1x32x288xi8>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c288]
+      : !pto.tensor_view<1x1x1x32x288xi8> -> !pto.partition_tensor_view<1x1x1x32x288xi8>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 32x288xi8>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 32x288xi8>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x32x288xi8>)
+              outs(%a : !pto.tile_buf<vec, 32x288xi8>)
+
+    pto.tnot ins(%a : !pto.tile_buf<vec, 32x288xi8>)
+             outs(%b : !pto.tile_buf<vec, 32x288xi8>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 32x288xi8>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x32x288xi8>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tor/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tor/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 0,
     },
+    {
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tor/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tor/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TOR_i32_32x32(__gm__ int32_t *a, __gm__ int32_
 void LaunchTOR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream) {
     TOR_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TOR_i32_merge_axis_16x72(__gm__ int32_t *a, __gm__ int32_t *b, __gm__ int32_t *c);
+
+void LaunchTOR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream) {
+    TOR_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tor/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tor/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTOR_i32_16x64(int32_t *a, int32_t *b, int32_t *c, void *stream);
+void LaunchTOR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream);
+
 void LaunchTOR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream);
 
 using LaunchFn = void (*)(int32_t *, int32_t *, int32_t *, void *);
@@ -40,6 +42,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"i32_16x64", LaunchTOR_i32_16x64, 16, 64, 16, 64, sizeof(int32_t)},
     {"i32_32x32", LaunchTOR_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i32_merge_axis_16x72", LaunchTOR_i32_merge_axis_16x72, 16, 72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tor/tor.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tor/tor.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
     return
   }
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TOR_i32_merge_axis_16x72(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>, %c_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tor ins(%a, %b : !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tors/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tors/cases.py
@@ -39,4 +39,11 @@ CASES = [
         "valid_shape": (15, 192),
         "eps": 0,
     },
+{
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tors/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tors/launch.cpp
@@ -43,3 +43,10 @@ extern "C" __global__ AICORE void TORS_i16_15x192(__gm__ int16_t *src, __gm__ in
 void LaunchTORS_i16_15x192(int16_t *src, int16_t *dst, void *stream) {
     TORS_i16_15x192<<<1, nullptr, stream>>>((__gm__ int16_t *)src, (__gm__ int16_t *)dst, TORS_SCALAR_I16);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TORS_i32_merge_axis_16x72(__gm__ int32_t *src, __gm__ int32_t *dst, int32_t scalar);
+
+void LaunchTORS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream) {
+    TORS_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)src, (__gm__ int32_t *)dst, TORS_SCALAR_I32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tors/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tors/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTORS_i32_32x64(int32_t *src, int32_t *dst, void *stream);
+void LaunchTORS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream);
 void LaunchTORS_i16_63x64(int16_t *src, int16_t *dst, void *stream);
 void LaunchTORS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTORS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -42,6 +43,7 @@ static const TestCase kCases[] = {
     {"i16_63x64",   (void (*)(void*,void*,void*))LaunchTORS_i16_63x64,   63,  64,  63,  64,  sizeof(int16_t)},
     {"i32_31x128",  (void (*)(void*,void*,void*))LaunchTORS_i32_31x128,  31,  128, 31,  128, sizeof(int32_t)},
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTORS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
+    {"i32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTORS_i32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tors/tors.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tors/tors.pto
@@ -173,4 +173,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TORS_i32_merge_axis_16x72(%src_ptr: !pto.ptr<i32>, %dst_ptr: !pto.ptr<i32>, %scalar: i32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tors ins(%src, %scalar : !pto.tile_buf<vec, 16x72xi32>, i32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/cases.py
@@ -80,4 +80,11 @@ CASES = [
         "valid_shape": (2048, 8),
         "eps": 1e-6,
     },
+    {
+        "name": "f16_merge_axis_16x144",
+        "dtype": np.float16,
+        "shape": (16, 144),
+        "valid_shape": (16, 144),
+        "eps": 1e-3,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/launch.cpp
@@ -67,3 +67,10 @@ extern "C" __global__ AICORE void TPRELU_f32_2048x8(__gm__ float *src0, __gm__ f
 void LaunchTPRELU_f32_2048x8(float *src0, float *src1, float *dst, void *stream) {
     TPRELU_f32_2048x8<<<1, nullptr, stream>>>((__gm__ float *)src0, (__gm__ float *)src1, (__gm__ float *)dst);
 }
+
+// Merge-axis case: f16 merge axis 16x136
+extern "C" __global__ AICORE void TPRELU_f16_merge_axis_16x144(__gm__ uint16_t *src0, __gm__ uint16_t *src1, __gm__ uint16_t *dst);
+
+void LaunchTPRELU_f16_merge_axis_16x144(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream) {
+    TPRELU_f16_merge_axis_16x144<<<1, nullptr, stream>>>((__gm__ uint16_t *)src0, (__gm__ uint16_t *)src1, (__gm__ uint16_t *)dst);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTPRELU_f16_64x64(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream);
+void LaunchTPRELU_f16_merge_axis_16x144(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream);
+
 void LaunchTPRELU_f16_63x63(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream);
 void LaunchTPRELU_f16_1x16384(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream);
 void LaunchTPRELU_f16_2048x16(uint16_t *src0, uint16_t *src1, uint16_t *dst, void *stream);
@@ -52,6 +54,7 @@ static const TestCase kCases[] = {
     {"f32_63x63",       F32, (void*)LaunchTPRELU_f32_63x63,       64,    64,     63,    63},
     {"f32_1x16384",     F32, (void*)LaunchTPRELU_f32_1x16384,     1,     16384,  1,     16384},
     {"f32_2048x8",      F32, (void*)LaunchTPRELU_f32_2048x8,      2048,  8,      2048,  8},
+    {"f16_merge_axis_16x144", F16, (void*)LaunchTPRELU_f16_merge_axis_16x144, 16, 144, 16, 144},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/tprelu.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/tprelu.pto
@@ -491,4 +491,65 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%dst_part : !pto.partition_tensor_view<1x1x1x2048x8xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f16 full-axis 16x136 (2176 elements)
+  func.func @TPRELU_f16_merge_axis_16x144(%src0_ptr: !pto.ptr<f16>, %src1_ptr: !pto.ptr<f16>, %dst_ptr: !pto.ptr<f16>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c144  = arith.constant 144  : index
+    %c2304 = arith.constant 2304 : index
+
+    %src0_view = pto.make_tensor_view %src0_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c144],
+      strides = [%c2304, %c2304, %c2304, %c144, %c1]
+      : !pto.tensor_view<1x1x1x16x144xf16>
+    %src1_view = pto.make_tensor_view %src1_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c144],
+      strides = [%c2304, %c2304, %c2304, %c144, %c1]
+      : !pto.tensor_view<1x1x1x16x144xf16>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c144],
+      strides = [%c2304, %c2304, %c2304, %c144, %c1]
+      : !pto.tensor_view<1x1x1x16x144xf16>
+
+    %src0_part = pto.partition_view %src0_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c144]
+      : !pto.tensor_view<1x1x1x16x144xf16> -> !pto.partition_tensor_view<1x1x1x16x144xf16>
+    %src1_part = pto.partition_view %src1_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c144]
+      : !pto.tensor_view<1x1x1x16x144xf16> -> !pto.partition_tensor_view<1x1x1x16x144xf16>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c144]
+      : !pto.tensor_view<1x1x1x16x144xf16> -> !pto.partition_tensor_view<1x1x1x16x144xf16>
+
+    %src0_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x144xf16>
+    %src1_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x144xf16>
+    %tmp_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x144xf16>
+    %dst_tile = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x144xf16>
+
+    pto.tload ins(%src0_part : !pto.partition_tensor_view<1x1x1x16x144xf16>)
+              outs(%src0_tile : !pto.tile_buf<vec, 16x144xf16>)
+    pto.tload ins(%src1_part : !pto.partition_tensor_view<1x1x1x16x144xf16>)
+              outs(%src1_tile : !pto.tile_buf<vec, 16x144xf16>)
+
+    pto.tprelu ins(%src0_tile, %src1_tile, %tmp_tile : !pto.tile_buf<vec, 16x144xf16>,
+                           !pto.tile_buf<vec, 16x144xf16>,
+                           !pto.tile_buf<vec, 16x144xf16>)
+               outs(%dst_tile : !pto.tile_buf<vec, 16x144xf16>)
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 16x144xf16>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x144xf16>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/cases.py
@@ -66,4 +66,11 @@ CASES = [
         "valid_shape": (58, 70),
         "eps": 1e-6,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/launch.cpp
@@ -53,3 +53,10 @@ extern "C" __global__ AICORE void TRECIP_f32_58x70(__gm__ float *a, __gm__ float
 void LaunchTRECIP_f32_58x70(void *a, void *b, void *stream) {
     TRECIP_f32_58x70<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TRECIP_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRECIP_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TRECIP_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTRECIP_f32_16x64(void *a, void *b, void *stream);
+void LaunchTRECIP_f32_merge_axis_16x72(void *a, void *b, void *stream);
 void LaunchTRECIP_f32_32x32(void *a, void *b, void *stream);
 void LaunchTRECIP_f16_16x64(void *a, void *b, void *stream);
 void LaunchTRECIP_f16_32x32(void *a, void *b, void *stream);
@@ -48,6 +49,7 @@ static const TestCase kCases[] = {
     {"f16_32x32", LaunchTRECIP_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
     {"f32_64x64_pad", LaunchTRECIP_f32_64x64_pad, 66, 72, 64, 64, sizeof(float)},
     {"f32_58x70", LaunchTRECIP_f32_58x70, 66, 72, 58, 70, sizeof(float)},
+    {"f32_merge_axis_16x72", LaunchTRECIP_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/trecip/trecip.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trecip/trecip.pto
@@ -265,4 +265,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x58x70xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TRECIP_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.trecip ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/trelu/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trelu/cases.py
@@ -49,4 +49,11 @@ CASES = [
         "valid_shape": (60, 60),
         "eps": 1e-6,
     },
+    {
+        "name": "int32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trelu/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trelu/launch.cpp
@@ -32,3 +32,10 @@ extern "C" __global__ AICORE void TRELU_f32_64x64_v60x60(__gm__ float *input, __
 void LaunchTRELU_f32_64x64_v60x60(float *input, float *output, void *stream) {
     TRELU_f32_64x64_v60x60<<<1, nullptr, stream>>>((__gm__ float *)input, (__gm__ float *)output);
 }
+
+// Merge-axis case: int32 merge axis 16x72
+extern "C" __global__ AICORE void TRELU_int32_merge_axis_16x72(__gm__ int32_t *input, __gm__ int32_t *output);
+
+void LaunchTRELU_int32_merge_axis_16x72(int32_t *input, int32_t *output, void *stream) {
+    TRELU_int32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)input, (__gm__ int32_t *)output);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trelu/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trelu/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTRELU_int32_64x64(int32_t *input, int32_t *output, void *stream);
+void LaunchTRELU_int32_merge_axis_16x72(int32_t *input, int32_t *output, void *stream);
+
 void LaunchTRELU_f16_64x64_v60x60(uint16_t *input, uint16_t *output, void *stream);
 void LaunchTRELU_f32_64x64_v60x60(float *input, float *output, void *stream);
 
@@ -38,6 +40,7 @@ static const TestCase kCases[] = {
     {"int32_64x64",             (void (*)(void*, void*, void*))LaunchTRELU_int32_64x64,     64, 64, sizeof(int32_t)},
     {"f16_64x64_valid_60x60",   (void (*)(void*, void*, void*))LaunchTRELU_f16_64x64_v60x60, 60, 60, sizeof(uint16_t)},
     {"f32_64x64_valid_60x60",   (void (*)(void*, void*, void*))LaunchTRELU_f32_64x64_v60x60, 60, 60, sizeof(float)},
+    {"int32_merge_axis_16x72",  (void (*)(void*, void*, void*))LaunchTRELU_int32_merge_axis_16x72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/trelu/trelu.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trelu/trelu.pto
@@ -136,4 +136,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%output_part : !pto.partition_tensor_view<1x1x1x60x60xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: int32 full-axis 16x72 (1152 elements)
+  func.func @TRELU_int32_merge_axis_16x72(%input_ptr: !pto.ptr<i32>, %output_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %input_view = pto.make_tensor_view %input_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %output_view = pto.make_tensor_view %output_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %input_part = pto.partition_view %input_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %output_part = pto.partition_view %output_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%input_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.trelu ins(%src : !pto.tile_buf<vec, 16x72xi32>)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%output_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/cases.py
@@ -52,4 +52,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 1e-3,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/launch.cpp
@@ -39,3 +39,10 @@ extern "C" __global__ AICORE void TRSQRT_f16_32x32(__gm__ uint16_t *a, __gm__ ui
 void LaunchTRSQRT_f16_32x32(void *a, void *b, void *stream) {
     TRSQRT_f16_32x32<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TRSQRT_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTRSQRT_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TRSQRT_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTRSQRT_f32_16x64(void *a, void *b, void *stream);
+void LaunchTRSQRT_f32_merge_axis_16x72(void *a, void *b, void *stream);
 void LaunchTRSQRT_f32_32x32(void *a, void *b, void *stream);
 void LaunchTRSQRT_f16_16x64(void *a, void *b, void *stream);
 void LaunchTRSQRT_f16_32x32(void *a, void *b, void *stream);
@@ -44,6 +45,7 @@ static const TestCase kCases[] = {
     {"f32_32x32", LaunchTRSQRT_f32_32x32, 32, 32, 32, 32, sizeof(float)},
     {"f16_16x64", LaunchTRSQRT_f16_16x64, 16, 64, 16, 64, sizeof(uint16_t)},
     {"f16_32x32", LaunchTRSQRT_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
+    {"f32_merge_axis_16x72", LaunchTRSQRT_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/trsqrt.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trsqrt/trsqrt.pto
@@ -178,4 +178,49 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%b_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TRSQRT_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.trsqrt ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshl/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshl/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 0,
     },
+    {
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshl/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshl/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TSHL_i32_32x32(__gm__ int32_t *a, __gm__ int32
 void LaunchTSHL_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream) {
     TSHL_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TSHL_i32_merge_axis_16x72(__gm__ int32_t *a, __gm__ int32_t *b, __gm__ int32_t *c);
+
+void LaunchTSHL_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream) {
+    TSHL_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshl/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshl/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSHL_i32_16x64(int32_t *a, int32_t *b, int32_t *c, void *stream);
+void LaunchTSHL_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream);
+
 void LaunchTSHL_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream);
 
 using LaunchFn = void (*)(int32_t *, int32_t *, int32_t *, void *);
@@ -40,6 +42,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"i32_16x64", LaunchTSHL_i32_16x64, 16, 64, 16, 64, sizeof(int32_t)},
     {"i32_32x32", LaunchTSHL_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i32_merge_axis_16x72", LaunchTSHL_i32_merge_axis_16x72, 16, 72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshl/tshl.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshl/tshl.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
     return
   }
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TSHL_i32_merge_axis_16x72(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>, %c_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tshl ins(%a, %b : !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshls/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshls/cases.py
@@ -39,4 +39,11 @@ CASES = [
         "valid_shape": (15, 192),
         "eps": 0,
     },
+{
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshls/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshls/launch.cpp
@@ -42,3 +42,10 @@ extern "C" __global__ AICORE void TSHLS_i16_15x192(__gm__ int16_t *src, __gm__ i
 void LaunchTSHLS_i16_15x192(int16_t *src, int16_t *dst, void *stream) {
     TSHLS_i16_15x192<<<1, nullptr, stream>>>((__gm__ int16_t *)src, (__gm__ int16_t *)dst, TSHLS_SCALAR);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TSHLS_i32_merge_axis_16x72(__gm__ int32_t *src, __gm__ int32_t *dst, int16_t scalar);
+
+void LaunchTSHLS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream) {
+    TSHLS_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)src, (__gm__ int32_t *)dst, TSHLS_SCALAR);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshls/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshls/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSHLS_i32_32x64(int32_t *src, int32_t *dst, void *stream);
+void LaunchTSHLS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream);
 void LaunchTSHLS_i16_63x64(int16_t *src, int16_t *dst, void *stream);
 void LaunchTSHLS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTSHLS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -42,6 +43,7 @@ static const TestCase kCases[] = {
     {"i16_63x64",   (void (*)(void*,void*,void*))LaunchTSHLS_i16_63x64,   63,  64,  63,  64,  sizeof(int16_t)},
     {"i32_31x128",  (void (*)(void*,void*,void*))LaunchTSHLS_i32_31x128,  31,  128, 31,  128, sizeof(int32_t)},
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTSHLS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
+    {"i32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTSHLS_i32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshls/tshls.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshls/tshls.pto
@@ -173,4 +173,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TSHLS_i32_merge_axis_16x72(%src_ptr: !pto.ptr<i32>, %dst_ptr: !pto.ptr<i32>, %scalar: i16) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tshls ins(%src, %scalar : !pto.tile_buf<vec, 16x72xi32>, i16)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshr/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshr/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 0,
     },
+    {
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshr/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshr/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TSHR_i32_32x32(__gm__ int32_t *a, __gm__ int32
 void LaunchTSHR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream) {
     TSHR_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TSHR_i32_merge_axis_16x72(__gm__ int32_t *a, __gm__ int32_t *b, __gm__ int32_t *c);
+
+void LaunchTSHR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream) {
+    TSHR_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshr/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshr/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSHR_i32_16x64(int32_t *a, int32_t *b, int32_t *c, void *stream);
+void LaunchTSHR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream);
+
 void LaunchTSHR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream);
 
 using LaunchFn = void (*)(int32_t *, int32_t *, int32_t *, void *);
@@ -40,6 +42,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"i32_16x64", LaunchTSHR_i32_16x64, 16, 64, 16, 64, sizeof(int32_t)},
     {"i32_32x32", LaunchTSHR_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i32_merge_axis_16x72", LaunchTSHR_i32_merge_axis_16x72, 16, 72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshr/tshr.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshr/tshr.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
     return
   }
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TSHR_i32_merge_axis_16x72(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>, %c_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tshr ins(%a, %b : !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshrs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshrs/cases.py
@@ -39,4 +39,11 @@ CASES = [
         "valid_shape": (15, 192),
         "eps": 0,
     },
+{
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshrs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshrs/launch.cpp
@@ -42,3 +42,10 @@ extern "C" __global__ AICORE void TSHRS_i16_15x192(__gm__ int16_t *src, __gm__ i
 void LaunchTSHRS_i16_15x192(int16_t *src, int16_t *dst, void *stream) {
     TSHRS_i16_15x192<<<1, nullptr, stream>>>((__gm__ int16_t *)src, (__gm__ int16_t *)dst, TSHRS_SCALAR);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TSHRS_i32_merge_axis_16x72(__gm__ int32_t *src, __gm__ int32_t *dst, int16_t scalar);
+
+void LaunchTSHRS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream) {
+    TSHRS_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)src, (__gm__ int32_t *)dst, TSHRS_SCALAR);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshrs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshrs/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSHRS_i32_32x64(int32_t *src, int32_t *dst, void *stream);
+void LaunchTSHRS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream);
 void LaunchTSHRS_i16_63x64(int16_t *src, int16_t *dst, void *stream);
 void LaunchTSHRS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTSHRS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -42,6 +43,7 @@ static const TestCase kCases[] = {
     {"i16_63x64",   (void (*)(void*,void*,void*))LaunchTSHRS_i16_63x64,   63,  64,  63,  64,  sizeof(int16_t)},
     {"i32_31x128",  (void (*)(void*,void*,void*))LaunchTSHRS_i32_31x128,  31,  128, 31,  128, sizeof(int32_t)},
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTSHRS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
+    {"i32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTSHRS_i32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tshrs/tshrs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tshrs/tshrs.pto
@@ -173,4 +173,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TSHRS_i32_merge_axis_16x72(%src_ptr: !pto.ptr<i32>, %dst_ptr: !pto.ptr<i32>, %scalar: i16) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tshrs ins(%src, %scalar : !pto.tile_buf<vec, 16x72xi32>, i16)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/cases.py
@@ -72,4 +72,12 @@ CASES = [
         "eps": 1e-7,
         "high_precision": True,
     },
+{
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+        "high_precision": False,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/launch.cpp
@@ -53,3 +53,10 @@ extern "C" __global__ AICORE void TSQRT_f16_64x64_hp2(__gm__ uint16_t *a, __gm__
 void LaunchTSQRT_f16_64x64_hp2(void *a, void *b, void *stream) {
     TSQRT_f16_64x64_hp2<<<1, nullptr, stream>>>((__gm__ uint16_t *)a, (__gm__ uint16_t *)b);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TSQRT_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b);
+
+void LaunchTSQRT_f32_merge_axis_16x72(void *a, void *b, void *stream) {
+    TSQRT_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSQRT_f32_16x64(void *a, void *b, void *stream);
+void LaunchTSQRT_f32_merge_axis_16x72(void *a, void *b, void *stream);
 void LaunchTSQRT_f32_32x32(void *a, void *b, void *stream);
 void LaunchTSQRT_f16_16x64(void *a, void *b, void *stream);
 void LaunchTSQRT_f16_32x32(void *a, void *b, void *stream);
@@ -48,6 +49,7 @@ static const TestCase kCases[] = {
     {"f16_32x32", LaunchTSQRT_f16_32x32, 32, 32, 32, 32, sizeof(uint16_t)},
     {"f32_64x64_hp1", LaunchTSQRT_f32_64x64_hp1, 64, 64, 64, 64, sizeof(float)},
     {"f16_64x64_hp2", LaunchTSQRT_f16_64x64_hp2, 64, 64, 64, 64, sizeof(uint16_t)},
+    {"f32_merge_axis_16x72", LaunchTSQRT_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/tsqrt.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsqrt/tsqrt.pto
@@ -261,4 +261,49 @@ pto.tstore ins(%b : !pto.tile_buf<vec, 32x32xf32>)
                outs(%b_part : !pto.partition_tensor_view<1x1x1x64x64xf16>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TSQRT_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tsqrt ins(%a : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsub/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsub/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 1e-6,
     },
+    {
+        "name": "f32_merge_axis_16x72",
+        "dtype": np.float32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 1e-6,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsub/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsub/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TSUB_f32_32x32(__gm__ float *a, __gm__ float *
 void LaunchTSUB_f32_32x32(float *a, float *b, float *c, void *stream) {
     TSUB_f32_32x32<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TSUB_f32_merge_axis_16x72(__gm__ float *a, __gm__ float *b, __gm__ float *c);
+
+void LaunchTSUB_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream) {
+    TSUB_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)a, (__gm__ float *)b, (__gm__ float *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsub/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsub/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSUB_f32_16x64(float *a, float *b, float *c, void *stream);
+void LaunchTSUB_f32_merge_axis_16x72(float *a, float *b, float *c, void *stream);
 void LaunchTSUB_f32_32x32(float *a, float *b, float *c, void *stream);
 
 using LaunchFn = void (*)(float *, float *, float *, void *);
@@ -40,6 +41,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"f32_16x64", LaunchTSUB_f32_16x64, 16, 64, 16, 64, sizeof(float)},
     {"f32_32x32", LaunchTSUB_f32_32x32, 32, 32, 32, 32, sizeof(float)},
+    {"f32_merge_axis_16x72", LaunchTSUB_f32_merge_axis_16x72, 16, 72, 16, 72, sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsub/tsub.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsub/tsub.pto
@@ -120,4 +120,62 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xf32>)
     return
   }
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TSUB_f32_merge_axis_16x72(%a_ptr: !pto.ptr<f32>, %b_ptr: !pto.ptr<f32>, %c_ptr: !pto.ptr<f32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tsub ins(%a, %b : !pto.tile_buf<vec, 16x72xf32>,
+                          !pto.tile_buf<vec, 16x72xf32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xf32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsubs/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsubs/cases.py
@@ -19,4 +19,5 @@ CASES = [
     {"name": "i16_15x192", "dtype": np.int16, "shape": (15, 192), "valid_shape": (15, 192), "eps": 0},
     {"name": "f32_7x448", "dtype": np.float32, "shape": (7, 448), "valid_shape": (7, 448), "eps": 1e-6},
     {"name": "f32_256x16", "dtype": np.float32, "shape": (256, 16), "valid_shape": (256, 16), "eps": 1e-6},
+{"name": "f32_merge_axis_16x72", "dtype": np.float32, "shape": (16, 72), "valid_shape": (16, 72), "eps": 1e-6},
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsubs/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsubs/launch.cpp
@@ -56,3 +56,10 @@ extern "C" __global__ AICORE void TSUBS_f32_256x16(__gm__ float *src, __gm__ flo
 void LaunchTSUBS_f32_256x16(float *src, float *dst, void *stream) {
     TSUBS_f32_256x16<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TSUBS_SCALAR_F32);
 }
+
+// Merge-axis case: f32 merge axis 16x72
+extern "C" __global__ AICORE void TSUBS_f32_merge_axis_16x72(__gm__ float *src, __gm__ float *dst, float scalar);
+
+void LaunchTSUBS_f32_merge_axis_16x72(float *src, float *dst, void *stream) {
+    TSUBS_f32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ float *)src, (__gm__ float *)dst, TSUBS_SCALAR_F32);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsubs/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsubs/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTSUBS_f32_32x64(float *src, float *dst, void *stream);
+void LaunchTSUBS_f32_merge_axis_16x72(float *src, float *dst, void *stream);
 void LaunchTSUBS_f16_63x64(uint16_t *src, uint16_t *dst, void *stream);
 void LaunchTSUBS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTSUBS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -46,6 +47,7 @@ static const TestCase kCases[] = {
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTSUBS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
     {"f32_7x448",   (void (*)(void*,void*,void*))LaunchTSUBS_f32_7x448,   7,   448, 7,   448, sizeof(float)},
     {"f32_256x16",  (void (*)(void*,void*,void*))LaunchTSUBS_f32_256x16,  256, 16,  256, 16,  sizeof(float)},
+    {"f32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTSUBS_f32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(float)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsubs/tsubs.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsubs/tsubs.pto
@@ -253,4 +253,47 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: f32 full-axis 16x72 (1152 elements)
+  func.func @TSUBS_f32_merge_axis_16x72(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f32>, %scalar: f32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xf32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xf32> -> !pto.partition_tensor_view<1x1x1x16x72xf32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xf32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tsubs ins(%src, %scalar : !pto.tile_buf<vec, 16x72xf32>, f32)
+              outs(%dst : !pto.tile_buf<vec, 16x72xf32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xf32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xf32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/txor/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txor/cases.py
@@ -37,4 +37,11 @@ CASES = [
         "valid_shape": (32, 32),
         "eps": 0,
     },
+    {
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/txor/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txor/launch.cpp
@@ -25,3 +25,10 @@ extern "C" __global__ AICORE void TXOR_i32_32x32(__gm__ int32_t *a, __gm__ int32
 void LaunchTXOR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream) {
     TXOR_i32_32x32<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TXOR_i32_merge_axis_16x72(__gm__ int32_t *a, __gm__ int32_t *b, __gm__ int32_t *c);
+
+void LaunchTXOR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream) {
+    TXOR_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)a, (__gm__ int32_t *)b, (__gm__ int32_t *)c);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/txor/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txor/main.cpp
@@ -23,6 +23,8 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTXOR_i32_16x64(int32_t *a, int32_t *b, int32_t *c, void *stream);
+void LaunchTXOR_i32_merge_axis_16x72(int32_t *a, int32_t *b, int32_t *c, void *stream);
+
 void LaunchTXOR_i32_32x32(int32_t *a, int32_t *b, int32_t *c, void *stream);
 
 using LaunchFn = void (*)(int32_t *, int32_t *, int32_t *, void *);
@@ -40,6 +42,7 @@ struct TestCase {
 static const TestCase kCases[] = {
     {"i32_16x64", LaunchTXOR_i32_16x64, 16, 64, 16, 64, sizeof(int32_t)},
     {"i32_32x32", LaunchTXOR_i32_32x32, 32, 32, 32, 32, sizeof(int32_t)},
+    {"i32_merge_axis_16x72", LaunchTXOR_i32_merge_axis_16x72, 16, 72, 16, 72, sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/txor/txor.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txor/txor.pto
@@ -122,4 +122,63 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
                outs(%c_part : !pto.partition_tensor_view<1x1x1x32x32xi32>)
     return
   }
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TXOR_i32_merge_axis_16x72(%a_ptr: !pto.ptr<i32>, %b_ptr: !pto.ptr<i32>, %c_ptr: !pto.ptr<i32>) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c16   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c1024 = arith.constant 1152 : index
+
+    %a_view = pto.make_tensor_view %a_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %a_part = pto.partition_view %a_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %a = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %c = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%a_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%a : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tload ins(%b_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%b : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.txor ins(%a, %b, %c : !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>,
+                          !pto.tile_buf<vec, 16x72xi32>)
+             outs(%c : !pto.tile_buf<vec, 16x72xi32>)
+
+    pto.tstore ins(%c : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%c_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }

--- a/test/tilelang_st/npu/a5/src/st/testcase/txors/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txors/cases.py
@@ -45,4 +45,11 @@ CASES = [
         "valid_shape": (15, 192),
         "eps": 0,
     },
+{
+        "name": "i32_merge_axis_16x72",
+        "dtype": np.int32,
+        "shape": (16, 72),
+        "valid_shape": (16, 72),
+        "eps": 0,
+    },
 ]

--- a/test/tilelang_st/npu/a5/src/st/testcase/txors/launch.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txors/launch.cpp
@@ -39,3 +39,10 @@ extern "C" __global__ AICORE void TXORS_i16_15x192(__gm__ int16_t *src, __gm__ i
 void LaunchTXORS_i16_15x192(int16_t *src, int16_t *dst, void *stream) {
     TXORS_i16_15x192<<<1, nullptr, stream>>>((__gm__ int16_t *)src, (__gm__ int16_t *)dst, (int16_t)3);
 }
+
+// Merge-axis case: i32 merge axis 16x72
+extern "C" __global__ AICORE void TXORS_i32_merge_axis_16x72(__gm__ int32_t *src, __gm__ int32_t *dst, int32_t scalar);
+
+void LaunchTXORS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream) {
+    TXORS_i32_merge_axis_16x72<<<1, nullptr, stream>>>((__gm__ int32_t *)src, (__gm__ int32_t *)dst, (int32_t)3);
+}

--- a/test/tilelang_st/npu/a5/src/st/testcase/txors/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txors/main.cpp
@@ -23,6 +23,7 @@ using namespace PtoTestCommon;
 
 // Kernel launch wrappers (defined in launch.cpp)
 void LaunchTXORS_i32_32x64(int32_t *src, int32_t *dst, void *stream);
+void LaunchTXORS_i32_merge_axis_16x72(int32_t *src, int32_t *dst, void *stream);
 void LaunchTXORS_i16_63x64(int16_t *src, int16_t *dst, void *stream);
 void LaunchTXORS_i32_31x128(int32_t *src, int32_t *dst, void *stream);
 void LaunchTXORS_i16_15x192(int16_t *src, int16_t *dst, void *stream);
@@ -42,6 +43,7 @@ static const TestCase kCases[] = {
     {"i16_63x64",   (void (*)(void*,void*,void*))LaunchTXORS_i16_63x64,   63,  64,  63,  64,  sizeof(int16_t)},
     {"i32_31x128",  (void (*)(void*,void*,void*))LaunchTXORS_i32_31x128,  31,  128, 31,  128, sizeof(int32_t)},
     {"i16_15x192",  (void (*)(void*,void*,void*))LaunchTXORS_i16_15x192,  15,  192, 15,  192, sizeof(int16_t)},
+    {"i32_merge_axis_16x72",   (void (*)(void*,void*,void*))LaunchTXORS_i32_merge_axis_16x72, 16, 72, 16, 72,  sizeof(int32_t)},
 };
 static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/txors/txors.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/txors/txors.pto
@@ -186,4 +186,50 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 
+
+
+
+
+  // Merge-axis case: i32 full-axis 16x72 (1152 elements)
+  func.func @TXORS_i32_merge_axis_16x72(%src_ptr: !pto.ptr<i32>, %dst_ptr: !pto.ptr<i32>, %scalar: i32) attributes {pto.aicore} {
+    %c0    = arith.constant 0    : index
+    %c1    = arith.constant 1    : index
+    %c32   = arith.constant 16   : index
+    %c64   = arith.constant 72   : index
+    %c2048 = arith.constant 1152 : index
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c32, %c64],
+      strides = [%c2048, %c2048, %c2048, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x72xi32>
+
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c64]
+      : !pto.tensor_view<1x1x1x16x72xi32> -> !pto.partition_tensor_view<1x1x1x16x72xi32>
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+    %tmp = pto.alloc_tile
+      : !pto.tile_buf<vec, 16x72xi32>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+              outs(%src : !pto.tile_buf<vec, 16x72xi32>)
+    pto.txors ins(%src, %scalar, %tmp : !pto.tile_buf<vec, 16x72xi32>, i32,
+                                             !pto.tile_buf<vec, 16x72xi32>)
+              outs(%dst : !pto.tile_buf<vec, 16x72xi32>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 16x72xi32>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x72xi32>)
+    return
+  }
 }


### PR DESCRIPTION
### 标题
TileLang element-wise OP 增加满轴合轴版本并补齐 ST 覆盖

### 描述
本次主要为 lib/TileOps 中的 element-wise 类 OP 增加“合轴/满轴”版本实现，并同步补齐对应的 TileLang ST 用例。

### 修改内容
新增 lib/TileOps/merge_axis.py，抽出满轴场景的公共约束与合轴遍历辅助逻辑。
为 element-wise OP 增加 merge_axis 版本模板，满轴时优先选择 1D 合轴实现，非满轴仍保持原有 2D 实现兜底。
更新 test/tilelang_st 下相关 testcase，补充合轴场景 .pto、cases.py、launch.cpp、main.cpp。
调整 run_ptoas_to_file.cmake，确保 ST 编译时使用当前仓库内的 TileOps / tilelang-dsl 实现，避免误用外部安装版本。
修正部分合轴 case 的 shape / valid_shape / stride 配置，使其满足满轴展开条件。

### 验证
已通过 test/tilelang_st 相关 element-wise 合轴 ST 回归。