### PR TITLE
Add PTODSL pipe surface APIs

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -11398,6 +11398,20 @@ static bool isInsideSectionVector(Operation *op) {
 }
 
 static std::optional<FunctionKernelKind>
+getEnclosingModuleKernelKind(Operation *op) {
+  for (Operation *parent = op; parent; parent = parent->getParentOp()) {
+    auto moduleOp = dyn_cast<ModuleOp>(parent);
+    if (!moduleOp)
+      continue;
+    auto kernelKindAttr = moduleOp->getAttrOfType<FunctionKernelKindAttr>(
+        FunctionKernelKindAttr::name);
+    if (kernelKindAttr)
+      return kernelKindAttr.getKernelKind();
+  }
+  return std::nullopt;
+}
+
+static std::optional<FunctionKernelKind>
 getEnclosingFunctionKernelKind(Operation *op) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
   if (!funcOp)
@@ -11414,7 +11428,8 @@ getEnclosingFunctionKernelKind(Operation *op) {
 
 static bool isInsideSectionOrAttributedKernel(Operation *op) {
   return isInsideSectionCube(op) || isInsideSectionVector(op) ||
-         getEnclosingFunctionKernelKind(op).has_value();
+         getEnclosingFunctionKernelKind(op).has_value() ||
+         getEnclosingModuleKernelKind(op).has_value();
 }
 
 static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
@@ -11426,8 +11441,18 @@ static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
 static LogicalResult verifyFrontendKernelKind(Operation *op,
                                               FunctionKernelKind expected,
                                               StringRef kernelName) {
-  auto kernelKind = getEnclosingFunctionKernelKind(op);
-  if (!kernelKind || *kernelKind != expected) {
+  if ((expected == FunctionKernelKind::Cube && isInsideSectionCube(op)) ||
+      (expected == FunctionKernelKind::Vector && isInsideSectionVector(op))) {
+    return success();
+  }
+
+  std::optional<FunctionKernelKind> kernelKind =
+      getEnclosingFunctionKernelKind(op);
+  if (!kernelKind)
+    kernelKind = getEnclosingModuleKernelKind(op);
+  if (!kernelKind)
+    return success();
+  if (*kernelKind != expected) {
     return op->emitOpError("must be inside a ")
            << kernelName << " kernel function";
   }
@@ -11708,18 +11733,14 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
 
   unsigned sameIdInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
-    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
-      if (aic.getId() == op.getId())
+    if (auto sameSideInit = dyn_cast<InitOpT>(candidate)) {
+      if (sameSideInit.getId() == op.getId())
         ++sameIdInitCount;
-      return;
     }
-    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate))
-      if (aiv.getId() == op.getId())
-        ++sameIdInitCount;
   });
   if (sameIdInitCount > 1) {
     return op.emitOpError(
-        "requires 'id' to be unique across frontend initialize_pipe ops in the function");
+        "requires 'id' to be unique across same-side frontend initialize_pipe ops in the function");
   }
 
   int8_t dirMask = op.getDirMask();
@@ -11748,14 +11769,22 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
         op.getOperation(), op.getGmSlotTensor(), dirMask, op.getSlotSize());
   }
 
-  if (hasC2vConsumerBuf != hasV2cConsumerBuf) {
+  if (!hasC2vConsumerBuf && !hasV2cConsumerBuf) {
     return op.emitOpError(
-        "expects 'c2v_consumer_buf' and 'v2c_consumer_buf' to be provided together");
+        "expects local pipe init to provide at least one consumer buffer "
+        "operand; use 'gm_slot_tensor' for globaltensor pipe entries");
   }
-  if (!hasC2vConsumerBuf) {
+  if (dirMask == 1 && !hasC2vConsumerBuf) {
     return op.emitOpError(
-        "expects local pipe init to provide 'c2v_consumer_buf' and "
-        "'v2c_consumer_buf'; use 'gm_slot_tensor' for globaltensor pipe entries");
+        "expects 'c2v_consumer_buf' when dir_mask is 1");
+  }
+  if (dirMask == 2 && !hasV2cConsumerBuf) {
+    return op.emitOpError(
+        "expects 'v2c_consumer_buf' when dir_mask is 2");
+  }
+  if (dirMask == 3 && (!hasC2vConsumerBuf || !hasV2cConsumerBuf)) {
+    return op.emitOpError(
+        "expects both 'c2v_consumer_buf' and 'v2c_consumer_buf' when dir_mask is 3");
   }
 
   if (auto localSlotNumAttr = op.getLocalSlotNumAttr()) {
@@ -11860,37 +11889,41 @@ LogicalResult ImportReservedBufferOp::verify() {
   return success();
 }
 
-static FailureOr<Operation *> lookupFrontendInitOpById(Operation *op,
-                                                       func::FuncOp funcOp,
-                                                       int32_t id) {
+static FailureOr<Operation *>
+lookupFrontendInitOpById(Operation *op, func::FuncOp funcOp, int32_t id,
+                         FunctionKernelKind expected) {
   Operation *matchedInit = nullptr;
   unsigned matchedInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
-    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
+    if (expected == FunctionKernelKind::Cube) {
+      auto aic = dyn_cast<AicInitializePipeOp>(candidate);
+      if (!aic)
+        return WalkResult::advance();
       if (aic.getId() == static_cast<uint32_t>(id)) {
         matchedInit = candidate;
         ++matchedInitCount;
       }
       return WalkResult::advance();
     }
-    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate)) {
-      if (aiv.getId() == static_cast<uint32_t>(id)) {
-        matchedInit = candidate;
-        ++matchedInitCount;
-      }
+
+    auto aiv = dyn_cast<AivInitializePipeOp>(candidate);
+    if (!aiv)
       return WalkResult::advance();
+    if (aiv.getId() == static_cast<uint32_t>(id)) {
+      matchedInit = candidate;
+      ++matchedInitCount;
     }
     return WalkResult::advance();
   });
 
   if (matchedInitCount == 0) {
     op->emitOpError() << "expects 'id' = " << id
-                      << " to match a frontend initialize_pipe op in the same function";
+                      << " to match a same-side frontend initialize_pipe op in the same function";
     return failure();
   }
   if (matchedInitCount > 1) {
     op->emitOpError() << "expects 'id' = " << id
-                      << " to match exactly one frontend initialize_pipe op in the same function";
+                      << " to match exactly one same-side frontend initialize_pipe op in the same function";
     return failure();
   }
   return matchedInit;
@@ -11908,10 +11941,10 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   return verifySplitAttr(op, split);
 }
 
-static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
-                                                       func::FuncOp funcOp,
-                                                       int32_t id) {
-  auto initOr = lookupFrontendInitOpById(op, funcOp, id);
+static FailureOr<int8_t>
+lookupFrontendInitDirMaskById(Operation *op, func::FuncOp funcOp, int32_t id,
+                              FunctionKernelKind expected) {
+  auto initOr = lookupFrontendInitOpById(op, funcOp, id, expected);
   if (failed(initOr))
     return failure();
   if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr))
@@ -11920,12 +11953,13 @@ static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
 }
 
 static LogicalResult verifyFrontendDataOpDirection(Operation *op, int32_t id,
-                                                   bool expectC2V) {
+                                                   bool expectC2V,
+                                                   FunctionKernelKind expected) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
   if (!funcOp)
     return op->emitOpError("must be nested under a func.func");
 
-  auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id);
+  auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id, expected);
   if (failed(dirMaskOr))
     return failure();
 
@@ -11951,7 +11985,8 @@ static Value getFrontendInitGmSlotTensor(Operation *initOp) {
 
 static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
                                                           int32_t id,
-                                                          Type entryTy) {
+                                                          Type entryTy,
+                                                          FunctionKernelKind expected) {
   auto entryViewTy = dyn_cast<TensorViewType>(entryTy);
   if (!entryViewTy)
     return success();
@@ -11960,7 +11995,7 @@ static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
   if (!funcOp)
     return op->emitOpError("must be nested under a func.func");
 
-  auto initOr = lookupFrontendInitOpById(op, funcOp, id);
+  auto initOr = lookupFrontendInitOpById(op, funcOp, id, expected);
   if (failed(initOr))
     return failure();
   Value gmSlotTensor = getFrontendInitGmSlotTensor(*initOr);
@@ -12007,10 +12042,11 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
                                    op.getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(op.getOperation(), op.getId(),
-                                           expectC2V)))
+                                           expectC2V, expected)))
     return failure();
   if (failed(verifyFrontendTensorEntryMatchesInit(op.getOperation(), op.getId(),
-                                                  op.getTile().getType())))
+                                                  op.getTile().getType(),
+                                                  expected)))
     return failure();
 
   bool hasValidRow = static_cast<bool>(op.getValidRow());
@@ -12414,10 +12450,12 @@ LogicalResult TAllocToAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Cube)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getEntry().getType());
+                                              getEntry().getType(),
+                                              FunctionKernelKind::Cube);
 }
 
 LogicalResult TAllocToAicOp::verify() {
@@ -12425,10 +12463,12 @@ LogicalResult TAllocToAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Vector)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getEntry().getType());
+                                              getEntry().getType(),
+                                              FunctionKernelKind::Vector);
 }
 
 LogicalResult TPushToAivOp::verify() {
@@ -12436,10 +12476,12 @@ LogicalResult TPushToAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Cube)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getTile().getType());
+                                              getTile().getType(),
+                                              FunctionKernelKind::Cube);
 }
 
 LogicalResult TPushToAicOp::verify() {
@@ -12447,10 +12489,12 @@ LogicalResult TPushToAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Vector)))
     return failure();
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getTile().getType());
+                                              getTile().getType(),
+                                              FunctionKernelKind::Vector);
 }
 
 LogicalResult TPopFromAicOp::verify() {
@@ -12468,11 +12512,13 @@ LogicalResult TFreeFromAicOp::verify() {
                                    "vector", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true,
+                                           FunctionKernelKind::Vector)))
     return failure();
   if (getEntry())
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                                getEntry().getType());
+                                                getEntry().getType(),
+                                                FunctionKernelKind::Vector);
   return success();
 }
 
