### PR TITLE
feat(ptodsl): add VS Code syntax highlighting package

### DIFF
--- a/editor-support/vscode-ptodsl/README.md
+++ b/editor-support/vscode-ptodsl/README.md
@@ -1,0 +1,19 @@
+# PTODSL Syntax for VS Code
+
+This extension provides TextMate-based syntax highlighting for PTODSL, the
+Python DSL used in this repository.
+
+What it highlights:
+
+- PTODSL decorators such as `@pto.jit`, `@pto.simd`, `@pto.simt`, and `@pto.cube`
+- PTODSL control-flow helpers such as `pto.for_`, `pto.if_`, `pto.yield_`, and `pto.vecscope`
+- Public PTODSL types, enums, and namespace helpers under `pto.*`
+- PTODSL scalar helpers under `scalar.*`
+- The grammar also injects into ordinary Python files, so existing `.py`
+  PTODSL sources can light up without renaming them first
+
+If you want a dedicated language mode, associate files such as
+`*.ptodsl.py` or `*.pto.py` with `PTODSL` in VS Code.
+
+This package is intentionally lightweight: it only adds syntax coloring and
+editor configuration, and it does not change PTODSL execution semantics.

--- a/editor-support/vscode-ptodsl/language-configuration.json
+++ b/editor-support/vscode-ptodsl/language-configuration.json
@@ -1,0 +1,63 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    [
+      "(",
+      ")"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "{",
+      "}"
+    ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "'",
+      "close": "'"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "{",
+      "close": "}"
+    }
+  ],
+  "surroundingPairs": [
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "'",
+      "close": "'"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "{",
+      "close": "}"
+    }
+  ]
+}

--- a/editor-support/vscode-ptodsl/package.json
+++ b/editor-support/vscode-ptodsl/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "vscode-ptodsl",
+  "displayName": "PTODSL Syntax",
+  "description": "TextMate-based syntax highlighting for PTODSL in Python files.",
+  "version": "0.1.0",
+  "publisher": "mly",
+  "engines": {
+    "vscode": "^1.84.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "keywords": [
+    "ptodsl",
+    "pto",
+    "python",
+    "syntax highlighting"
+  ],
+  "activationEvents": [
+    "onLanguage:ptodsl",
+    "onLanguage:python"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "ptodsl",
+        "aliases": [
+          "PTODSL"
+        ],
+        "extensions": [
+          ".ptodsl.py",
+          ".pto.py"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "ptodsl",
+        "scopeName": "source.ptodsl",
+        "path": "./syntaxes/ptodsl.tmLanguage.json"
+      },
+      {
+        "scopeName": "ptodsl.injection",
+        "path": "./syntaxes/ptodsl-injection.tmLanguage.json",
+        "injectTo": [
+          "source.python"
+        ]
+      }
+    ]
+  }
+}

