### PR TITLE
test: force vpto sim git failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
         github.event_name == 'pull_request'
       }}
     env:
-      LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
+      LLVM_REPO: https://github.invalid/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci
       TILELANG_DSL_WORKSPACE: ${{ github.workspace }}/.work/tilelang-dsl-ci


### PR DESCRIPTION
## 测试目的

伪造 `vpto-sim-validation` 的 git/network 失败，用来验证 default branch 上的 `Watchdog` 是否会识别失败并触发 job-level rerun。

## 修改内容

只把 `vpto-sim-validation` job 的 `LLVM_REPO` 改为不可解析域名：

```yaml
https://github.invalid/vpto-dev/llvm-project.git
```

预期失败阶段：`Prepare LLVM source (no rebuild)`。

预期日志包含：`Could not resolve host`，应命中 watchdog 的 git/network failure pattern。

## 预期验证结果

1. 本 PR 的 `CI / vpto-sim-validation` 首次 attempt 失败。
2. `Watchdog` 被 `workflow_run` 触发。
3. `Watchdog` 下载 failed job log，识别 `Prepare LLVM source (no rebuild)` 中的 git/network 失败。
4. `Watchdog` 调用 job-level rerun API，`vpto-sim-validation` 出现第二次 attempt。