@@ -12481,11 +12527,13 @@ LogicalResult TFreeFromAivOp::verify() {
                                    "cube", getId(), getSplit())))
     return failure();
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false,
+                                           FunctionKernelKind::Cube)))
     return failure();
   if (getEntry())
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                                getEntry().getType());
+                                                getEntry().getType(),
+                                                FunctionKernelKind::Cube);
   return success();
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -11441,9 +11441,17 @@ static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
 static LogicalResult verifyFrontendKernelKind(Operation *op,
                                               FunctionKernelKind expected,
                                               StringRef kernelName) {
-  if ((expected == FunctionKernelKind::Cube && isInsideSectionCube(op)) ||
-      (expected == FunctionKernelKind::Vector && isInsideSectionVector(op))) {
-    return success();
+  if (isInsideSectionCube(op)) {
+    if (expected == FunctionKernelKind::Cube)
+      return success();
+    return op->emitOpError("must be inside a ")
+           << kernelName << " kernel function or section";
+  }
+  if (isInsideSectionVector(op)) {
+    if (expected == FunctionKernelKind::Vector)
+      return success();
+    return op->emitOpError("must be inside a ")
+           << kernelName << " kernel function or section";
   }
 
   std::optional<FunctionKernelKind> kernelKind =
@@ -11454,7 +11462,7 @@ static LogicalResult verifyFrontendKernelKind(Operation *op,
     return success();
   if (*kernelKind != expected) {
     return op->emitOpError("must be inside a ")
-           << kernelName << " kernel function";
+           << kernelName << " kernel function or section";
   }
   return success();
 }
@@ -11750,20 +11758,31 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
     return op.emitOpError("expects 'slot_size' to be greater than 0");
 
   bool hasGlobalSlotTensor = static_cast<bool>(op.getGmSlotTensor());
+  bool hasGmSlotBuffer = static_cast<bool>(op.getGmSlotBuffer());
   bool hasC2vConsumerBuf = static_cast<bool>(op.getC2vConsumerBuf());
   bool hasV2cConsumerBuf = static_cast<bool>(op.getV2cConsumerBuf());
   if (hasGlobalSlotTensor) {
-    if (op.getGmSlotBuffer() || hasC2vConsumerBuf || hasV2cConsumerBuf) {
-      return op.emitOpError(
-          "globaltensor pipe init expects only 'gm_slot_tensor' and no "
-          "'gm_slot_buffer', 'c2v_consumer_buf', or 'v2c_consumer_buf'");
-    }
     if (op.getLocalSlotNumAttr())
       return op.emitOpError(
           "globaltensor pipe init does not use 'local_slot_num'");
     if (getTargetArch(op.getOperation()) == PTOArch::A5) {
       return op.emitOpError(
           "globaltensor pipe entries are supported for a2/a3 l2g2l pipes");
+    }
+    if (!hasGmSlotBuffer)
+      return op.emitOpError(
+          "globaltensor pipe init expects 'gm_slot_buffer' for a2/a3 l2g2l pipes");
+    if (dirMask == 1 && !hasC2vConsumerBuf) {
+      return op.emitOpError(
+          "expects 'c2v_consumer_buf' when dir_mask is 1");
+    }
+    if (dirMask == 2 && !hasV2cConsumerBuf) {
+      return op.emitOpError(
+          "expects 'v2c_consumer_buf' when dir_mask is 2");
+    }
+    if (dirMask == 3 && (!hasC2vConsumerBuf || !hasV2cConsumerBuf)) {
+      return op.emitOpError(
+          "expects both 'c2v_consumer_buf' and 'v2c_consumer_buf' when dir_mask is 3");
     }
     return verifyFrontendGlobalSlotTensor(
         op.getOperation(), op.getGmSlotTensor(), dirMask, op.getSlotSize());
@@ -12135,7 +12154,11 @@ static LogicalResult verifyTensorEntryMatchesInternalPipeInit(Operation *op,
            << "expects !pto.tensor_view pipe entry to use a pipe produced by "
               "pto.initialize_l2g2l_pipe";
   }
-  if (initOp.getLocalAddr()) {
+  Type slotTy = initOp.getGmAddr().getType();
+  if (auto entryTypeAttr =
+          initOp->getAttrOfType<TypeAttr>("__pto.globaltensor_entry_type")) {
+    slotTy = entryTypeAttr.getValue();
+  } else if (initOp.getLocalAddr()) {
     return op->emitOpError()
            << "expects !pto.tensor_view pipe entry to use global-only "
               "pto.initialize_l2g2l_pipe without local_addr";
@@ -12143,8 +12166,7 @@ static LogicalResult verifyTensorEntryMatchesInternalPipeInit(Operation *op,
 
   Type slotElementType;
   ArrayRef<int64_t> slotShape;
-  if (!getTensorLikeElementAndShape(initOp.getGmAddr().getType(),
-                                    slotElementType, slotShape)) {
+  if (!getTensorLikeElementAndShape(slotTy, slotElementType, slotShape)) {
     return op->emitOpError()
            << "expects !pto.tensor_view pipe entry to use "
               "pto.initialize_l2g2l_pipe gm_addr with tensor/memref slot type";

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -36,6 +36,8 @@ constexpr int8_t kBidirectionalDirMask = 3;
 constexpr int32_t kSingleDirectionSlotNum = 8;
 constexpr int32_t kBidirectionalSlotNum = 4;
 constexpr llvm::StringLiteral kFrontendPipeIdAttrName = "__pto.frontend_id";
+constexpr llvm::StringLiteral kGlobalTensorEntryTypeAttrName =
+    "__pto.globaltensor_entry_type";
 constexpr llvm::StringLiteral kGlobalTensorStridesAttrName =
     "__pto.globaltensor_strides";
 
@@ -131,11 +133,21 @@ static FailureOr<Value> createFrontendPipe(InitOpT initOp, IRRewriter &rewriter,
     if (arch == PTOArch::A5)
       return initOp.emitOpError(
           "globaltensor pipe entries are supported for a2/a3 l2g2l pipes");
+    if (failed(requireFrontendGmSlotBuffer(initOp)))
+      return failure();
+    if (!localAddr)
+      return initOp.emitOpError(
+          "requires local consumer buffer operands for globaltensor pipe lowering");
 
+    IntegerAttr localSlotNumAttr = initOp.getLocalSlotNumAttr();
+    if (!localSlotNumAttr)
+      localSlotNumAttr = rewriter.getI32IntegerAttr(slotNum);
     auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
-        loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, IntegerAttr{},
-        IntegerAttr{}, noSplitAttr, initOp.getGmSlotTensor(), Value{},
-        Value{});
+        loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, localSlotNumAttr,
+        IntegerAttr{}, noSplitAttr, initOp.getGmSlotBuffer(), localAddr,
+        peerLocalAddr);
+    pipe->setAttr(kGlobalTensorEntryTypeAttrName,
+                  TypeAttr::get(initOp.getGmSlotTensor().getType()));
     propagateFrontendIdAttr(initOp, pipe.getOperation(), rewriter);
     return pipe.getPipe();
   }

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -47,7 +47,14 @@ struct FrontendPipeHandles {
   Operation *anchorOp = nullptr;
 };
 
-using FrontendPipeHandleMap = llvm::DenseMap<int32_t, FrontendPipeHandles>;
+static int64_t frontendPipeHandleKey(int32_t id, FunctionKernelKind side) {
+  // The same logical pipe id may be initialized on both Cube and Vector sides.
+  // Handle lookup and duplicate detection are side-specific.
+  return static_cast<int64_t>(id) * 2 +
+         (side == FunctionKernelKind::Cube ? 0 : 1);
+}
+
+using FrontendPipeHandleMap = llvm::DenseMap<int64_t, FrontendPipeHandles>;
 
 template <typename InitOpT>
 static LogicalResult requireFrontendGmSlotBuffer(InitOpT initOp) {
@@ -269,31 +276,31 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
                                                            IRRewriter &rewriter) {
   FrontendPipeHandleMap handlesById;
   SmallVector<Operation *> frontendInitOps;
-  llvm::DenseMap<int32_t, Operation *> initOpById;
+  llvm::DenseMap<int64_t, Operation *> initOpByKey;
   bool hasDuplicateId = false;
-  bool hasAicInit = false;
-  bool hasAivInit = false;
 
   funcOp.walk([&](Operation *op) {
     if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
-      hasAicInit = true;
       frontendInitOps.push_back(op);
-      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      int64_t key =
+          frontendPipeHandleKey(init.getId(), FunctionKernelKind::Cube);
+      auto [it, inserted] = initOpByKey.try_emplace(key, op);
       if (!inserted) {
         op->emitOpError()
-            << "requires unique initialize_pipe id in function (duplicate id = "
+            << "requires unique same-side initialize_pipe id in function (duplicate id = "
             << init.getId() << ")";
         hasDuplicateId = true;
       }
       return WalkResult::advance();
     }
     if (auto init = dyn_cast<AivInitializePipeOp>(op)) {
-      hasAivInit = true;
       frontendInitOps.push_back(op);
-      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      int64_t key =
+          frontendPipeHandleKey(init.getId(), FunctionKernelKind::Vector);
+      auto [it, inserted] = initOpByKey.try_emplace(key, op);
       if (!inserted) {
         op->emitOpError()
-            << "requires unique initialize_pipe id in function (duplicate id = "
+            << "requires unique same-side initialize_pipe id in function (duplicate id = "
             << init.getId() << ")";
         hasDuplicateId = true;
       }
@@ -305,19 +312,14 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
   if (hasDuplicateId)
     return failure();
 
-  if (hasAicInit && hasAivInit) {
-    funcOp.emitOpError("cannot mix pto.aic_initialize_pipe and "
-                       "pto.aiv_initialize_pipe in one function");
-    return failure();
-  }
-
   for (Operation *op : frontendInitOps) {
     if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
       int32_t id = init.getId();
       auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
       if (failed(loweredOr))
         return failure();
-      handlesById.try_emplace(id, *loweredOr);
+      handlesById.try_emplace(
+          frontendPipeHandleKey(id, FunctionKernelKind::Cube), *loweredOr);
       continue;
     }
 
@@ -326,7 +328,8 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
     auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
     if (failed(loweredOr))
       return failure();
-    handlesById.try_emplace(id, *loweredOr);
+    handlesById.try_emplace(
+        frontendPipeHandleKey(id, FunctionKernelKind::Vector), *loweredOr);
   }
 
   return handlesById;
@@ -357,12 +360,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
       frontendOps.push_back(op);
   });
 
-  auto lookupHandles = [&](Operation *op, int32_t id)
+  auto lookupHandles = [&](Operation *op, int32_t id,
+                           FunctionKernelKind side)
       -> FailureOr<const FrontendPipeHandles *> {
-    auto it = handlesById.find(id);
+    auto it = handlesById.find(frontendPipeHandleKey(id, side));
     if (it == handlesById.end()) {
       op->emitOpError()
-          << "requires matching frontend initialize_pipe(id = " << id
+          << "requires matching same-side frontend initialize_pipe(id = " << id
           << ") in the same function";
       return failure();
     }
@@ -379,7 +383,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     rewriter.setInsertionPoint(op);
 
     if (auto alloc = dyn_cast<TAllocToAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, alloc.getId());
+      auto handlesOr =
+          lookupHandles(op, alloc.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -398,7 +403,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto alloc = dyn_cast<TAllocToAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, alloc.getId());
+      auto handlesOr =
+          lookupHandles(op, alloc.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -417,7 +423,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto push = dyn_cast<TPushToAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, push.getId());
+      auto handlesOr =
+          lookupHandles(op, push.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -432,7 +439,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto push = dyn_cast<TPushToAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, push.getId());
+      auto handlesOr =
+          lookupHandles(op, push.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -447,7 +455,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, pop.getId());
+      auto handlesOr =
+          lookupHandles(op, pop.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -478,7 +487,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAivOp>(op)) {
-      auto handlesOr = lookupHandles(op, pop.getId());
+      auto handlesOr =
+          lookupHandles(op, pop.getId(), FunctionKernelKind::Cube);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -509,7 +519,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto free = dyn_cast<TFreeFromAicOp>(op)) {
-      auto handlesOr = lookupHandles(op, free.getId());
+      auto handlesOr =
+          lookupHandles(op, free.getId(), FunctionKernelKind::Vector);
       if (failed(handlesOr))
         return failure();
       const FrontendPipeHandles &handles = **handlesOr;
@@ -525,7 +536,8 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     auto free = cast<TFreeFromAivOp>(op);
-    auto handlesOr = lookupHandles(op, free.getId());
+    auto handlesOr =
+        lookupHandles(op, free.getId(), FunctionKernelKind::Cube);
     if (failed(handlesOr))
       return failure();
     const FrontendPipeHandles &handles = **handlesOr;

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -1009,62 +1009,46 @@ transactions.
 
 ### 7.6.1 Pipe Constructors
 
-#### `pto.pipe.c2v_global(gm_slot_tensor, *, id, slot_size=None, nosplit=None)`
+#### `pto.pipe.c2v(*, consumer_buf, id, slot_size=None, gm_slot_buffer=None, gm_slot_tensor=None, local_slot_num=None, nosplit=None)`
 
-Creates a logical Cube-to-Vector pipe whose entries are GlobalTensor-like GM
-FIFO slots.
+Creates a logical Cube-to-Vector pipe.
 
-Global-entry pipes model the A2/A3 L2G2L path. On A5, use a local FIFO pipe
-with `reserve_buffer` / `import_reserved_buffer` and tile-entry transactions.
+The constructor does not expose separate global/local names. A local tile-entry
+pipe is selected by passing `slot_size` and `consumer_buf`. An A2/A3
+global-entry L2G2L pipe is selected by additionally passing `gm_slot_buffer`
+and `gm_slot_tensor`; `gm_slot_tensor` describes the entry type/shape and
+`gm_slot_buffer` is the GM FIFO storage pointer. On A5, use the local tile-entry
+form and omit `gm_slot_tensor`.
 
 **Parameters:**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `gm_slot_tensor` | `TensorView` | Required. Describes one FIFO slot entry. |
+| `consumer_buf` | varies | Required. Consumer-owned FIFO buffer. The consumer side reserves it with `pto.reserve_buffer`; the producer side imports it with `pto.import_reserved_buffer`. |
 | `id` | `int` | Required. Stable pipe identifier shared by the producer and consumer sides. |
-| `slot_size` | `int` | Optional. Defaults to the byte size of one slot of `gm_slot_tensor`. |
+| `slot_size` | `int` | Required for local tile-entry pipes. Optional for global-entry pipes; defaults to the byte size of one slot of `gm_slot_tensor`. |
+| `gm_slot_buffer` | `PtrType` | Required for A2/A3 global-entry pipes. Optional GM FIFO storage pointer for L2G2L local lowering. |
+| `gm_slot_tensor` | `TensorView` | Optional. When provided, the pipe uses GlobalTensor-like entries and `alloc/pop` infer the entry descriptor type. |
+| `local_slot_num` | `int` | Optional. Local FIFO slot count override for local tile-entry pipes. |
 | `nosplit` | `bool` | Optional. Override-only metadata; not required in the common path. |
 
 The returned pipe object exposes C2V-producer methods (`init_cube`, `alloc`,
 `push`) on the Cube side and C2V-consumer methods (`init_simd`, `pop`, `free`)
 on the Vector side.
 
-#### `pto.pipe.v2c_global(gm_slot_tensor, *, id, slot_size=None, nosplit=None)`
+#### `pto.pipe.v2c(*, consumer_buf, id, slot_size=None, gm_slot_buffer=None, gm_slot_tensor=None, local_slot_num=None, nosplit=None)`
 
-Creates a logical Vector-to-Cube pipe. Same contract as `c2v_global`, but
+Creates a logical Vector-to-Cube pipe. Same contract as `c2v`, but
 reversed direction: the Vector side is the producer and the Cube side is the
 consumer.
 
-#### `pto.pipe.c2v_local(*, slot_size, consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
+#### `pto.pipe.bidirectional(*, slot_size, c2v_consumer_buf, v2c_consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
 
-Creates a logical local-FIFO C2V pipe.
+Creates a bidirectional local tile-entry pipe. Accepts both `c2v_consumer_buf`
+and `v2c_consumer_buf` since the pipe carries traffic in both directions. Use
+the root pipe for `init_cube()` / `init_simd()`, and use directional endpoints
+for transactions:
 
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `slot_size` | `int` | Required. Logical slot size in bytes. |
-| `consumer_buf` | varies | Required. Consumer-owned FIFO buffer. The consumer side reserves it with `pto.reserve_buffer`; the producer side imports it with `pto.import_reserved_buffer`. |
-| `gm_slot_buffer` | `PtrType` | Optional. GM slot buffer pointer (A2/A3 path). |
-| `id` | `int` | Required. Stable pipe identifier shared by the producer and consumer sides. |
-| `local_slot_num` | `int` | Optional. Local FIFO slot count override. |
-| `nosplit` | `bool` | Optional. No-split pipe mode. |
-
-`consumer_buf` is singular because the direction is already fixed by the
-`c2v_local` constructor. The high-level surface does not require users to spell
-`c2v_consumer_buf` versus `v2c_consumer_buf`.
-
-#### `pto.pipe.v2c_local(*, slot_size, consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
-
-Same contract as `c2v_local`, but reversed direction.
-
-#### `pto.pipe.bidirectional_local(*, slot_size, c2v_consumer_buf, v2c_consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
-
-Creates a bidirectional local pipe. Accepts both `c2v_consumer_buf` and
-`v2c_consumer_buf` since the pipe carries traffic in both directions. Use the
-root pipe for `init_cube()` / `init_simd()`, and use directional endpoints for
-transactions:
 
 ```python
 # Cube side
@@ -1115,6 +1099,9 @@ Rules:
 
 - `split` is a compile-time integer: `0` = no split, `1` = up/down split,
   `2` = left/right split.
+- Pipe transactions are associated with their pipe by the stable `id`,
+  direction, and side. Python variable names are not part of the IR. Kernels
+  with multiple pipes must use distinct stable ids.
 - For global-entry pipes, `push` and `pop` do not implicitly perform
   `tstore`/`tload`; callers must move data explicitly before `push` or after
   `pop`.
@@ -1135,7 +1122,13 @@ Declaration (shared between Cube and Vector sides):
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_declaration","symbol":"pipe_communication_c2v_global_declaration_probe","compile":{}} -->
 ```python
-c2v = pto.pipe.c2v_global(gm_slots, id=0)
+c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+c2v = pto.pipe.c2v(
+    gm_slot_tensor=gm_slots,
+    gm_slot_buffer=gm_slot_buffer,
+    consumer_buf=c2v_buf,
+    id=0,
+)
 ```
 
 Cube (producer) side:
@@ -1175,7 +1168,13 @@ Declaration:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_declaration","symbol":"pipe_communication_v2c_global_declaration_probe","compile":{}} -->
 ```python
-v2c = pto.pipe.v2c_global(gm_slots, id=0)
+v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+v2c = pto.pipe.v2c(
+    gm_slot_tensor=gm_slots,
+    gm_slot_buffer=gm_slot_buffer,
+    consumer_buf=v2c_buf,
+    id=0,
+)
 ```
 
 Vector (producer) side:
@@ -1209,7 +1208,7 @@ Vector (consumer) side reserves the local buffer:
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_declaration","symbol":"pipe_communication_c2v_local_declaration_probe","compile":{}} -->
 ```python
 c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
-c2v = pto.pipe.c2v_local(
+c2v = pto.pipe.c2v(
     slot_size=1024,
     consumer_buf=c2v_buf,
     gm_slot_buffer=gm_slot_buffer,
@@ -1222,7 +1221,7 @@ Cube (producer) side imports the peer buffer:
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_import","symbol":"pipe_communication_c2v_local_import_probe","compile":{}} -->
 ```python
 c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
-c2v_peer = pto.pipe.c2v_local(
+c2v_peer = pto.pipe.c2v(
     slot_size=1024,
     consumer_buf=c2v_buf,
     gm_slot_buffer=gm_slot_buffer,
@@ -1261,7 +1260,7 @@ descriptor was allocated by the frontend.
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.bidirectional_local_declaration","symbol":"pipe_communication_bidirectional_local_declaration_probe","compile":{}} -->
 ```python
-bidi = pto.pipe.bidirectional_local(
+bidi = pto.pipe.bidirectional(
     slot_size=1024,
     c2v_consumer_buf=c2v_buf,
     v2c_consumer_buf=v2c_buf,
@@ -1289,7 +1288,13 @@ def cube_producer(
     BLOCK: pto.constexpr = 128,
 ):
     gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-    c2v = pto.pipe.c2v_global(gm_view, id=0)
+    c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+    c2v = pto.pipe.c2v(
+        gm_slot_tensor=gm_view,
+        gm_slot_buffer=gm_slot_buffer,
+        consumer_buf=c2v_buf,
+        id=0,
+    )
 
     a_part = pto.partition_view(
         pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
@@ -1315,7 +1320,13 @@ def vector_consumer(
     BLOCK: pto.constexpr = 128,
 ):
     gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-    c2v = pto.pipe.c2v_global(gm_view, id=0)
+    c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+    c2v = pto.pipe.c2v(
+        gm_slot_tensor=gm_view,
+        gm_slot_buffer=gm_slot_buffer,
+        consumer_buf=c2v_buf,
+        id=0,
+    )
 
     b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
     b_part = pto.partition_view(

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -999,3 +999,337 @@ def qk_matmul(q_tile, k_tile, q_l0a, k_l0b, s_acc, s_tile):
 ```
 
 At the cube micro-op boundary, PTODSL currently uses explicit typed pointers. `tile.as_ptr()` materializes the pointer view for UB and cube-local scratch buffers, while the surrounding sub-kernel surface still uses `Tile` values for metadata such as `valid_shape`.
+
+## 7.6 Pipe Communication (Cube ↔ Vector FIFO)
+
+Pipe communication is the mechanism for Cube and Vector sub-kernels to exchange
+data through hardware FIFO channels. PTODSL provides a high-level `pto.pipe`
+API that presents pipes as logical declarations plus direction-aware
+transactions.
+
+### 7.6.1 Pipe Constructors
+
+#### `pto.pipe.c2v_global(gm_slot_tensor, *, id, slot_size=None, nosplit=None)`
+
+Creates a logical Cube-to-Vector pipe whose entries are GlobalTensor-like GM
+FIFO slots.
+
+Global-entry pipes model the A2/A3 L2G2L path. On A5, use a local FIFO pipe
+with `reserve_buffer` / `import_reserved_buffer` and tile-entry transactions.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `gm_slot_tensor` | `TensorView` | Required. Describes one FIFO slot entry. |
+| `id` | `int` | Required. Stable pipe identifier shared by the producer and consumer sides. |
+| `slot_size` | `int` | Optional. Defaults to the byte size of one slot of `gm_slot_tensor`. |
+| `nosplit` | `bool` | Optional. Override-only metadata; not required in the common path. |
+
+The returned pipe object exposes C2V-producer methods (`init_cube`, `alloc`,
+`push`) on the Cube side and C2V-consumer methods (`init_simd`, `pop`, `free`)
+on the Vector side.
+
+#### `pto.pipe.v2c_global(gm_slot_tensor, *, id, slot_size=None, nosplit=None)`
+
+Creates a logical Vector-to-Cube pipe. Same contract as `c2v_global`, but
+reversed direction: the Vector side is the producer and the Cube side is the
+consumer.
+
+#### `pto.pipe.c2v_local(*, slot_size, consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
+
+Creates a logical local-FIFO C2V pipe.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `slot_size` | `int` | Required. Logical slot size in bytes. |
+| `consumer_buf` | varies | Required. Consumer-owned FIFO buffer. The consumer side reserves it with `pto.reserve_buffer`; the producer side imports it with `pto.import_reserved_buffer`. |
+| `gm_slot_buffer` | `PtrType` | Optional. GM slot buffer pointer (A2/A3 path). |
+| `id` | `int` | Required. Stable pipe identifier shared by the producer and consumer sides. |
+| `local_slot_num` | `int` | Optional. Local FIFO slot count override. |
+| `nosplit` | `bool` | Optional. No-split pipe mode. |
+
+`consumer_buf` is singular because the direction is already fixed by the
+`c2v_local` constructor. The high-level surface does not require users to spell
+`c2v_consumer_buf` versus `v2c_consumer_buf`.
+
+#### `pto.pipe.v2c_local(*, slot_size, consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
+
+Same contract as `c2v_local`, but reversed direction.
+
+#### `pto.pipe.bidirectional_local(*, slot_size, c2v_consumer_buf, v2c_consumer_buf, id, gm_slot_buffer=None, local_slot_num=None, nosplit=None)`
+
+Creates a bidirectional local pipe. Accepts both `c2v_consumer_buf` and
+`v2c_consumer_buf` since the pipe carries traffic in both directions. Use the
+root pipe for `init_cube()` / `init_simd()`, and use directional endpoints for
+transactions:
+
+```python
+# Cube side
+bidi.init_cube()
+bidi.c2v.push(cube_tile)
+cube_tile = bidi.v2c.pop(result_type=cube_tile_type)
+bidi.v2c.free()
+
+# SIMD side
+bidi.init_simd()
+vec_tile = bidi.c2v.pop(result_type=vec_tile_type)
+bidi.c2v.free()
+bidi.v2c.push(vec_tile)
+```
+
+### 7.6.2 Pipe Methods
+
+Every logical pipe object exposes only the methods that make sense for its
+direction.
+
+**Producer-side methods** (Cube side for C2V, Vector side for V2C):
+
+| Method | Description |
+|--------|-------------|
+| `init_cube()` | Initialise the pipe on the Cube side. |
+| `init_simd()` | Initialise the pipe on the Vector (SIMD) side. |
+| `alloc(split=0)` | Allocate the next FIFO slot. Global-entry pipes only. Returns an entry descriptor. |
+| `push(entry_or_tile, split=0)` | Push a filled GlobalTensor entry or local tile to the consumer. Notifies the consumer side. |
+
+**Consumer-side methods** (Vector side for C2V, Cube side for V2C):
+
+| Method | Description |
+|--------|-------------|
+| `init_cube()` | Initialise the pipe on the Cube side. |
+| `init_simd()` | Initialise the pipe on the Vector (SIMD) side. |
+| `pop(split=0, result_type=None, valid_shape=None)` | Pop the next entry from the producer. For global-entry pipes, `result_type` defaults to the pipe's `entry_type`; for local/tile-entry pipes it must be provided. |
+| `free(entry=None, split=0)` | Release the consumed slot back to the producer. |
+
+**Read-only properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entry_type` | type | The entry descriptor type for this pipe. |
+| `id` | `int` | The compile-time stable pipe identifier. |
+| `slot_size` | `int` | The logical slot size in bytes. |
+
+Rules:
+
+- `split` is a compile-time integer: `0` = no split, `1` = up/down split,
+  `2` = left/right split.
+- For global-entry pipes, `push` and `pop` do not implicitly perform
+  `tstore`/`tload`; callers must move data explicitly before `push` or after
+  `pop`.
+- For global-entry pipes, `result_type` on `pop()` defaults to the pipe's
+  `entry_type`.
+- For local/tile-entry pipes, there is no `alloc()`. The producer pushes an
+  existing tile directly. The consumer pops into a newly declared tile of
+  `result_type`.
+- For local/tile-entry pipes, `result_type` may be either a tile type or a tile
+  value whose type should be reused. `valid_shape=[rows, cols]` can be supplied
+  when the popped tile needs runtime valid-shape metadata.
+- `entry` on `free()` may be omitted for tile-entry pipes. For global-entry
+  pipes it must carry the entry descriptor returned by the matching `pop()`.
+
+### 7.6.3 Global-Entry C2V Pipe
+
+Declaration (shared between Cube and Vector sides):
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_declaration","symbol":"pipe_communication_c2v_global_declaration_probe","compile":{}} -->
+```python
+c2v = pto.pipe.c2v_global(gm_slots, id=0)
+```
+
+Cube (producer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_producer","symbol":"pipe_communication_c2v_global_producer_probe","compile":{}} -->
+```python
+@pto.cube
+def producer(src_tile):
+    c2v.init_cube()
+    entry = c2v.alloc(split=0)
+    entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+    pto.tile.store(src_tile, entry_part)
+    c2v.push(entry, split=0)
+```
+
+Vector (consumer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global_consumer","symbol":"pipe_communication_c2v_global_consumer_probe","compile":{}} -->
+```python
+@pto.simd
+def consumer(dst_tile):
+    c2v.init_simd()
+    entry = c2v.pop(split=0, result_type=c2v.entry_type)
+    entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+    pto.tile.load(entry_part, dst_tile)
+    c2v.free(entry, split=0)
+```
+
+The Cube side initialises the pipe, allocates a GM FIFO slot, stores the tile
+data into that slot via `tile.store`, then pushes the entry to notify the
+consumer. The Vector side initialises the pipe, pops the next ready entry, loads
+the data into a local tile via `tile.load`, then frees the slot.
+
+### 7.6.4 Global-Entry V2C Pipe
+
+Declaration:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_declaration","symbol":"pipe_communication_v2c_global_declaration_probe","compile":{}} -->
+```python
+v2c = pto.pipe.v2c_global(gm_slots, id=0)
+```
+
+Vector (producer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_producer","symbol":"pipe_communication_v2c_global_producer_probe","compile":{}} -->
+```python
+@pto.simd
+def producer(src_tile):
+    v2c.init_simd()
+    entry = v2c.alloc(split=0)
+    pto.tile.store(src_tile, pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16]))
+    v2c.push(entry, split=0)
+```
+
+Cube (consumer) side:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.v2c_global_consumer","symbol":"pipe_communication_v2c_global_consumer_probe","compile":{}} -->
+```python
+@pto.cube
+def consumer(dst_tile):
+    v2c.init_cube()
+    entry = v2c.pop(split=0, result_type=v2c.entry_type)
+    pto.tile.load(pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16]), dst_tile)
+    v2c.free(entry, split=0)
+```
+
+### 7.6.5 Local FIFO C2V Pipe
+
+Vector (consumer) side reserves the local buffer:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_declaration","symbol":"pipe_communication_c2v_local_declaration_probe","compile":{}} -->
+```python
+c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+c2v = pto.pipe.c2v_local(
+    slot_size=1024,
+    consumer_buf=c2v_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+Cube (producer) side imports the peer buffer:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_import","symbol":"pipe_communication_c2v_local_import_probe","compile":{}} -->
+```python
+c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
+c2v_peer = pto.pipe.c2v_local(
+    slot_size=1024,
+    consumer_buf=c2v_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+Cube (producer) transaction:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_producer","symbol":"pipe_communication_c2v_local_producer_probe","compile":{}} -->
+```python
+@pto.cube
+def producer(src_tile):
+    c2v_peer.init_cube()
+    c2v_peer.push(src_tile, split=0)
+```
+
+Vector (consumer) transaction:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_local_consumer","symbol":"pipe_communication_c2v_local_consumer_probe","compile":{}} -->
+```python
+@pto.simd
+def consumer(dst_part):
+    c2v.init_simd()
+    tile = c2v.pop(result_type=dst_tile, split=0)
+    pto.tile.store(tile, dst_part)
+    c2v.free(split=0)
+```
+
+The local form is the A5-facing form used when Cube and Vector exchange UB/MAT
+tiles through a local FIFO. `push(tile)` emits a tile-entry `tpush`; `pop()`
+emits a tile-entry `tpop`; `free()` can omit the entry because no GM FIFO slot
+descriptor was allocated by the frontend.
+
+### 7.6.6 Bidirectional Local Pipe
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.bidirectional_local_declaration","symbol":"pipe_communication_bidirectional_local_declaration_probe","compile":{}} -->
+```python
+bidi = pto.pipe.bidirectional_local(
+    slot_size=1024,
+    c2v_consumer_buf=c2v_buf,
+    v2c_consumer_buf=v2c_buf,
+    gm_slot_buffer=gm_slot_buffer,
+    id=0,
+)
+```
+
+For bidirectional local pipes, the C2V consumer buffer lives in `VEC` and the V2C consumer buffer lives in `MAT`.
+
+The two-buffer shape only appears where the pipe is genuinely bidirectional.
+
+### 7.6.7 Complete Example: C2V Global-Entry Pipe
+
+This is a complete two-kernel C2V pipe example with `@pto.jit` entry points
+and `gm_slots` expressed via `pto.make_tensor_view`:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"pipe_communication.c2v_global","symbol":"pipe_communication_c2v_global_probe","compile":{"BLOCK":128}} -->
+```python
+@pto.jit(target="a3")
+def cube_producer(
+    gm_slot_buffer: pto.gm_ptr(pto.f32),
+    src: pto.gm_ptr(pto.f32),
+    *,
+    BLOCK: pto.constexpr = 128,
+):
+    gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+    c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+    a_part = pto.partition_view(
+        pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+        offsets=[0, 0], sizes=[16, 16])
+    a_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+    @pto.cube
+    def cube_kernel():
+        pto.tile.load(a_part, a_tile)
+        c2v.init_cube()
+        entry = c2v.alloc(split=0)
+        entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+        pto.tile.store(a_tile, entry_part)
+        c2v.push(entry, split=0)
+
+    cube_kernel()
+
+@pto.jit(target="a3")
+def vector_consumer(
+    gm_slot_buffer: pto.gm_ptr(pto.f32),
+    dst: pto.gm_ptr(pto.f32),
+    *,
+    BLOCK: pto.constexpr = 128,
+):
+    gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+    c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+    b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+    b_part = pto.partition_view(
+        pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+        offsets=[0, 0], sizes=[16, 16])
+
+    @pto.simd
+    def vector_kernel():
+        c2v.init_simd()
+        entry = c2v.pop(split=0, result_type=c2v.entry_type)
+        entry_part = pto.partition_view(entry, offsets=[0, 0], sizes=[16, 16])
+        pto.tile.load(entry_part, b_tile)
+        c2v.free(entry, split=0)
+        pto.tile.store(b_tile, b_part)
+
+    vector_kernel()
+```

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -53,6 +53,7 @@ from ._types import (
     _isinstance_pto_type,
     _integer_signedness,
     _materialize_integer_literal,
+    _normalize_address_space,
     _resolve,
     _strip_integer_signedness,
     mask_type,
@@ -3247,6 +3248,33 @@ def wait_flag(src: str, dst: str, *, event_id: int = 0):
     _pto.wait_flag_dyn(_pipe_attr(src), _pipe_attr(dst), event_operand)
 
 
+def reserve_buffer(name, *, size, location, auto=True, base=None):
+    """``pto.reserve_buffer(name, size, location, auto=True, base=None)``."""
+    space = _normalize_address_space(location)
+    if space not in (_pto.AddressSpace.VEC, _pto.AddressSpace.MAT):
+        raise ValueError(
+            "reserve_buffer(location=...) expects 'vec' or 'mat' address space"
+        )
+    op = _pto.ReserveBufferOp(
+        name,
+        size,
+        _pto.AddressSpaceAttr.get(space),
+        bool(auto),
+        base=base,
+    )
+    return wrap_surface_value(op.result)
+
+
+def import_reserved_buffer(name, *, peer_func):
+    """``pto.import_reserved_buffer(name, peer_func=...)``."""
+    if not isinstance(peer_func, str):
+        peer_func = getattr(getattr(peer_func, "spec", None), "symbol_name", None) \
+            or getattr(peer_func, "__name__", None) \
+            or str(peer_func)
+    op = _pto.ImportReservedBufferOp(name, peer_func)
+    return wrap_surface_value(op.result)
+
+
 __all__ = [
     "const",
     "castptr", "addptr",
@@ -3299,4 +3327,5 @@ __all__ = [
     "pipe_barrier", "get_buf", "rls_buf",
     "set_cross_flag", "wait_cross_flag", "set_intra_flag", "wait_intra_flag",
     "set_flag", "wait_flag",
+    "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/_pipe_namespace.py
+++ b/ptodsl/ptodsl/_pipe_namespace.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+"""High-level PTODSL pipe surface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from ._ops import (
+    _coerce_index,
+    _element_bytewidth,
+    _pto,
+    unwrap_surface_value,
+    wrap_surface_value,
+)
+
+
+def _require_pipe_id(id, *, context: str) -> int:
+    if id is None:
+        raise TypeError(f"{context} requires an explicit stable id")
+    return int(id)
+
+
+def _infer_global_slot_size(gm_slot_tensor) -> int:
+    surface_shape = getattr(gm_slot_tensor, "shape", None)
+    value = unwrap_surface_value(gm_slot_tensor)
+    tensor_type = value.type
+    if not _pto.TensorViewType.isinstance(tensor_type):
+        raise TypeError(
+            "pipe.c2v_global/v2c_global expects gm_slot_tensor to be !pto.tensor_view"
+        )
+
+    tensor_view_type = _pto.TensorViewType(tensor_type)
+    shape = tuple(surface_shape) if surface_shape is not None else tuple(tensor_view_type.shape)
+    if any(dim < 0 for dim in shape):
+        raise ValueError(
+            "pipe.c2v_global/v2c_global cannot infer slot_size from a dynamic gm_slot_tensor shape"
+        )
+    count = 1
+    for dim in shape:
+        count *= int(dim)
+    return count * _element_bytewidth(tensor_view_type.element_type)
+
+
+def _as_int(value, *, context: str):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    return _coerce_index(value, context=context)
+
+
+def _normalize_entry_value(value):
+    if value is None:
+        return None
+    return unwrap_surface_value(value)
+
+
+def _normalize_result_type(value, *, context: str):
+    if value is None:
+        return None
+    unwrapped = unwrap_surface_value(value)
+    return getattr(unwrapped, "type", unwrapped)
+
+
+def _normalize_valid_shape(valid_shape, *, valid_row, valid_col):
+    if valid_shape is not None:
+        if valid_row is not None or valid_col is not None:
+            raise TypeError("pipe.pop(...) accepts either valid_shape or valid_row/valid_col, not both")
+        if len(valid_shape) == 1:
+            valid_row, valid_col = 1, valid_shape[0]
+        elif len(valid_shape) == 2:
+            valid_row, valid_col = valid_shape
+        else:
+            raise TypeError("pipe.pop(valid_shape=...) expects one or two dimensions")
+    if (valid_row is None) != (valid_col is None):
+        raise TypeError("pipe.pop(...) requires valid_row and valid_col to be provided together")
+    if valid_row is None:
+        return None, None
+    return (
+        _coerce_index(valid_row, context="pipe.pop(..., valid_row=...)"),
+        _coerce_index(valid_col, context="pipe.pop(..., valid_col=...)"),
+    )
+
+
+@dataclass(frozen=True)
+class _PipeDescriptor:
+    kind: str
+    direction: str
+    id: int
+    slot_size: int
+    entry_type: object | None
+    gm_slot_tensor: object | None = None
+    gm_slot_buffer: object | None = None
+    c2v_consumer_buf: object | None = None
+    v2c_consumer_buf: object | None = None
+    local_slot_num: int | None = None
+    nosplit: bool | None = None
+
+
+class _PipeSurface:
+    """Direction-aware logical pipe object."""
+
+    def __init__(self, descriptor: _PipeDescriptor):
+        self._descriptor = descriptor
+
+    @property
+    def entry_type(self):
+        return self._descriptor.entry_type
+
+    @property
+    def id(self):
+        return self._descriptor.id
+
+    @property
+    def slot_size(self):
+        return self._descriptor.slot_size
+
+    @property
+    def c2v(self):
+        if self._descriptor.direction != "both":
+            raise TypeError("c2v endpoint is only available on bidirectional local pipes")
+        return _PipeSurface(
+            replace(
+                self._descriptor,
+                kind="c2v_local",
+                direction="c2v",
+                v2c_consumer_buf=None,
+            )
+        )
+
+    @property
+    def v2c(self):
+        if self._descriptor.direction != "both":
+            raise TypeError("v2c endpoint is only available on bidirectional local pipes")
+        return _PipeSurface(
+            replace(
+                self._descriptor,
+                kind="v2c_local",
+                direction="v2c",
+                c2v_consumer_buf=None,
+            )
+        )
+
+    def init_cube(self):
+        self._emit_init("cube")
+
+    def init_simd(self):
+        self._emit_init("simd")
+
+    def alloc(self, split=0):
+        if self._descriptor.kind != "global":
+            raise TypeError("alloc() is only available on global-entry pipes")
+        split = _as_int(split, context="pipe.alloc(..., split=...)")
+        entry_type = self.entry_type
+        if entry_type is None:
+            raise RuntimeError("global-entry pipe is missing entry_type metadata")
+        if self._descriptor.direction == "c2v":
+            op = _pto.TAllocToAivOp(entry_type, split, id=self.id)
+        else:
+            op = _pto.TAllocToAicOp(entry_type, split, id=self.id)
+        return wrap_surface_value(op.result)
+
+    def push(self, entry, split=0):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous push direction")
+        split = _as_int(split, context="pipe.push(..., split=...)")
+        if entry is None:
+            raise TypeError("push() requires an entry value")
+        entry_value = _normalize_entry_value(entry)
+        if self._descriptor.direction == "c2v":
+            _pto.TPushToAivOp(entry_value, split, id=self.id)
+        else:
+            _pto.TPushToAicOp(entry_value, split, id=self.id)
+
+    def pop(self, split=0, result_type=None, *, valid_shape=None, valid_row=None, valid_col=None):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous pop direction")
+        split = _as_int(split, context="pipe.pop(..., split=...)")
+        if result_type is None:
+            result_type = self.entry_type
+        result_type = _normalize_result_type(result_type, context="pipe.pop(..., result_type=...)")
+        if result_type is None:
+            raise TypeError("pop() requires result_type for local/tile-entry pipes")
+        valid_row, valid_col = _normalize_valid_shape(
+            valid_shape,
+            valid_row=valid_row,
+            valid_col=valid_col,
+        )
+        if self._descriptor.direction == "c2v":
+            op = self._emit_pop_from_aic(result_type, split, valid_row, valid_col)
+        else:
+            op = self._emit_pop_from_aiv(result_type, split, valid_row, valid_col)
+        return wrap_surface_value(op.result)
+
+    def free(self, entry=None, split=0):
+        if self._descriptor.direction == "both":
+            raise TypeError("bidirectional local pipes do not have an unambiguous free direction")
+        split = _as_int(split, context="pipe.free(..., split=...)")
+        if self._descriptor.kind == "global" and entry is None:
+            raise TypeError("free() requires an entry value for global-entry pipes")
+        entry_value = _normalize_entry_value(entry)
+        if self._descriptor.direction == "c2v":
+            _pto.TFreeFromAicOp(split, entry=entry_value, id=self.id)
+        else:
+            _pto.TFreeFromAivOp(split, entry=entry_value, id=self.id)
+
+    def _emit_pop_from_aic(self, result_type, split, valid_row, valid_col):
+        if valid_row is None:
+            return _pto.TPopFromAicOp(result_type, split, id=self.id)
+        return _pto.TPopFromAicOp(
+            result_type,
+            split,
+            valid_row=valid_row,
+            valid_col=valid_col,
+            id=self.id,
+        )
+
+    def _emit_pop_from_aiv(self, result_type, split, valid_row, valid_col):
+        if valid_row is None:
+            return _pto.TPopFromAivOp(result_type, split, id=self.id)
+        return _pto.TPopFromAivOp(
+            result_type,
+            split,
+            valid_row=valid_row,
+            valid_col=valid_col,
+            id=self.id,
+        )
+
+    def _emit_init(self, side: str):
+        desc = self._descriptor
+        init_kwargs = {
+            "id": desc.id,
+        }
+
+        if desc.kind == "global":
+            init_kwargs["gm_slot_tensor"] = desc.gm_slot_tensor
+            init_kwargs["nosplit"] = desc.nosplit
+        elif desc.kind == "c2v_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
+        elif desc.kind == "v2c_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
+        else:
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+
+        if desc.kind == "bidirectional_local":
+            init_kwargs["local_slot_num"] = desc.local_slot_num
+            init_kwargs["nosplit"] = desc.nosplit
+            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+            init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
+            init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
+
+        init_kwargs = {key: value for key, value in init_kwargs.items() if value is not None}
+
+        if side == "cube":
+            _pto.AicInitializePipeOp(
+                1 if desc.direction == "c2v" else 2 if desc.direction == "v2c" else 3,
+                desc.slot_size,
+                **init_kwargs,
+            )
+            return
+
+        _pto.AivInitializePipeOp(
+            1 if desc.direction == "c2v" else 2 if desc.direction == "v2c" else 3,
+            desc.slot_size,
+            **init_kwargs,
+        )
+
+
+class _PipeNamespace:
+    def c2v_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
+        id = _require_pipe_id(id, context="pipe.c2v_global(...)")
+        if slot_size is None:
+            slot_size = _infer_global_slot_size(gm_slot_tensor)
+        descriptor = _PipeDescriptor(
+            kind="global",
+            direction="c2v",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=unwrap_surface_value(gm_slot_tensor).type,
+            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def v2c_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
+        id = _require_pipe_id(id, context="pipe.v2c_global(...)")
+        if slot_size is None:
+            slot_size = _infer_global_slot_size(gm_slot_tensor)
+        descriptor = _PipeDescriptor(
+            kind="global",
+            direction="v2c",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=unwrap_surface_value(gm_slot_tensor).type,
+            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def c2v_local(
+        self,
+        *,
+        slot_size,
+        consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.c2v_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="c2v_local",
+            direction="c2v",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            c2v_consumer_buf=_normalize_entry_value(consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def v2c_local(
+        self,
+        *,
+        slot_size,
+        consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.v2c_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="v2c_local",
+            direction="v2c",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            v2c_consumer_buf=_normalize_entry_value(consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+    def bidirectional_local(
+        self,
+        *,
+        slot_size,
+        c2v_consumer_buf,
+        v2c_consumer_buf,
+        gm_slot_buffer=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        id = _require_pipe_id(id, context="pipe.bidirectional_local(...)")
+        descriptor = _PipeDescriptor(
+            kind="bidirectional_local",
+            direction="both",
+            id=int(id),
+            slot_size=int(slot_size),
+            entry_type=None,
+            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
+            c2v_consumer_buf=_normalize_entry_value(c2v_consumer_buf),
+            v2c_consumer_buf=_normalize_entry_value(v2c_consumer_buf),
+            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+            nosplit=nosplit,
+        )
+        return _PipeSurface(descriptor)
+
+
+pipe = _PipeNamespace()

--- a/ptodsl/ptodsl/_pipe_namespace.py
+++ b/ptodsl/ptodsl/_pipe_namespace.py
@@ -32,14 +32,14 @@ def _infer_global_slot_size(gm_slot_tensor) -> int:
     tensor_type = value.type
     if not _pto.TensorViewType.isinstance(tensor_type):
         raise TypeError(
-            "pipe.c2v_global/v2c_global expects gm_slot_tensor to be !pto.tensor_view"
+            "pipe.c2v/v2c expects gm_slot_tensor to be !pto.tensor_view"
         )
 
     tensor_view_type = _pto.TensorViewType(tensor_type)
     shape = tuple(surface_shape) if surface_shape is not None else tuple(tensor_view_type.shape)
     if any(dim < 0 for dim in shape):
         raise ValueError(
-            "pipe.c2v_global/v2c_global cannot infer slot_size from a dynamic gm_slot_tensor shape"
+            "pipe.c2v/v2c cannot infer slot_size from a dynamic gm_slot_tensor shape"
         )
     count = 1
     for dim in shape:
@@ -124,11 +124,10 @@ class _PipeSurface:
     @property
     def c2v(self):
         if self._descriptor.direction != "both":
-            raise TypeError("c2v endpoint is only available on bidirectional local pipes")
+            raise TypeError("c2v endpoint is only available on bidirectional pipes")
         return _PipeSurface(
             replace(
                 self._descriptor,
-                kind="c2v_local",
                 direction="c2v",
                 v2c_consumer_buf=None,
             )
@@ -137,11 +136,10 @@ class _PipeSurface:
     @property
     def v2c(self):
         if self._descriptor.direction != "both":
-            raise TypeError("v2c endpoint is only available on bidirectional local pipes")
+            raise TypeError("v2c endpoint is only available on bidirectional pipes")
         return _PipeSurface(
             replace(
                 self._descriptor,
-                kind="v2c_local",
                 direction="v2c",
                 c2v_consumer_buf=None,
             )
@@ -154,7 +152,7 @@ class _PipeSurface:
         self._emit_init("simd")
 
     def alloc(self, split=0):
-        if self._descriptor.kind != "global":
+        if self._descriptor.gm_slot_tensor is None:
             raise TypeError("alloc() is only available on global-entry pipes")
         split = _as_int(split, context="pipe.alloc(..., split=...)")
         entry_type = self.entry_type
@@ -202,7 +200,7 @@ class _PipeSurface:
         if self._descriptor.direction == "both":
             raise TypeError("bidirectional local pipes do not have an unambiguous free direction")
         split = _as_int(split, context="pipe.free(..., split=...)")
-        if self._descriptor.kind == "global" and entry is None:
+        if self._descriptor.gm_slot_tensor is not None and entry is None:
             raise TypeError("free() requires an entry value for global-entry pipes")
         entry_value = _normalize_entry_value(entry)
         if self._descriptor.direction == "c2v":
@@ -238,29 +236,13 @@ class _PipeSurface:
             "id": desc.id,
         }
 
-        if desc.kind == "global":
-            init_kwargs["gm_slot_tensor"] = desc.gm_slot_tensor
-            init_kwargs["nosplit"] = desc.nosplit
-        elif desc.kind == "c2v_local":
-            init_kwargs["local_slot_num"] = desc.local_slot_num
-            init_kwargs["nosplit"] = desc.nosplit
-            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+        init_kwargs["local_slot_num"] = desc.local_slot_num
+        init_kwargs["nosplit"] = desc.nosplit
+        init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
+        init_kwargs["gm_slot_tensor"] = desc.gm_slot_tensor
+        if desc.direction in ("c2v", "both"):
             init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
-        elif desc.kind == "v2c_local":
-            init_kwargs["local_slot_num"] = desc.local_slot_num
-            init_kwargs["nosplit"] = desc.nosplit
-            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
-            init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
-        else:
-            init_kwargs["local_slot_num"] = desc.local_slot_num
-            init_kwargs["nosplit"] = desc.nosplit
-            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
-
-        if desc.kind == "bidirectional_local":
-            init_kwargs["local_slot_num"] = desc.local_slot_num
-            init_kwargs["nosplit"] = desc.nosplit
-            init_kwargs["gm_slot_buffer"] = desc.gm_slot_buffer
-            init_kwargs["c2v_consumer_buf"] = desc.c2v_consumer_buf
+        if desc.direction in ("v2c", "both"):
             init_kwargs["v2c_consumer_buf"] = desc.v2c_consumer_buf
 
         init_kwargs = {key: value for key, value in init_kwargs.items() if value is not None}
@@ -281,85 +263,92 @@ class _PipeSurface:
 
 
 class _PipeNamespace:
-    def c2v_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
-        id = _require_pipe_id(id, context="pipe.c2v_global(...)")
-        if slot_size is None:
-            slot_size = _infer_global_slot_size(gm_slot_tensor)
-        descriptor = _PipeDescriptor(
-            kind="global",
-            direction="c2v",
-            id=int(id),
-            slot_size=int(slot_size),
-            entry_type=unwrap_surface_value(gm_slot_tensor).type,
-            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
-            nosplit=nosplit,
-        )
-        return _PipeSurface(descriptor)
-
-    def v2c_global(self, gm_slot_tensor, *, id=None, slot_size=None, nosplit=None):
-        id = _require_pipe_id(id, context="pipe.v2c_global(...)")
-        if slot_size is None:
-            slot_size = _infer_global_slot_size(gm_slot_tensor)
-        descriptor = _PipeDescriptor(
-            kind="global",
-            direction="v2c",
-            id=int(id),
-            slot_size=int(slot_size),
-            entry_type=unwrap_surface_value(gm_slot_tensor).type,
-            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
-            nosplit=nosplit,
-        )
-        return _PipeSurface(descriptor)
-
-    def c2v_local(
+    def _directional_pipe(
         self,
         *,
-        slot_size,
-        consumer_buf,
+        direction,
+        slot_size=None,
+        consumer_buf=None,
         gm_slot_buffer=None,
+        gm_slot_tensor=None,
         id=None,
         local_slot_num=None,
         nosplit=None,
     ):
-        id = _require_pipe_id(id, context="pipe.c2v_local(...)")
+        id = _require_pipe_id(id, context=f"pipe.{direction}(...)")
+        if consumer_buf is None:
+            raise TypeError(f"pipe.{direction}(...) requires consumer_buf")
+        entry_type = None
+        if slot_size is None:
+            if gm_slot_tensor is None:
+                raise TypeError(f"pipe.{direction}(...) requires slot_size when gm_slot_tensor is not provided")
+            slot_size = _infer_global_slot_size(gm_slot_tensor)
+        if gm_slot_tensor is not None:
+            if gm_slot_buffer is None:
+                raise TypeError(f"pipe.{direction}(...) requires gm_slot_buffer when gm_slot_tensor is provided")
+            if local_slot_num is not None:
+                raise TypeError(f"pipe.{direction}(...) does not accept local_slot_num when gm_slot_tensor is provided")
+            entry_type = unwrap_surface_value(gm_slot_tensor).type
         descriptor = _PipeDescriptor(
-            kind="c2v_local",
-            direction="c2v",
+            kind="global" if gm_slot_tensor is not None else "local",
+            direction=direction,
             id=int(id),
             slot_size=int(slot_size),
-            entry_type=None,
+            entry_type=entry_type,
+            gm_slot_tensor=_normalize_entry_value(gm_slot_tensor),
             gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
-            c2v_consumer_buf=_normalize_entry_value(consumer_buf),
+            c2v_consumer_buf=_normalize_entry_value(consumer_buf) if direction == "c2v" else None,
+            v2c_consumer_buf=_normalize_entry_value(consumer_buf) if direction == "v2c" else None,
             local_slot_num=None if local_slot_num is None else int(local_slot_num),
             nosplit=nosplit,
         )
         return _PipeSurface(descriptor)
 
-    def v2c_local(
+    def c2v(
         self,
         *,
-        slot_size,
-        consumer_buf,
+        slot_size=None,
+        consumer_buf=None,
         gm_slot_buffer=None,
+        gm_slot_tensor=None,
         id=None,
         local_slot_num=None,
         nosplit=None,
     ):
-        id = _require_pipe_id(id, context="pipe.v2c_local(...)")
-        descriptor = _PipeDescriptor(
-            kind="v2c_local",
-            direction="v2c",
-            id=int(id),
-            slot_size=int(slot_size),
-            entry_type=None,
-            gm_slot_buffer=_normalize_entry_value(gm_slot_buffer),
-            v2c_consumer_buf=_normalize_entry_value(consumer_buf),
-            local_slot_num=None if local_slot_num is None else int(local_slot_num),
+        return self._directional_pipe(
+            direction="c2v",
+            slot_size=slot_size,
+            consumer_buf=consumer_buf,
+            gm_slot_buffer=gm_slot_buffer,
+            gm_slot_tensor=gm_slot_tensor,
+            id=id,
+            local_slot_num=local_slot_num,
             nosplit=nosplit,
         )
-        return _PipeSurface(descriptor)
 
-    def bidirectional_local(
+    def v2c(
+        self,
+        *,
+        slot_size=None,
+        consumer_buf=None,
+        gm_slot_buffer=None,
+        gm_slot_tensor=None,
+        id=None,
+        local_slot_num=None,
+        nosplit=None,
+    ):
+        return self._directional_pipe(
+            direction="v2c",
+            slot_size=slot_size,
+            consumer_buf=consumer_buf,
+            gm_slot_buffer=gm_slot_buffer,
+            gm_slot_tensor=gm_slot_tensor,
+            id=id,
+            local_slot_num=local_slot_num,
+            nosplit=nosplit,
+        )
+
+    def bidirectional(
         self,
         *,
         slot_size,
@@ -370,9 +359,9 @@ class _PipeNamespace:
         local_slot_num=None,
         nosplit=None,
     ):
-        id = _require_pipe_id(id, context="pipe.bidirectional_local(...)")
+        id = _require_pipe_id(id, context="pipe.bidirectional(...)")
         descriptor = _PipeDescriptor(
-            kind="bidirectional_local",
+            kind="local",
             direction="both",
             id=int(id),
             slot_size=int(slot_size),

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -121,6 +121,16 @@ class TraceSession:
     def lower_inline_subkernel(self, subkernel, *args, **kwargs):
         """Lower one inline PTODSL subkernel call through the shared session."""
         with self.enter_subkernel(subkernel):
+            role = subkernel.spec.role.value
+            if role in {"cube", "simd"}:
+                section = (
+                    _pto.SectionCubeOp()
+                    if role == "cube"
+                    else _pto.SectionVectorOp()
+                )
+                section_block = section.body.blocks.append()
+                with InsertionPoint(section_block):
+                    return subkernel.emit_body(*args, **kwargs)
             return subkernel.emit_body(*args, **kwargs)
 
     def begin_carry_loop(self, start, stop, step, state_items):

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -95,6 +95,7 @@ from ._ops import (             # noqa: F401
     get_buf, rls_buf,
     set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
     set_flag, wait_flag,
+    reserve_buffer, import_reserved_buffer,
 )
 
 # ── Control flow ──────────────────────────────────────────────────────────────
@@ -106,8 +107,13 @@ from ._control_flow import (    # noqa: F401
 # ── Decorator ─────────────────────────────────────────────────────────────────
 from ._jit import jit, KernelHandle, merge_jit_modules      # noqa: F401
 from ._subkernels import cube, simd, simt     # noqa: F401
+from ._pipe_namespace import pipe  # noqa: F401
 
 # ── Shorthand dtype aliases ───────────────────────────────────────────────────
+def gm_ptr(elem):
+    return ptr(elem, "gm")
+
+
 f32 = float32
 f16 = float16
 i1 = int1

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -1821,7 +1821,13 @@ FRAGMENT_FIXTURES = {
             src: pto.gm_ptr(pto.f32),
         ):
             gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-            c2v = pto.pipe.c2v_global(gm_view, id=0)
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            c2v = pto.pipe.c2v(
+                gm_slot_tensor=gm_view,
+                gm_slot_buffer=gm_slot_buffer,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
 
             a_part = pto.partition_view(
                 pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
@@ -1839,7 +1845,13 @@ FRAGMENT_FIXTURES = {
             dst: pto.gm_ptr(pto.f32),
         ):
             gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-            c2v = pto.pipe.c2v_global(gm_view, id=0)
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            c2v = pto.pipe.c2v(
+                gm_slot_tensor=gm_view,
+                gm_slot_buffer=gm_slot_buffer,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
 
             b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
             b_part = pto.partition_view(
@@ -1867,7 +1879,13 @@ FRAGMENT_FIXTURES = {
             src: pto.gm_ptr(pto.f32),
         ):
             gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-            v2c = pto.pipe.v2c_global(gm_view, id=0)
+            v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+            v2c = pto.pipe.v2c(
+                gm_slot_tensor=gm_view,
+                gm_slot_buffer=gm_slot_buffer,
+                consumer_buf=v2c_buf,
+                id=0,
+            )
 
             src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
 
@@ -1882,7 +1900,13 @@ FRAGMENT_FIXTURES = {
             dst: pto.gm_ptr(pto.f32),
         ):
             gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
-            v2c = pto.pipe.v2c_global(gm_view, id=0)
+            v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+            v2c = pto.pipe.v2c(
+                gm_slot_tensor=gm_view,
+                gm_slot_buffer=gm_slot_buffer,
+                consumer_buf=v2c_buf,
+                id=0,
+            )
 
             dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
 
@@ -1927,7 +1951,7 @@ FRAGMENT_FIXTURES = {
         ):
             vector_kernel()
             c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
-            c2v_peer = pto.pipe.c2v_local(
+            c2v_peer = pto.pipe.c2v(
                 slot_size=1024,
                 consumer_buf=c2v_buf,
                 id=0,
@@ -1944,7 +1968,7 @@ FRAGMENT_FIXTURES = {
             dst: pto.gm_ptr(pto.f32),
         ):
             c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
-            c2v = pto.pipe.c2v_local(
+            c2v = pto.pipe.c2v(
                 slot_size=1024,
                 consumer_buf=c2v_buf,
                 id=0,

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -1803,4 +1803,184 @@ FRAGMENT_FIXTURES = {
         {SNIPPET_PLACEHOLDER}
         """
     ),
+    "pipe_communication.c2v_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+            a_part = pto.partition_view(
+                pto.make_tensor_view(src, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+            a_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_c2v_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            c2v = pto.pipe.c2v_global(gm_view, id=0)
+
+            b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+            b_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_declaration": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            gm_slots = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_producer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+
+            src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.v2c_global_consumer": _fixture(
+        f"""
+        @pto.jit(target="a3")
+        def pipe_communication_v2c_global_consumer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            gm_view = pto.make_tensor_view(gm_slot_buffer, shape=[16, 16], strides=[16, 1])
+            v2c = pto.pipe.v2c_global(gm_view, id=0)
+
+            dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_import": _fixture(
+        f"""
+        @pto.simt
+        def vector_kernel():
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+
+
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_import_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            vector_kernel()
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_producer": _fixture(
+        f"""
+        @pto.simt
+        def vector_kernel():
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+
+
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_producer_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+            src: pto.gm_ptr(pto.f32),
+        ):
+            vector_kernel()
+            c2v_buf = pto.import_reserved_buffer("c2v_fifo", peer_func="vector_kernel")
+            c2v_peer = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
+            src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_local_consumer": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_c2v_local_consumer_probe(
+            dst: pto.gm_ptr(pto.f32),
+        ):
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            c2v = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                id=0,
+            )
+            dst_part = pto.partition_view(
+                pto.make_tensor_view(dst, shape=[16, 16], strides=[16, 1]),
+                offsets=[0, 0], sizes=[16, 16])
+            dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.bidirectional_local_declaration": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def pipe_communication_bidirectional_local_declaration_probe(
+            gm_slot_buffer: pto.gm_ptr(pto.f32),
+        ):
+            c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+            v2c_buf = pto.reserve_buffer("v2c_fifo", size=8192, location="mat")
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
+    "pipe_communication.c2v_global": _fixture(
+        f"""
+        {SNIPPET_PLACEHOLDER}
+
+
+        class _PipeCommunicationC2VGlobalProbe:
+            def compile(self, **kwargs):
+                cube_compiled = cube_producer.compile(**kwargs)
+                cube_compiled.verify()
+                return vector_consumer.compile(**kwargs)
+
+
+        pipe_communication_c2v_global_probe = _PipeCommunicationC2VGlobalProbe()
+        """
+    ),
 }

--- a/ptodsl/tests/test_pipe_surface_sample_compile.py
+++ b/ptodsl/tests/test_pipe_surface_sample_compile.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SAMPLE = REPO_ROOT / "test" / "samples" / "TPushTPop" / "ptodsl" / "local_c2v" / "kernel.py"
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_sample_module():
+    spec = spec_from_file_location("ptodsl_tpush_tpop_local_c2v_sample", SAMPLE)
+    expect(spec is not None and spec.loader is not None, f"unable to load sample from {SAMPLE}")
+    module = module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_ptoas_binary() -> Path | None:
+    candidates = [
+        REPO_ROOT / "build" / "tools" / "ptoas" / "ptoas",
+        REPO_ROOT / "install" / "bin" / "ptoas",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    from_path = shutil.which("ptoas")
+    if from_path:
+        return Path(from_path)
+    return None
+
+
+def run_ptoas_frontend(ptoas_bin: Path, mlir_text: str) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False, encoding="utf-8") as handle:
+        handle.write(mlir_text)
+        input_path = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [str(ptoas_bin), "--pto-arch=a5", str(input_path), "--emit-pto-ir", "-o", "-"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    expect(
+        result.returncode == 0,
+        f"sample should pass PTOAS frontend verification\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    return result.stdout
+
+
+def main() -> None:
+    sample = load_sample_module()
+    mlir_text = sample.emit_mlir()
+
+    expect("pto.aic_initialize_pipe" in mlir_text, "Cube side should initialize the local pipe")
+    expect("pto.aiv_initialize_pipe" in mlir_text, "Vector side should initialize the local pipe")
+    expect("pto.tpush_to_aiv" in mlir_text, "Cube side should push to Vector")
+    expect("pto.tpop_from_aic" in mlir_text, "Vector side should pop from Cube")
+    expect("pto.tfree_from_aic" in mlir_text, "Vector side should free the consumed slot")
+
+    ptoas_bin = resolve_ptoas_binary()
+    if ptoas_bin is not None:
+        frontend_text = run_ptoas_frontend(ptoas_bin, mlir_text)
+        expect("pto.tpush" in frontend_text, "PTOAS output should contain lowered tpush")
+        expect("pto.tpop" in frontend_text, "PTOAS output should contain lowered tpop")
+
+    print("ptodsl_pipe_surface_sample_compile: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -17,7 +17,10 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ptodsl"))
 
 import ptodsl._ops as _ops
+import ptodsl._pipe_namespace as _pipe_namespace
+from ptodsl._bootstrap import make_context
 from ptodsl import pto
+from mlir.ir import F32Type
 
 
 def _identity(value):
@@ -381,6 +384,312 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         sync_set_op.assert_not_called()
         sync_wait_op.assert_not_called()
+
+    def test_pipe_namespace_and_buffer_helpers_are_exposed(self):
+        names = [
+            "c2v_global", "v2c_global",
+            "c2v_local", "v2c_local", "bidirectional_local",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(pto.pipe, name), name)
+
+        for name in ["reserve_buffer", "import_reserved_buffer"]:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(pto, name), name)
+
+        self.assertTrue(hasattr(pto, "gm_ptr"), "gm_ptr")
+
+    def test_global_pipe_methods_dispatch_to_matching_frontend_ops(self):
+        alloc_entry = object()
+        pop_entry = object()
+
+        with make_context():
+            gm_slot_type = _pipe_namespace._pto.TensorViewType.get([16, 16], F32Type.get())
+        gm_slot = SimpleNamespace(type=gm_slot_type)
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
+            pipe = pto.pipe.c2v_global(gm_slot, id=7)
+
+        self.assertEqual(pipe.id, 7)
+        self.assertEqual(pipe.slot_size, 1024)
+        self.assertEqual(pipe.entry_type, gm_slot_type)
+
+        with patch.object(_pipe_namespace._pto, "AicInitializePipeOp") as aic_init, \
+             patch.object(_pipe_namespace._pto, "AivInitializePipeOp") as aiv_init, \
+             patch.object(_pipe_namespace._pto, "TAllocToAivOp", return_value=SimpleNamespace(result=alloc_entry)) as alloc_op, \
+             patch.object(_pipe_namespace._pto, "TPushToAivOp") as push_op, \
+             patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=pop_entry)) as pop_op, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAicOp") as free_op, \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity):
+            pipe.init_cube()
+            pipe.init_simd()
+            alloc_result = pipe.alloc()
+            pipe.push(alloc_result, split=1)
+            pop_result = pipe.pop()
+            pipe.free(pop_result, split=2)
+
+        aic_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
+        aiv_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
+        alloc_op.assert_called_once_with(gm_slot_type, 0, id=7)
+        push_op.assert_called_once_with(alloc_entry, 1, id=7)
+        pop_op.assert_called_once_with(gm_slot_type, 0, id=7)
+        free_op.assert_called_once_with(2, entry=pop_entry, id=7)
+        self.assertIs(alloc_result, alloc_entry)
+        self.assertIs(pop_result, pop_entry)
+
+    def test_local_pipe_constructors_route_consumer_buffers(self):
+        c2v_buf = object()
+        v2c_buf = object()
+        gm_slot_buffer = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(
+                slot_size=1024,
+                consumer_buf=c2v_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=3,
+                local_slot_num=2,
+                nosplit=True,
+            )
+            v2c = pto.pipe.v2c_local(
+                slot_size=2048,
+                consumer_buf=v2c_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=4,
+                local_slot_num=5,
+            )
+            bidi = pto.pipe.bidirectional_local(
+                slot_size=4096,
+                c2v_consumer_buf=c2v_buf,
+                v2c_consumer_buf=v2c_buf,
+                gm_slot_buffer=gm_slot_buffer,
+                id=5,
+            )
+
+        self.assertIsNone(c2v.entry_type)
+        self.assertIsNone(v2c.entry_type)
+        self.assertIsNone(bidi.entry_type)
+        self.assertEqual(bidi.c2v.id, 5)
+        self.assertEqual(bidi.v2c.id, 5)
+
+        with patch.object(_pipe_namespace._pto, "AicInitializePipeOp") as aic_init, \
+             patch.object(_pipe_namespace._pto, "AivInitializePipeOp") as aiv_init:
+            c2v.init_cube()
+            c2v.init_simd()
+            v2c.init_cube()
+            bidi.init_simd()
+
+        self.assertEqual(aic_init.call_args_list[0].args, (1, 1024))
+        self.assertEqual(aic_init.call_args_list[0].kwargs, {
+            "id": 3,
+            "local_slot_num": 2,
+            "nosplit": True,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+        })
+        self.assertEqual(aiv_init.call_args_list[0].args, (1, 1024))
+        self.assertEqual(aiv_init.call_args_list[0].kwargs, {
+            "id": 3,
+            "local_slot_num": 2,
+            "nosplit": True,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+        })
+        self.assertEqual(aic_init.call_args_list[1].args, (2, 2048))
+        self.assertEqual(aic_init.call_args_list[1].kwargs, {
+            "id": 4,
+            "local_slot_num": 5,
+            "gm_slot_buffer": gm_slot_buffer,
+            "v2c_consumer_buf": v2c_buf,
+        })
+        self.assertEqual(aiv_init.call_args_list[1].args, (3, 4096))
+        self.assertEqual(aiv_init.call_args_list[1].kwargs, {
+            "id": 5,
+            "gm_slot_buffer": gm_slot_buffer,
+            "c2v_consumer_buf": c2v_buf,
+            "v2c_consumer_buf": v2c_buf,
+        })
+
+    def test_pipe_constructors_require_explicit_stable_ids(self):
+        buf = object()
+        with make_context():
+            gm_slot_type = _pipe_namespace._pto.TensorViewType.get([16, 16], F32Type.get())
+        gm_slot = SimpleNamespace(type=gm_slot_type)
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
+            cases = [
+                lambda: pto.pipe.c2v_global(gm_slot),
+                lambda: pto.pipe.v2c_global(gm_slot),
+                lambda: pto.pipe.c2v_local(slot_size=1024, consumer_buf=buf),
+                lambda: pto.pipe.v2c_local(slot_size=1024, consumer_buf=buf),
+                lambda: pto.pipe.bidirectional_local(
+                    slot_size=1024,
+                    c2v_consumer_buf=buf,
+                    v2c_consumer_buf=buf,
+                ),
+            ]
+            for case in cases:
+                with self.subTest(case=case):
+                    with self.assertRaises(TypeError) as exc:
+                        case()
+                    self.assertIn("requires an explicit stable id", str(exc.exception))
+
+    def test_local_pipe_transactions_dispatch_to_tile_entry_frontend_ops(self):
+        c2v_buf = object()
+        v2c_buf = object()
+        c2v_tile = object()
+        v2c_tile = object()
+        c2v_result = object()
+        v2c_result = object()
+        c2v_type = "c2v_tile_ty"
+        v2c_type = "v2c_tile_ty"
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=6)
+            v2c = pto.pipe.v2c_local(slot_size=2048, consumer_buf=v2c_buf, id=7)
+
+        with patch.object(_pipe_namespace._pto, "TPushToAivOp") as c2v_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=c2v_result)) as c2v_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAicOp") as c2v_free, \
+             patch.object(_pipe_namespace._pto, "TPushToAicOp") as v2c_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAivOp", return_value=SimpleNamespace(result=v2c_result)) as v2c_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAivOp") as v2c_free, \
+             patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v.push(c2v_tile, split=1)
+            c2v_output = c2v.pop(result_type=c2v_type, split=2)
+            c2v.free(split=0)
+
+            v2c.push(v2c_tile, split=2)
+            v2c_output = v2c.pop(result_type=v2c_type, split=1)
+            v2c.free(split=0)
+
+        c2v_push.assert_called_once_with(c2v_tile, 1, id=6)
+        c2v_pop.assert_called_once_with(c2v_type, 2, id=6)
+        c2v_free.assert_called_once_with(0, entry=None, id=6)
+        self.assertIs(c2v_output, c2v_result)
+
+        v2c_push.assert_called_once_with(v2c_tile, 2, id=7)
+        v2c_pop.assert_called_once_with(v2c_type, 1, id=7)
+        v2c_free.assert_called_once_with(0, entry=None, id=7)
+        self.assertIs(v2c_output, v2c_result)
+
+    def test_local_pipe_pop_can_carry_runtime_valid_shape(self):
+        c2v_buf = object()
+        c2v_type = "c2v_tile_ty"
+        row = object()
+        col = object()
+        result = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=8)
+
+        with patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=result)) as pop_op, \
+             patch.object(_pipe_namespace, "_coerce_index", side_effect=lambda value, *, context: value), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            output = c2v.pop(result_type=c2v_type, valid_shape=[row, col])
+
+        pop_op.assert_called_once_with(
+            c2v_type,
+            0,
+            valid_row=row,
+            valid_col=col,
+            id=8,
+        )
+        self.assertIs(output, result)
+
+    def test_pipe_surface_rejects_ambiguous_or_invalid_transactions(self):
+        c2v_buf = object()
+        v2c_buf = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=9)
+            bidi = pto.pipe.bidirectional_local(
+                slot_size=1024,
+                c2v_consumer_buf=c2v_buf,
+                v2c_consumer_buf=v2c_buf,
+                id=10,
+            )
+
+        with self.assertRaises(TypeError):
+            c2v.alloc()
+        with self.assertRaises(TypeError):
+            c2v.pop()
+        with self.assertRaises(TypeError):
+            bidi.push(object())
+        with self.assertRaises(TypeError):
+            bidi.pop(result_type="tile_ty")
+        with self.assertRaises(TypeError):
+            bidi.free()
+
+    def test_bidirectional_pipe_endpoints_dispatch_transactions(self):
+        c2v_buf = object()
+        v2c_buf = object()
+        c2v_tile = object()
+        v2c_tile = object()
+        c2v_result = object()
+        v2c_result = object()
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            bidi = pto.pipe.bidirectional_local(
+                slot_size=1024,
+                c2v_consumer_buf=c2v_buf,
+                v2c_consumer_buf=v2c_buf,
+                id=10,
+            )
+
+        with patch.object(_pipe_namespace._pto, "TPushToAivOp") as c2v_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=c2v_result)) as c2v_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAicOp") as c2v_free, \
+             patch.object(_pipe_namespace._pto, "TPushToAicOp") as v2c_push, \
+             patch.object(_pipe_namespace._pto, "TPopFromAivOp", return_value=SimpleNamespace(result=v2c_result)) as v2c_pop, \
+             patch.object(_pipe_namespace._pto, "TFreeFromAivOp") as v2c_free, \
+             patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            bidi.c2v.push(c2v_tile, split=0)
+            c2v_output = bidi.c2v.pop(result_type="c2v_ty", split=1)
+            bidi.c2v.free(split=2)
+            bidi.v2c.push(v2c_tile, split=2)
+            v2c_output = bidi.v2c.pop(result_type="v2c_ty", split=1)
+            bidi.v2c.free(split=0)
+
+        c2v_push.assert_called_once_with(c2v_tile, 0, id=10)
+        c2v_pop.assert_called_once_with("c2v_ty", 1, id=10)
+        c2v_free.assert_called_once_with(2, entry=None, id=10)
+        v2c_push.assert_called_once_with(v2c_tile, 2, id=10)
+        v2c_pop.assert_called_once_with("v2c_ty", 1, id=10)
+        v2c_free.assert_called_once_with(0, entry=None, id=10)
+        self.assertIs(c2v_output, c2v_result)
+        self.assertIs(v2c_output, v2c_result)
+
+    def test_reserved_buffer_helpers_normalize_location_and_peer_func(self):
+        with make_context():
+            with patch.object(_ops._pto, "ReserveBufferOp", return_value=SimpleNamespace(result=object())) as reserve_op, \
+                 patch.object(_ops._pto, "ImportReservedBufferOp", return_value=SimpleNamespace(result=object())) as import_op, \
+                 patch.object(_ops, "wrap_surface_value", side_effect=_identity):
+                reserve_result = _ops.reserve_buffer("fifo", size=8192, location="vec")
+                import_result = _ops.import_reserved_buffer(
+                    "fifo",
+                    peer_func=SimpleNamespace(spec=SimpleNamespace(symbol_name="vector_kernel")),
+                )
+
+        self.assertIsNotNone(reserve_result)
+        self.assertIsNotNone(import_result)
+        self.assertEqual(reserve_op.call_args.args[0], "fifo")
+        self.assertEqual(reserve_op.call_args.args[1], 8192)
+        self.assertEqual(str(reserve_op.call_args.args[2]), "#pto.address_space<vec>")
+        self.assertEqual(reserve_op.call_args.args[3], True)
+        self.assertEqual(import_op.call_args.args, ("fifo", "vector_kernel"))
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -387,12 +387,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_pipe_namespace_and_buffer_helpers_are_exposed(self):
         names = [
-            "c2v_global", "v2c_global",
-            "c2v_local", "v2c_local", "bidirectional_local",
+            "c2v", "v2c", "bidirectional",
         ]
         for name in names:
             with self.subTest(name=name):
                 self.assertTrue(hasattr(pto.pipe, name), name)
+        old_names = [
+            "c2v_global", "v2c_global",
+            "c2v_local", "v2c_local", "bidirectional_local",
+        ]
+        for name in old_names:
+            with self.subTest(name=name):
+                self.assertFalse(hasattr(pto.pipe, name), name)
 
         for name in ["reserve_buffer", "import_reserved_buffer"]:
             with self.subTest(name=name):
@@ -407,11 +413,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         with make_context():
             gm_slot_type = _pipe_namespace._pto.TensorViewType.get([16, 16], F32Type.get())
         gm_slot = SimpleNamespace(type=gm_slot_type)
+        gm_slot_buffer = object()
+        consumer_buf = object()
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
-            pipe = pto.pipe.c2v_global(gm_slot, id=7)
+            pipe = pto.pipe.c2v(
+                gm_slot_tensor=gm_slot,
+                gm_slot_buffer=gm_slot_buffer,
+                consumer_buf=consumer_buf,
+                id=7,
+            )
 
         self.assertEqual(pipe.id, 7)
         self.assertEqual(pipe.slot_size, 1024)
@@ -432,8 +445,14 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             pop_result = pipe.pop()
             pipe.free(pop_result, split=2)
 
-        aic_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
-        aiv_init.assert_called_once_with(1, 1024, id=7, gm_slot_tensor=gm_slot)
+        expected_init_kwargs = {
+            "id": 7,
+            "gm_slot_buffer": gm_slot_buffer,
+            "gm_slot_tensor": gm_slot,
+            "c2v_consumer_buf": consumer_buf,
+        }
+        aic_init.assert_called_once_with(1, 1024, **expected_init_kwargs)
+        aiv_init.assert_called_once_with(1, 1024, **expected_init_kwargs)
         alloc_op.assert_called_once_with(gm_slot_type, 0, id=7)
         push_op.assert_called_once_with(alloc_entry, 1, id=7)
         pop_op.assert_called_once_with(gm_slot_type, 0, id=7)
@@ -448,7 +467,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
-            c2v = pto.pipe.c2v_local(
+            c2v = pto.pipe.c2v(
                 slot_size=1024,
                 consumer_buf=c2v_buf,
                 gm_slot_buffer=gm_slot_buffer,
@@ -456,14 +475,14 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                 local_slot_num=2,
                 nosplit=True,
             )
-            v2c = pto.pipe.v2c_local(
+            v2c = pto.pipe.v2c(
                 slot_size=2048,
                 consumer_buf=v2c_buf,
                 gm_slot_buffer=gm_slot_buffer,
                 id=4,
                 local_slot_num=5,
             )
-            bidi = pto.pipe.bidirectional_local(
+            bidi = pto.pipe.bidirectional(
                 slot_size=4096,
                 c2v_consumer_buf=c2v_buf,
                 v2c_consumer_buf=v2c_buf,
@@ -524,11 +543,11 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
             cases = [
-                lambda: pto.pipe.c2v_global(gm_slot),
-                lambda: pto.pipe.v2c_global(gm_slot),
-                lambda: pto.pipe.c2v_local(slot_size=1024, consumer_buf=buf),
-                lambda: pto.pipe.v2c_local(slot_size=1024, consumer_buf=buf),
-                lambda: pto.pipe.bidirectional_local(
+                lambda: pto.pipe.c2v(gm_slot_tensor=gm_slot),
+                lambda: pto.pipe.v2c(gm_slot_tensor=gm_slot),
+                lambda: pto.pipe.c2v(slot_size=1024, consumer_buf=buf),
+                lambda: pto.pipe.v2c(slot_size=1024, consumer_buf=buf),
+                lambda: pto.pipe.bidirectional(
                     slot_size=1024,
                     c2v_consumer_buf=buf,
                     v2c_consumer_buf=buf,
@@ -552,8 +571,8 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
-            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=6)
-            v2c = pto.pipe.v2c_local(slot_size=2048, consumer_buf=v2c_buf, id=7)
+            c2v = pto.pipe.c2v(slot_size=1024, consumer_buf=c2v_buf, id=6)
+            v2c = pto.pipe.v2c(slot_size=2048, consumer_buf=v2c_buf, id=7)
 
         with patch.object(_pipe_namespace._pto, "TPushToAivOp") as c2v_push, \
              patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=c2v_result)) as c2v_pop, \
@@ -590,7 +609,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
-            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=8)
+            c2v = pto.pipe.c2v(slot_size=1024, consumer_buf=c2v_buf, id=8)
 
         with patch.object(_pipe_namespace._pto, "TPopFromAicOp", return_value=SimpleNamespace(result=result)) as pop_op, \
              patch.object(_pipe_namespace, "_coerce_index", side_effect=lambda value, *, context: value), \
@@ -612,8 +631,8 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
-            c2v = pto.pipe.c2v_local(slot_size=1024, consumer_buf=c2v_buf, id=9)
-            bidi = pto.pipe.bidirectional_local(
+            c2v = pto.pipe.c2v(slot_size=1024, consumer_buf=c2v_buf, id=9)
+            bidi = pto.pipe.bidirectional(
                 slot_size=1024,
                 c2v_consumer_buf=c2v_buf,
                 v2c_consumer_buf=v2c_buf,
@@ -641,7 +660,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
-            bidi = pto.pipe.bidirectional_local(
+            bidi = pto.pipe.bidirectional(
                 slot_size=1024,
                 c2v_consumer_buf=c2v_buf,
                 v2c_consumer_buf=v2c_buf,

--- a/test/lit/pto/frontend_pipe_module_kind_verify_invalid.pto
+++ b/test/lit/pto/frontend_pipe_module_kind_verify_invalid.pto
@@ -1,0 +1,11 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @bad_cube_pipe_in_vector_module(%consumer_buf: i32) {
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %consumer_buf : i32)
+    return
+  }
+}
+
+// CHECK: error: 'pto.aic_initialize_pipe' op must be inside a cube kernel function

--- a/test/lit/pto/frontend_pipe_section_kind_verify_invalid.pto
+++ b/test/lit/pto/frontend_pipe_section_kind_verify_invalid.pto
@@ -1,0 +1,13 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @bad_cube_pipe_in_vector_section(%consumer_buf: i32) {
+    pto.section.vector {
+      pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+        (c2v_consumer_buf = %consumer_buf : i32)
+    }
+    return
+  }
+}
+
+// CHECK: error: 'pto.aic_initialize_pipe' op must be inside a cube kernel function or section

--- a/test/lit/pto/tpush_tpop_globaltensor_frontend_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_frontend_a3.pto
@@ -12,8 +12,14 @@ module {
     %gm_slots = pto.make_tensor_view %gm_slot_buffer,
       shape = [%c16, %c16], strides = [%c16, %c1]
       : !pto.tensor_view<16x16xf32>
+    %c2v_local = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
-      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %entry = pto.talloc_to_aiv {id = 0, split = 0}
       -> !pto.tensor_view<16x16xf32>
@@ -36,8 +42,16 @@ module {
     %gm_slots = pto.make_tensor_view %gm_slot_buffer,
       shape = [%c16, %c16], strides = [%c16, %c1]
       : !pto.tensor_view<16x16xf32>
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
     pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
-      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %entry = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tensor_view<16x16xf32>

--- a/test/lit/pto/tpush_tpop_globaltensor_loop_nosplit_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_loop_nosplit_a3.pto
@@ -15,8 +15,14 @@ module {
     %slot_desc = pto.make_tensor_view %fifo_mem,
       shape = [%c4, %c128, %c128], strides = [%c16384, %c128, %c1]
       : !pto.tensor_view<4x128x128xf32>
+    %c2v_local = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
-      (gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>)
+      (gm_slot_buffer = %fifo_mem : !pto.ptr<f32>,
+       gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %push_global = pto.talloc_to_aiv {id = 0, split = 0}
       -> !pto.tensor_view<4x128x128xf32>
@@ -52,8 +58,16 @@ module {
     %slot_desc = pto.make_tensor_view %fifo_mem,
       shape = [%c4, %c128, %c128], strides = [%c16384, %c128, %c1]
       : !pto.tensor_view<4x128x128xf32>
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
     pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
-      (gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>)
+      (gm_slot_buffer = %fifo_mem : !pto.ptr<f32>,
+       gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %out_desc = pto.make_tensor_view %out,
       shape = [%c4, %c128, %c128], strides = [%c128, %c512, %c1]

--- a/test/lit/pto/tpush_tpop_globaltensor_split_half_slot_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_split_half_slot_a3.pto
@@ -19,8 +19,14 @@ module {
     %slot_desc = pto.make_tensor_view %fifo_mem,
       shape = [%c4, %c128, %c128], strides = [%c16384, %c128, %c1]
       : !pto.tensor_view<4x128x128xf32>
+    %c2v_local = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
-      (gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>)
+      (gm_slot_buffer = %fifo_mem : !pto.ptr<f32>,
+       gm_slot_tensor = %slot_desc : !pto.tensor_view<4x128x128xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %entry = pto.talloc_to_aiv {id = 0, split = 1}
       -> !pto.tensor_view<4x128x128xf32>
@@ -40,8 +46,16 @@ module {
     %slot_desc = pto.make_tensor_view %fifo_mem,
       shape = [%c4, %c64, %c128], strides = [%c16384, %c128, %c1]
       : !pto.tensor_view<4x64x128xf32>
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
     pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
-      (gm_slot_tensor = %slot_desc : !pto.tensor_view<4x64x128xf32>)
+      (gm_slot_buffer = %fifo_mem : !pto.ptr<f32>,
+       gm_slot_tensor = %slot_desc : !pto.tensor_view<4x64x128xf32>,
+       c2v_consumer_buf = %c2v_local : i32)
 
     %entry = pto.tpop_from_aic {id = 0, split = 1}
       -> !pto.tensor_view<4x64x128xf32>

--- a/test/samples/TPushTPop/ptodsl/local_c2v/README.md
+++ b/test/samples/TPushTPop/ptodsl/local_c2v/README.md
@@ -1,0 +1,20 @@
+# PTODSL Local C2V TPush/Tpop Sample
+
+This sample mirrors the local FIFO shape in `test/samples/TPushTPop/test1` with
+PTODSL pipe surface APIs.
+
+Compile-only:
+
+```bash
+python3 test/samples/TPushTPop/ptodsl/local_c2v/kernel.py --emit-mlir
+```
+
+PTOAS frontend verification:
+
+```bash
+python3 test/samples/TPushTPop/ptodsl/local_c2v/kernel.py --verify-ptoas
+```
+
+The sample generates separate Cube and Vector PTODSL kernels, merges the
+generated functions into one MLIR module, and verifies that PTOAS lowers the
+local FIFO path through `TPUSH` / `TPOP` / `TFREE`.

--- a/test/samples/TPushTPop/ptodsl/local_c2v/kernel.py
+++ b/test/samples/TPushTPop/ptodsl/local_c2v/kernel.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License"). Please refer to the License for details.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND.
+
+"""PTODSL local C2V TPush/Tpop sample for A5.
+
+This mirrors the local FIFO shape used by ``test/samples/TPushTPop/test1``:
+the Cube side imports the Vector-owned FIFO buffer, pushes one tile, and the
+SIMD side pops/frees the tile before storing it back to GM.
+"""
+
+import argparse
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+if __package__ in {None, ""}:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        package_root = candidate / "ptodsl" / "ptodsl" / "__init__.py"
+        if package_root.exists():
+            sys.path.insert(0, str(candidate / "ptodsl"))
+            break
+    else:
+        raise RuntimeError("Unable to locate the PTODSL Python package root")
+
+from ptodsl import pto
+
+
+_ROWS = 16
+_COLS = 16
+_SLOT_SIZE = _ROWS * _COLS * 4
+_FIFO_SIZE = _SLOT_SIZE * 8
+
+
+@pto.jit(name="ptodsl_tpush_tpop_local_c2v_cube", target="a5", kernel_kind="cube")
+def ptodsl_tpush_tpop_local_c2v_cube(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+):
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_rows = pto.const(_ROWS)
+    c_cols = pto.const(_COLS)
+
+    a_view = pto.make_tensor_view(A_ptr, shape=[c_rows, c_cols], strides=[c_cols, c1])
+    a_part = pto.partition_view(a_view, offsets=[c0, c0], sizes=[c_rows, c_cols])
+
+    # The standalone Cube compile needs a local peer declaration to satisfy
+    # frontend verification. emit_mlir() removes this compile-only reserve and
+    # rewrites the peer to the real Vector function in the merged sample module.
+    pto.reserve_buffer("c2v_fifo", size=_FIFO_SIZE, location="vec")
+    c2v_import = pto.import_reserved_buffer(
+        "c2v_fifo",
+        peer_func="ptodsl_tpush_tpop_local_c2v_cube",
+    )
+    c2v = pto.pipe.c2v_local(
+        slot_size=_SLOT_SIZE,
+        consumer_buf=c2v_import,
+        id=0,
+    )
+    src_tile = pto.alloc_tile(shape=[_ROWS, _COLS], dtype=pto.f32)
+    pto.tile.load(a_part, src_tile)
+    c2v.init_cube()
+    c2v.push(src_tile, split=0)
+
+
+@pto.jit(name="ptodsl_tpush_tpop_local_c2v_vector", target="a5", kernel_kind="vector")
+def ptodsl_tpush_tpop_local_c2v_vector(
+    O_ptr: pto.ptr(pto.f32, "gm"),
+):
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_rows = pto.const(_ROWS)
+    c_cols = pto.const(_COLS)
+
+    o_view = pto.make_tensor_view(O_ptr, shape=[c_rows, c_cols], strides=[c_cols, c1])
+    o_part = pto.partition_view(o_view, offsets=[c0, c0], sizes=[c_rows, c_cols])
+
+    c2v_buf = pto.reserve_buffer("c2v_fifo", size=_FIFO_SIZE, location="vec")
+    c2v = pto.pipe.c2v_local(
+        slot_size=_SLOT_SIZE,
+        consumer_buf=c2v_buf,
+        id=0,
+    )
+    dst_type = pto.alloc_tile(shape=[_ROWS, _COLS], dtype=pto.f32)
+    c2v.init_simd()
+    fifo_tile = c2v.pop(result_type=dst_type, split=0)
+    pto.tile.store(fifo_tile, o_part)
+    c2v.free(split=0)
+
+
+def emit_mlir() -> str:
+    cube_text = _function_module_body(
+        ptodsl_tpush_tpop_local_c2v_cube.compile().mlir_text(),
+        kernel_kind="cube",
+        drop_compile_only_peer_reserve=True,
+        peer_rewrite=(
+            "peer_func = @ptodsl_tpush_tpop_local_c2v_cube",
+            "peer_func = @ptodsl_tpush_tpop_local_c2v_vector",
+        ),
+    )
+    vector_text = _function_module_body(
+        ptodsl_tpush_tpop_local_c2v_vector.compile().mlir_text(),
+        kernel_kind="vector",
+    )
+    return "module {\n" + cube_text + "\n" + vector_text + "\n}\n"
+
+
+def _function_module_body(
+    mlir_text: str,
+    *,
+    kernel_kind: str,
+    peer_rewrite: tuple[str, str] | None = None,
+    drop_compile_only_peer_reserve: bool = False,
+) -> str:
+    lines = [line for line in mlir_text.strip().splitlines()]
+    if not lines or not lines[0].startswith("module attributes"):
+        raise ValueError("expected a PTODSL single-function module")
+    if lines[-1] != "}":
+        raise ValueError("expected a PTODSL module closing brace")
+
+    body = "\n".join(lines[1:-1])
+    body = body.replace(
+        "attributes {pto.aicore}",
+        f"attributes {{pto.aicore, pto.kernel_kind = #pto.kernel_kind<{kernel_kind}>}}",
+        1,
+    )
+    if drop_compile_only_peer_reserve:
+        body = _drop_compile_only_peer_reserve(body)
+    if peer_rewrite is not None:
+        old, new = peer_rewrite
+        body = body.replace(old, new, 1)
+    return body
+
+
+def _drop_compile_only_peer_reserve(body: str) -> str:
+    return re.sub(
+        r"\n    %\d+ = pto\.reserve_buffer\{name = \"c2v_fifo\", size = \d+, "
+        r"location = <vec>, auto = true\} -> i32",
+        "",
+        body,
+        count=1,
+    )
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _resolve_ptoas() -> Path:
+    root = _repo_root()
+    candidates = [
+        root / "build" / "tools" / "ptoas" / "ptoas",
+        root / "install" / "bin" / "ptoas",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    from_path = shutil.which("ptoas")
+    if from_path:
+        return Path(from_path)
+    raise FileNotFoundError("unable to locate ptoas under build/, install/, or PATH")
+
+
+def verify_ptoas() -> str:
+    mlir_text = emit_mlir()
+    ptoas = _resolve_ptoas()
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False, encoding="utf-8") as handle:
+        handle.write(mlir_text)
+        input_path = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [str(ptoas), "--pto-arch=a5", str(input_path), "--emit-pto-ir", "-o", "-"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            "ptoas frontend verification failed\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emit-mlir", action="store_true", help="print the PTODSL-generated MLIR")
+    parser.add_argument("--verify-ptoas", action="store_true", help="run PTOAS frontend verification")
+    args = parser.parse_args(argv)
+
+    if args.emit_mlir:
+        print(emit_mlir())
+        return 0
+
+    if args.verify_ptoas:
+        verify_ptoas()
+        print("PASS ptodsl_tpush_tpop_local_c2v ptoas frontend")
+        return 0
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/samples/TPushTPop/ptodsl/local_c2v/kernel.py
+++ b/test/samples/TPushTPop/ptodsl/local_c2v/kernel.py
@@ -58,7 +58,7 @@ def ptodsl_tpush_tpop_local_c2v_cube(
         "c2v_fifo",
         peer_func="ptodsl_tpush_tpop_local_c2v_cube",
     )
-    c2v = pto.pipe.c2v_local(
+    c2v = pto.pipe.c2v(
         slot_size=_SLOT_SIZE,
         consumer_buf=c2v_import,
         id=0,
@@ -82,7 +82,7 @@ def ptodsl_tpush_tpop_local_c2v_vector(
     o_part = pto.partition_view(o_view, offsets=[c0, c0], sizes=[c_rows, c_cols])
 
     c2v_buf = pto.reserve_buffer("c2v_fifo", size=_FIFO_SIZE, location="vec")
-    c2v = pto.pipe.c2v_local(
+    c2v = pto.pipe.c2v(
         slot_size=_SLOT_SIZE,
         consumer_buf=c2v_buf,
         id=0,


### PR DESCRIPTION
  ## Summary

  This PR adds the reusable PTODSL pipe surface/frontend API work, based on Zhendong404 commit
  `a382a51064e5c3c3a160377ee778dca88c5f91bf`, plus the pipe transaction support needed by the FA PTODSL frontend path.

  Main changes:
  - Add `pto.pipe` high-level namespace.
  - Add unified directional pipe constructors:
    - `pto.pipe.c2v(...)`
    - `pto.pipe.v2c(...)`
    - `pto.pipe.bidirectional(...)`
  - Use parameters to distinguish local tile-entry and A2/A3 global-entry L2G2L usage:
    - `consumer_buf`
    - `gm_slot_buffer`
    - `gm_slot_tensor`
    - `slot_size`
  - Add buffer helpers:
    - `pto.reserve_buffer(...)`
    - `pto.import_reserved_buffer(...)`
    - `pto.gm_ptr(...)`
  - Enable frontend pipe transactions:
    - `pipe.push(...)`
    - `pipe.pop(...)`
    - `pipe.free(...)`
  - Allow frontend pipe ops inside PTODSL `@pto.cube` / `@pto.simd` section scopes.
  - Tighten frontend pipe verifier checks for cube/vector kernel kind and wrong-side sections.
  - Update `ptodsl/docs/user_guide/07-data-movement-ops.md` with the new pipe surface usage.
  - Add unit tests, docs fragment fixtures, sample compile coverage, and invalid verifier regression tests.

  ## Notes

  The public API no longer exposes separate `*_global` / `*_local` constructor names. The pipe direction is part of the
  constructor name, while local/global-entry behavior is selected by the provided operands.

  `gm_slot_buffer` is the actual GM FIFO storage pointer. `gm_slot_tensor` is kept as the entry descriptor for type/
  shape/slot-size inference and verification.

  This PR is intentionally separate from the FA PTODSL PR and only covers the reusable PTODSL pipe surface/frontend API
  work.

  ## Validation

  Run on `dev-481211`:

  - `ninja -C build` passed.
  - `python3 ptodsl/tests/test_vector_cube_ops.py -v` passed.
  - `python3 ptodsl/tests/test_pipe_surface_sample_compile.py` passed.
  - `python3 ptodsl/tests/test_docs_as_test.py` passed.
  - A3 globaltensor frontend inputs passed with `ptoas --pto-arch=a3`.
  - Wrong-side section verifier regression was manually checked and reports the expected error.