--- a/editor-support/vscode-ptodsl/syntaxes/ptodsl-injection.tmLanguage.json
+++ b/editor-support/vscode-ptodsl/syntaxes/ptodsl-injection.tmLanguage.json
@@ -1,0 +1,129 @@
+{
+  "scopeName": "ptodsl.injection",
+  "injectionSelector": "L:source.python",
+  "patterns": [
+    {
+      "include": "#ptodsl-imports"
+    },
+    {
+      "include": "#ptodsl-decorators"
+    },
+    {
+      "include": "#ptodsl-control-flow"
+    },
+    {
+      "include": "#ptodsl-enum-chains"
+    },
+    {
+      "include": "#ptodsl-surface-types"
+    },
+    {
+      "include": "#ptodsl-namespace-calls"
+    }
+  ],
+  "repository": {
+    "ptodsl-imports": {
+      "patterns": [
+        {
+          "name": "meta.import.ptodsl",
+          "match": "\\b(?:from\\s+ptodsl\\s+import|import\\s+ptodsl)\\b"
+        }
+      ]
+    },
+    "ptodsl-decorators": {
+      "patterns": [
+        {
+          "name": "meta.decorator.ptodsl",
+          "match": "@(pto)\\.(jit|simd|simt|cube)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "entity.name.function.decorator.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-control-flow": {
+      "patterns": [
+        {
+          "name": "keyword.control.ptodsl",
+          "match": "\\b(pto)\\.(for_|if_|yield_|vecscope)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "keyword.control.ptodsl"
+            }
+          }
+        },
+        {
+          "name": "keyword.control.ptodsl",
+          "match": "\\b(br)\\.(then_|else_)\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.variable.ptodsl"
+            },
+            "2": {
+              "name": "keyword.control.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-enum-chains": {
+      "patterns": [
+        {
+          "name": "constant.language.ptodsl",
+          "match": "\\b(pto)\\.(MemorySpace|BarrierType|Pipe|MaskPattern|CmpMode|PredicatePart|PredicateDist|VStoreDist|DeinterleaveDist|InterleaveDist|PostUpdate|PartMode|VPackPart|VcvtRoundMode|VcvtSatMode|VcvtPartMode)\\.([A-Za-z0-9_]+)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.type.ptodsl"
+            },
+            "3": {
+              "name": "constant.language.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-surface-types": {
+      "patterns": [
+        {
+          "name": "support.type.ptodsl",
+          "match": "\\b(pto)\\.(Tile|TensorView|PartitionTensorView|TensorSpec|constexpr|float32|float16|bf16|f8e4m3|f8e5m2|hif8|f4e1m2x2|f4e2m1x2|int1|int8|int16|int32|int64|si8|si16|si32|si64|ui8|ui16|ui32|ui64|index|ptr|vreg_type|mask_type|AlignType)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.type.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-namespace-calls": {
+      "patterns": [
+        {
+          "name": "support.function.ptodsl",
+          "match": "\\b(pto|scalar)\\.[A-Za-z_][A-Za-z0-9_]*\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.function.ptodsl"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/editor-support/vscode-ptodsl/syntaxes/ptodsl.tmLanguage.json
+++ b/editor-support/vscode-ptodsl/syntaxes/ptodsl.tmLanguage.json
@@ -1,0 +1,131 @@
+{
+  "scopeName": "source.ptodsl",
+  "patterns": [
+    {
+      "include": "#ptodsl-imports"
+    },
+    {
+      "include": "#ptodsl-decorators"
+    },
+    {
+      "include": "#ptodsl-control-flow"
+    },
+    {
+      "include": "#ptodsl-enum-chains"
+    },
+    {
+      "include": "#ptodsl-surface-types"
+    },
+    {
+      "include": "#ptodsl-namespace-calls"
+    },
+    {
+      "include": "source.python"
+    }
+  ],
+  "repository": {
+    "ptodsl-imports": {
+      "patterns": [
+        {
+          "name": "meta.import.ptodsl",
+          "match": "\\b(?:from\\s+ptodsl\\s+import|import\\s+ptodsl)\\b"
+        }
+      ]
+    },
+    "ptodsl-decorators": {
+      "patterns": [
+        {
+          "name": "meta.decorator.ptodsl",
+          "match": "@(pto)\\.(jit|simd|simt|cube)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "entity.name.function.decorator.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-control-flow": {
+      "patterns": [
+        {
+          "name": "keyword.control.ptodsl",
+          "match": "\\b(pto)\\.(for_|if_|yield_|vecscope)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "keyword.control.ptodsl"
+            }
+          }
+        },
+        {
+          "name": "keyword.control.ptodsl",
+          "match": "\\b(br)\\.(then_|else_)\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.variable.ptodsl"
+            },
+            "2": {
+              "name": "keyword.control.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-enum-chains": {
+      "patterns": [
+        {
+          "name": "constant.language.ptodsl",
+          "match": "\\b(pto)\\.(MemorySpace|BarrierType|Pipe|MaskPattern|CmpMode|PredicatePart|PredicateDist|VStoreDist|DeinterleaveDist|InterleaveDist|PostUpdate|PartMode|VPackPart|VcvtRoundMode|VcvtSatMode|VcvtPartMode)\\.([A-Za-z0-9_]+)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.type.ptodsl"
+            },
+            "3": {
+              "name": "constant.language.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-surface-types": {
+      "patterns": [
+        {
+          "name": "support.type.ptodsl",
+          "match": "\\b(pto)\\.(Tile|TensorView|PartitionTensorView|TensorSpec|constexpr|float32|float16|bf16|f8e4m3|f8e5m2|hif8|f4e1m2x2|f4e2m1x2|int1|int8|int16|int32|int64|si8|si16|si32|si64|ui8|ui16|ui32|ui64|index|ptr|vreg_type|mask_type|AlignType)\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.type.ptodsl"
+            }
+          }
+        }
+      ]
+    },
+    "ptodsl-namespace-calls": {
+      "patterns": [
+        {
+          "name": "support.function.ptodsl",
+          "match": "\\b(pto|scalar)\\.[A-Za-z_][A-Za-z0-9_]*\\b",
+          "captures": {
+            "1": {
+              "name": "support.namespace.ptodsl"
+            },
+            "2": {
+              "name": "support.function.ptodsl"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -56,6 +56,15 @@ pip install -e .
 
 ---
 
+## Editor support
+
+`editor-support/vscode-ptodsl/` contains a lightweight VS Code syntax package
+for PTODSL. It highlights PTODSL decorators, control-flow helpers, surface
+types, and `scalar.*` helpers on top of ordinary Python syntax, and it can
+also be assigned directly to `*.ptodsl.py` or `*.pto.py` files.
+
+---
+
 ## Running the IR check
 
 ```bash


### PR DESCRIPTION
## Summary
- add a lightweight VS Code syntax-highlighting package for PTODSL under `editor-support/vscode-ptodsl/`
- provide both a dedicated `ptodsl` language grammar and a Python injection grammar so existing PTODSL `.py` files highlight without renaming
- document the new editor support entry point in `ptodsl/README.md`

## Validation
- `python3 -m json.tool editor-support/vscode-ptodsl/package.json`
- `python3 -m json.tool editor-support/vscode-ptodsl/language-configuration.json`
- `python3 -m json.tool editor-support/vscode-ptodsl/syntaxes/ptodsl.tmLanguage.json`
- `python3 -m json.tool editor-support/vscode-ptodsl/syntaxes/ptodsl-injection.tmLanguage.json`