### PR TITLE
test: force ci-sim git failure

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -26,7 +26,7 @@ jobs:
       group: vpto-sim-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     env:
-      LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
+      LLVM_REPO: https://github.invalid/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto
       PTO_INSTALL_DIR: ${{ github.workspace }}/install
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci


### PR DESCRIPTION
## 测试目的

验证拆分后的 `ci-sim` workflow 失败后，`Watchdog` 是否能不等待主 `CI / build-and-test`，直接识别 `vpto-sim-validation` 的 git/network 失败并触发 job-level rerun。

## 修改内容

只把 `.github/workflows/ci_sim.yml` 中 `vpto-sim-validation` 的 `LLVM_REPO` 改为不可解析域名：

```yaml
https://github.invalid/vpto-dev/llvm-project.git
```

预期失败阶段：`Prepare LLVM source (no rebuild)`。

预期 watchdog 行为：`ci-sim` completed 后立刻触发 `Watchdog`，命中 `Could not resolve host` 并 rerun `vpto-sim-validation`。
