### PR TITLE
ci: allow watchdog test on fork

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -22,7 +22,8 @@ jobs:
   rerun-self-hosted-git-failure:
     if: >-
       ${{
-        github.repository == 'hw-native-sys/PTOAS' &&
+        (github.repository == 'hw-native-sys/PTOAS' ||
+         github.repository == 'mouliangyu/PTOAS') &&
         github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt == 1

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -22,8 +22,6 @@ jobs:
   rerun-self-hosted-git-failure:
     if: >-
       ${{
-        (github.repository == 'hw-native-sys/PTOAS' ||
-         github.repository == 'mouliangyu/PTOAS') &&
         github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt == 1


### PR DESCRIPTION
## 修改内容

删除 `Watchdog` 的仓库名 guard。

`Watchdog` 已经限定为：

- 上游 workflow 是 `CI`
- 事件是 `pull_request`
- 结论是 `failure`
- 只处理首次 run attempt
- 只重跑命中的 `vpto-sim-validation` git/network 失败

仓库名检查不是必要条件，而且会阻止在 fork 仓库上验证 watchdog 的 job-level rerun 能力。

## 验证

- `python3` 解析 `.github/workflows/watchdog.yml` 通过
- `git diff --check` 通过
