### PR TITLE
test: force ci-sim failure for close guard

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -26,7 +26,7 @@ jobs:
       group: vpto-sim-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     env:
-      LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
+      LLVM_REPO: https://github.invalid/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto
       PTO_INSTALL_DIR: ${{ github.workspace }}/install
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci


### PR DESCRIPTION
## 测试目的

验证 PR 被关闭后，`Watchdog` 即使被 `ci-sim` 的失败 `workflow_run` 触发，也会因为 PR state 不是 `open` 而跳过 rerun。

## 修改内容

把 `ci-sim` 中的 `LLVM_REPO` 改为 `https://github.invalid/...` 来制造 git/network 失败。
