### PR TITLE
Detailed VMI vs MI design comparison, using Quant&RoPE demo walk-through

### DIFF
--- a/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
+++ b/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
@@ -20,6 +20,20 @@ input, and **f16 → fp8 E4M3** quant execution using a precomputed reciprocal
 scale. DMA shells differ between the full-kernel VMI quant example and the
 compute-only MI/CCE excerpts; this doc focuses on the **vector compute bodies**.
 
+**Reader contract:** after reading this note, you should be able to connect the
+scale/quant equations to the VMI source, predict the main MI/CCE lowering shape
+(`DINTLV`, `part`, `vintlv`, `PK4_B32`, masks), and identify which lines are
+algorithmic math versus register-layout repair.
+
+**Concrete VF tile used by the simulator examples:** the correctness tests use
+`rowNum=32`, `colBlockSize=256`, `ubBlockSize=32`, and
+`vlForHalfNumber=128`. That means each input row is `256` bf16/f16 values
+(`512` bytes), there are `8` scale groups per row (`256/32`), `scale1` occupies
+`32*32=1024` bytes, `scale2` occupies `256` bytes, and reciprocal scale occupies
+`16` uint16 lanes (`32` bytes). Wall-time configs also list
+`(rowNum,colBlockSize)=(4,64),(16,128),(32,256)`, but the local vector pipeline
+is written around the 256-lane row contract.
+
 This document is intentionally honest: VMI is a large win on the quant path and
 a solid win on scale computation, but it does not remove tiling, stride math, or
 pipeline synchronization.
@@ -144,7 +158,80 @@ Instruction behavior and caveats:
   `PK4_B32`; those are layout decisions derived from the value type and assigned
   physical layout.
 
-### 3.1 MI details algorithm engineers should not have to memorize
+### 3.1 How to use the side-by-side snippets
+
+When reading the scale and quant walkthroughs, tag each instruction by role:
+
+| Role | Question to ask | MX examples |
+|------|-----------------|-------------|
+| **MATH** | Does this change the numeric value? | `max`, `select`, `mulf`, scale encode |
+| **TYPE** | Does this change dtype while preserving logical lane `i`? | `extf`, `truncf`, `trunci`, `vcvt`, `vpack` |
+| **LAYOUT** | Does this only move bits/lanes? | `DINTLV_B16`, `PART_EVEN/ODD`, `vintlv`, `PK4_B32`, `vselr` |
+| **MEMORY** | Does this cross the UB/register boundary? | `load`, `store`, `masked_store`, `vlds`, `vsts` |
+
+The VMI source tries to keep **MATH** and **TYPE** visible. MI/CCE show every
+**LAYOUT** and **MEMORY** step because the author is working directly against
+the 256-byte physical register model.
+
+### 3.2 Expected lowering shapes for recurring VMI ops
+
+These are review expectations for the concrete examples, not a promise that each
+VMI op lowers to one MI instruction.
+
+**256-lane f16 row load + widen in the quant path:**
+
+```mlir
+%x_f16 = pto.vmi.load %x_ub[%row_off] : ... -> !pto.vmi.vreg<256xf16>
+%x_f32 = pto.vmi.extf %x_f16 : ... -> !pto.vmi.vreg<256xf32>
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%x0, %x1 = pto.vldsx2 %xHalf[%row_off], "DINTLV_B16" : ...
+%x0_even = pto.vcvt %x0, %mask16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
+%x0_odd  = pto.vcvt %x0, %mask16 {part = "ODD"}  : ... -> !pto.vreg<64xf32>
+// ... same for x1, then vintlv repair before contiguous fp8 conversion ...
+```
+
+`extf` means “produce f32 lane `i` for every logical `x[i]`.” The lowered MI
+must split the 512-byte row, widen four physical streams, and repair layout.
+
+**fp32 → fp8 narrow + store:**
+
+```mlir
+%y_fp8 = pto.vmi.truncf %scaled : ... -> !pto.vmi.vreg<256xf8E4M3FN>
+pto.vmi.masked_store %y_fp8, %y_ub[%row_off], %mask : ...
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%p0 = pto.vcvt %chunk0, %mask32 {part = "P0", rnd = "R", sat = "SAT"} : ...
+%p0_u8 = pto.vbitcast %p0 : ...
+pto.vsts %p0_u8, %y_ub[%row_off], %mask8 {dist = "PK4_B32"} : ...
+// repeated for byte offsets 64, 128, 192
+```
+
+`truncf` preserves logical lane order and target FP8 semantics; `PK4_B32` is the
+physical byte extraction needed to materialize dense UB bytes.
+
+**Scale-byte narrowing:**
+
+```mlir
+%scale_u8 = pto.vmi.trunci %scale_u16 : ... -> !pto.vmi.vreg<256xui8>
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%scale_u8 = pto.vpack %scale_u16, "LOWER" : !pto.vreg<128xi16> -> !pto.vreg<256xui8>
+```
+
+The VMI surface says “keep the low 8 bits per logical lane”; MI spells the
+physical pack operation and later masks the first 8 meaningful scale bytes.
+
+### 3.3 MI details algorithm engineers should not have to memorize
 
 These are the hardware subtleties VMI is designed to hide in MX quant:
 
@@ -171,7 +258,23 @@ mixes `b16`, `b32`, and `b8` in one loop body.
 VMI replaces these with “load 256 f16”, “extend to fp32”, “multiply”, “truncate
 to fp8”, and “store”.
 
-### 3.2 Physical register model (the 256-byte contract)
+### 3.4 Common bugs VMI helps avoid
+
+- **Dropping one layout repair step:** after `DINTLV_B16` and `PART_EVEN/ODD`,
+  four f32 streams hold stride-4 logical indices. Skipping a `vintlv` produces a
+  byte-exact but lane-permuted FP8 row.
+- **Using the wrong `part` on FP8 cast:** the CCE/MI FP8 path writes into
+  `PART_P0` before `PK4_B32`; another part changes which byte the store packs.
+- **Wrong `PK4_B32` byte offset:** the four stores cover offsets
+  `0,64,128,192`; a wrong offset aliases or gaps a quarter row.
+- **Mask-family drift:** scale code mixes `b16` and `b8`; quant code mixes
+  `b16`, `b32`, and `b8`. VMI keeps a logical active-lane mask and lowering picks
+  the concrete predicate family.
+- **Confusing `vcgmax` with ordinary max:** `vcgmax` is a grouped lane reduction
+  with layout side effects. VMI names this as `group_reduce_maxi` plus
+  `group_broadcast`, making the reduction boundary easier to review.
+
+### 3.5 Physical register model (the 256-byte contract)
 
 Every A5 vector register is **256 bytes (2048 bits)** wide. That single fact
 drives almost all layout ceremony in block MX quant.
@@ -209,7 +312,7 @@ type, preserve logical index `i`.”** They do **not** mean the hardware perform
 one instruction. The compiler lowers them to the `vcvt` / `vintlv` / `vsts`
 sequence appropriate for the assigned physical layout.
 
-### 3.3 DINTLV load — first split (256 f16 → 2×128 f16)
+### 3.6 DINTLV load — first split (256 f16 → 2×128 f16)
 
 UB memory holds one quant row as **256 contiguous f16**:
 
@@ -241,7 +344,7 @@ VMI `vmi.load` returns `vreg<256×f16>` — the split still happens in lowered
 MI, but the VMI type + layout metadata record the inverse map
 (`even_reg[k]→2k`, `odd_reg[k]→2k+1`).
 
-### 3.4 PART_EVEN / PART_ODD widen — second split (each 128×f16 → 2×64×f32)
+### 3.7 PART_EVEN / PART_ODD widen — second split (each 128×f16 → 2×64×f32)
 
 Widen f16→f32 doubles element width: 128 f16 (256 B) → 128 f32 (512 B). The
 hardware writes widened results into **two 64×f32 registers** using part
@@ -271,7 +374,7 @@ memory order `[0,1,2,3,…]`.
 four `vcvt {part=EVEN/ODD}` plus (depending on the next op) relayout. The
 author never names `x0Zero0` or chooses which part applies to which DINTLV half.
 
-### 3.5 `vintlv` — rebuilding logical order (four steps on 256 elements)
+### 3.8 `vintlv` — rebuilding logical order (four steps on 256 elements)
 
 `vintlv(src0, src1)` interleaves **lane-by-lane** from two source registers into
 two destination registers. Within a 128-element local window it turns
@@ -323,7 +426,7 @@ multiply and repair at store time with `vstsx2 … INTLV_B32` instead of four
 `vintlv` (Pack-Unpack reference §4.2). The MI demo chooses **repair-then-`PART_P0`**
 because it matches the CCE `ComputeY1ToFP8` FP16 branch structure.
 
-### 3.6 PART_P0 + PK4_B32 — FP8 narrow and store (third layout axis)
+### 3.9 PART_P0 + PK4_B32 — FP8 narrow and store (third layout axis)
 
 After the `vintlv` chain, each 64×f32 register holds **64 contiguous logical
 values**. FP8 output still needs two more physical transforms:
@@ -424,7 +527,7 @@ Instruction-by-instruction:
   the comparison/select relation.
 
 **Physical layout note:** the scale path never widens to f32 per element, so it
-does **not** need the four-quadrant `vintlv` chain from §3.5. It still pays the
+does **not** need the four-quadrant `vintlv` chain from §3.8. It still pays the
 **DINTLV load tax**: `acc0` owns exponent maxima for logical indices
 `0,2,4,…,254` and `acc1` for `1,3,5,…,255`. `vcgmax` fuses reduction with
 broadcast only **within each mask family** (`b16`), so the dual-accumulator
@@ -714,10 +817,25 @@ Be explicit about remaining low-level work:
 | Debug wrong FP8 lanes / PK offsets / padding | Lowered **MI** (VMI hides the failure point) |
 | Learn DINTLV + part + PK rules hands-on | **MI** + `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` |
 
+**Review checklist for VMI MX quant code:**
+
+1. Confirm the logical vector width matches the row contract (`256` lanes for
+   the covered scale and quant bodies).
+2. Confirm scale math still spells special cases explicitly: Inf/NaN, zero,
+   clamp/range handling, and reciprocal edge cases.
+3. Confirm dtype transitions match the intended stage: `extf` before fp32
+   multiply, `truncf` for FP8/FP4 output, and `trunci` for compact scale bytes.
+4. Inspect lowered MI for the expected `DINTLV_B16` split, `PART_EVEN/ODD`
+   widen, `vintlv` repair, `PART_P0` FP8 cast, and four `PK4_B32` stores on the
+   f16→fp8 path.
+5. Compare against `bmx_cce_kernels.h` when debugging: start at the
+   `Expected UB effect` block, then the register allocation and phase comments
+   for `ComputeOcp`, `ComputeDdr`, `ComputeY1ToFP4`, or `ComputeY1ToFP8`.
+
 **Suggested reading order:**
 
 1. Section 1 of this doc (math)
-2. **§3.2–§3.6** (physical register model — read before MI/CCE examples)
+2. **§3.5–§3.9** (physical register model — read before MI/CCE examples)
 3. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` — best “before/after” showcase
 4. **§6.5–§6.9** (quant pipeline index map + VMI vs MI diagrams)
 5. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` — see what VMI removed
@@ -736,7 +854,7 @@ Be explicit about remaining low-level work:
 | Closer to math? | **Yes** — VMI keeps “max exponent → scale → multiply → cast” visible |
 | Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling |
 | Biggest win? | **f16→fp8 quant**, where MI spends most lines on layout repair |
-| Why `extf`/`truncf` vs `vintlv`? | VMI ops preserve **logical index `i`**; MI `vintlv` repairs **physical lane placement** after DINTLV + PART widen (§3.3–§3.6, §6.5–§6.7) |
+| Why `extf`/`truncf` vs `vintlv`? | VMI ops preserve **logical index `i`**; MI `vintlv` repairs **physical lane placement** after DINTLV + PART widen (§3.6–§3.9, §6.5–§6.7) |
 
 VMI is not “MX quant in five lines.” It is **MX quant with the split/part/PK
 contract moved into the compiler** — most valuable exactly where block quant

--- a/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
+++ b/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
@@ -87,6 +87,21 @@ convert, and multi-store PK packing choreography.
 **VMI does not remove:** row/block loop nesting, UB stride math, gather-index
 setup at the API boundary, DMA, or pipeline flags.
 
+The VMI conversion ops intentionally mirror MLIR `arith` names, but operate on
+abstract vector registers:
+
+- `pto.vmi.extf` / `extsi` / `extui` mean per-lane extension while preserving
+  logical index `i`.
+- `pto.vmi.truncf` / `trunci` mean per-lane narrowing to the destination element
+  type while preserving logical index `i`.
+
+This is a semantic contract, not a one-instruction promise. In the f16→fp8
+quant path, one `vmi.extf` over `vreg<256×f16>` lowers to split loads, four
+`vcvt {part=EVEN/ODD}` conversions, and layout repair. One `vmi.truncf` plus
+`masked_store` lowers to fp8 `vcvt` with rounding/saturation/part placement and
+packed stores. VMI removes layout authorship; the lowered MI still performs the
+necessary hardware work.
+
 ---
 
 ## 3. Instruction map: math → CCE → MI → VMI
@@ -109,6 +124,25 @@ setup at the API boundary, DMA, or pipeline flags.
 | Re-order after widen | `vintlv` | 4× `pto.vintlv` to rebuild P0–P3 layout | *(compiler)* |
 | Narrow f32 → fp8 E4M3 | `vcvt` (`ROUND_R`, `RS_ENABLE`, `PART_P0`, `MODE_ZEROING`) | 4× `pto.vcvt` + `vbitcast` + 4× `pto.vsts` `{dist=PK4_B32}` | `pto.vmi.truncf` + `pto.vmi.masked_store` |
 | Tail / active lanes | `pset` / `plt_b16` / `plt_b32` / `plt_b8` | `pto.pset_b16` / `pset_b32` / `pset_b8` / `pge_*` | `pto.vmi.create_mask` |
+
+Instruction behavior and caveats:
+
+- `vmi.load` names a logical row. For `vreg<256×f16>`, the lowered MI cannot fit
+  the row into one 256-byte physical register, so it uses `DINTLV_B16` or an
+  equivalent split layout.
+- `vmi.broadcast` creates a logical vector constant. MI `vbr` broadcasts into one
+  physical register width, which is why MI scale code often carries separate
+  constants for each DINTLV half.
+- `vmi.cmpi` + `vmi.select` are written as ordinary predicate/select data flow.
+  MI uses `vcmp`/`vsel` with a concrete b16 mask, and CCE exposes the same
+  predicate register handling.
+- `group_reduce_maxi` and `group_broadcast` deliberately split the two meanings
+  hidden inside `vcgmax`: reduction across lanes and replication of the result.
+- `trunci` replaces `vpack LOWER` only at the VMI surface. Lowering still has to
+  honor the source lane layout and destination byte layout.
+- `masked_store` hides whether the MI store is `NORM_B8`, `NORM_B16`, or
+  `PK4_B32`; those are layout decisions derived from the value type and assigned
+  physical layout.
 
 ### 3.1 MI details algorithm engineers should not have to memorize
 
@@ -376,6 +410,19 @@ VMI advantage: the algorithm reads as “mask exponent bits, running max over 25
 lanes”. MI/CCE force you to track **even/odd half ownership** from the first
 load.
 
+Instruction-by-instruction:
+
+- `vmi.load` reads the row as `vreg<256×ui16>` so the exponent extraction can be
+  written once over logical lanes. MI starts with `vldsx2 DINTLV_B16`, producing
+  even and odd ownership domains.
+- `vmi.bitcast` changes interpretation from unsigned bits to signed integer
+  lanes without moving data, matching MI `vbitcast`.
+- `vmi.andi` masks with `0x7F80`, keeping bf16 exponent bits `[14:7]`. MI/CCE
+  spell this as `vand` plus an all-lanes b16 predicate.
+- `vmi.cmpi "slt"` produces the predicate `acc < xExp`, and `vmi.select` chooses
+  the new maximum. MI/CCE use `vmax`, which is shorter but less explicit about
+  the comparison/select relation.
+
 **Physical layout note:** the scale path never widens to f32 per element, so it
 does **not** need the four-quadrant `vintlv` chain from §3.5. It still pays the
 **DINTLV load tax**: `acc0` owns exponent maxima for logical indices
@@ -452,6 +499,17 @@ This is the clearest VMI win in the MX quant suite.
 %res_fp8 = pto.vmi.truncf %res_fp32 : ... -> !pto.vmi.vreg<256xf8E4M3FN>
 pto.vmi.masked_store %res_fp8, %y_ub[%row_off], %full_mask : ...
 ```
+
+Each line corresponds directly to the row formula `y_i = fp8(x_i * scale_i)`:
+
+- `vmi.load` establishes the logical index contract `[0..255]`.
+- `extf` widens each f16 lane to f32; in MI this is four `vcvt` ops because
+  `DINTLV_B16` and width expansion create four physical streams.
+- `mulf` is the only numerical arithmetic in this stage.
+- `truncf` narrows to FP8 E4M3 with target rounding/saturation rules. MI must
+  spell `rnd=R`, `sat=SAT`, and part placement explicitly.
+- `masked_store` writes the packed fp8 row. MI needs four `PK4_B32` stores at
+  byte offsets `0, 64, 128, 192`.
 
 ### 6.3 MI quant path (same math, hardware vocabulary)
 

--- a/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
+++ b/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
@@ -1,184 +1,131 @@
-# Block MX Quant on PTO: Why VMI Helps Algorithm Engineers
+# Block MX Quant on PTO: VMI vs MI vs CCE
 
-This note compares the block MX quantization example kernels in this directory
-across three expression layers. The examples cover the two main compute stages
-of OCP Microscaling (MX) block quantization:
+This walkthrough explains the block MX quantization examples in this directory.
+It is written for algorithm engineers who want the scale/quant math to stay
+visible, while still understanding the register-layout work that MI and CCE must
+spell explicitly.
 
-| Layer | Example files | Who it is for |
-|-------|---------------|---------------|
-| **CCE** | `bmx_cce_kernels.h` | Ground-truth intrinsics execution |
+| Layer | Example files | Use it for |
+|-------|---------------|------------|
+| **CCE** | `bmx_cce_kernels.h` | Intrinsics ground truth and expected UB behavior |
 | **MI** (`pto.mi`) | `mx_block_quant_scale_ocp_bf16.mi.pto`, `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` | Hardware-faithful PTO micro-ops |
 | **VMI** (`pto.vmi`) | `mx_block_quant_scale_ocp_bf16.vmi.pto`, `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` | Logical-vector authoring |
 
-**Audience:** algorithm engineers implementing or reviewing MX block quant who
-want scale math and quant math visible in code, without hand-managing DINTLV
-splits, part selection, mask families, or store packing modes.
-
-**Scope:** two paired demos on a fixed tile shape — **256 half-precision
-elements per row**, **32-element column blocks**, OCP scale path on **bf16**
-input, and **f16 → fp8 E4M3** quant execution using a precomputed reciprocal
-scale. DMA shells differ between the full-kernel VMI quant example and the
-compute-only MI/CCE excerpts; this doc focuses on the **vector compute bodies**.
-
-**Reader contract:** after reading this note, you should be able to connect the
-scale/quant equations to the VMI source, predict the main MI/CCE lowering shape
-(`DINTLV`, `part`, `vintlv`, `PK4_B32`, masks), and identify which lines are
+**How to use this note:** read it as a bridge between the MX scale/quant formulas
+and the actual VMI/MI/CCE code. The goal is to make it clear what each VMI
+instruction means, what MI/CCE pattern it usually lowers to, and which lines are
 algorithmic math versus register-layout repair.
 
-**Concrete VF tile used by the simulator examples:** the correctness tests use
-`rowNum=32`, `colBlockSize=256`, `ubBlockSize=32`, and
-`vlForHalfNumber=128`. That means each input row is `256` bf16/f16 values
-(`512` bytes), there are `8` scale groups per row (`256/32`), `scale1` occupies
-`32*32=1024` bytes, `scale2` occupies `256` bytes, and reciprocal scale occupies
-`16` uint16 lanes (`32` bytes). Wall-time configs also list
-`(rowNum,colBlockSize)=(4,64),(16,128),(32,256)`, but the local vector pipeline
-is written around the 256-lane row contract.
+**Concrete VF tile in the simulator examples:** correctness tests use
+`rowNum=32`, `colBlockSize=256`, `ubBlockSize=32`, and `vlForHalfNumber=128`.
+Each input row is `256` bf16/f16 values (`512` bytes). There are `8` scale groups
+per row (`256/32`), `scale1` is `32*32=1024` bytes, `scale2` is `256` bytes,
+and reciprocal scale is `16` uint16 lanes (`32` bytes). Wall-time configs also
+list `(rowNum,colBlockSize)=(4,64),(16,128),(32,256)`, but the local vector
+pipeline is written around a 256-lane row.
 
-This document is intentionally honest: VMI is a large win on the quant path and
-a solid win on scale computation, but it does not remove tiling, stride math, or
-pipeline synchronization.
-
----
-
-## 1. Block MX quant math (what both stages implement)
-
-OCP MX block quantization processes input `X` in **32×32 element super-blocks**
-(32 columns × 32 rows). Each super-block shares one **scale1** (E8M0, `uint8`)
-and produces a **reciprocal scale** used to normalize values before casting to
-FP8/FP4.
-
-### 1.1 Step 1 — shared scale (`ComputeOcp`)
-
-For each 32-element column group inside the super-block:
-
-```
-max_exp = max( biased_exponent(x_i) )     // over all rows and lanes in the block
-scale1  = encode_E8M0( clamp(max_exp - emax_target) )
-recip   = bias - max_exp                  // bf16 exponent field for dequant in step 2
-```
-
-Special cases handled in all three layers:
-
-- **Inf/NaN block** → scale1 = `0xFF`, reciprocal → custom NaN pattern
-- **All-zero block** → scale1 = 0, reciprocal = 0
-- **Exponent below representable range** → clamp to `yMaxExp` before encoding
-- **Subnormal reciprocal edge** → substitute a special exponent threshold
-
-The bf16 demo (`ComputeOcp_bf16`) extracts exponents with `x & 0x7F80`, reduces
-across rows, then writes **scale1**, **scale2** (interleaved layout), and
-**reciprocal** to UB.
-
-### 1.2 Step 2 — quantize to FP8 (`ComputeY1ToFP8`, f16 path)
-
-For each row of 256 f16 elements:
-
-```
-y_i = quant_fp8( widen_f32(x_i) * widen_f32(reciprocal_scale) )
-```
-
-The f16 demo uses **fp32 intermediate arithmetic** before narrowing to **fp8
-E4M3** with round-nearest-even and saturation — matching the CCE reference
-(`ComputeY1ToFP8`, FP16 branch).
+VMI keeps layout bookkeeping out of the source you write. It does not remove
+row/block loops, UB stride math, DMA, pipeline flags, or the need to inspect
+lowered MI for debugging and tuning.
 
 ---
 
-## 2. What VMI actually is
+## 1. MX Quant Math
 
-VMI (`pto.vmi`) sits between your algorithm and MI (`pto.mi`). You write
-**logical contiguous vectors** (`!pto.vmi.vreg<N×T>`) and **semantic ops**
-(`vmi.load`, `vmi.extf`, `vmi.mulf`, `vmi.truncf`, `group_reduce_maxi`, …).
-The compiler lowers to MI with the correct `dist`, `part`, `PK/UNPK`, and mask
-granularity.
+The examples cover two vector compute stages.
 
-See `PTO-Gym-vmi/docs/PTO-vmi-design.en.md` and
-`PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
-for the underlying layout rules VMI hides.
+### Step 1: OCP Shared Scale
 
-**VMI removes:** DINTLV even/odd register splitting, dual accumulators caused
-by that split, per-op mask plumbing, explicit `part`/`rnd`/`sat` on every
-convert, and multi-store PK packing choreography.
+For each 32-column group, compute a shared exponent across the rows in the tile:
 
-**VMI does not remove:** row/block loop nesting, UB stride math, gather-index
-setup at the API boundary, DMA, or pipeline flags.
+```text
+max_exp = max(biased_exponent(x_i))      # across rows and lanes in the group
+scale1  = encode_E8M0(max(max_exp, yMaxExp) - yMaxExp)
+recip   = 0x7F00 - (max(max_exp, yMaxExp) - yMaxExp)
+```
 
-The VMI conversion ops intentionally mirror MLIR `arith` names, but operate on
-abstract vector registers:
+Special cases are explicit in all layers:
 
-- `pto.vmi.extf` / `extsi` / `extui` mean per-lane extension while preserving
-  logical index `i`.
-- `pto.vmi.truncf` / `trunci` mean per-lane narrowing to the destination element
-  type while preserving logical index `i`.
+- Inf/NaN block: `scale1 = 0xFF`, reciprocal uses the custom BF16 NaN pattern
+- all-zero block: `scale1 = 0`, reciprocal `= 0`
+- exponent below target range: clamp by `yMaxExp`
+- invalid reciprocal edge: substitute `SPECIAL_EXP_THRESHOLD`
 
-This is a semantic contract, not a one-instruction promise. In the f16→fp8
-quant path, one `vmi.extf` over `vreg<256×f16>` lowers to split loads, four
-`vcvt {part=EVEN/ODD}` conversions, and layout repair. One `vmi.truncf` plus
-`masked_store` lowers to fp8 `vcvt` with rounding/saturation/part placement and
-packed stores. VMI removes layout authorship; the lowered MI still performs the
-necessary hardware work.
+The bf16 scale demo extracts exponent bits with `x & 0x7F80`, reduces across
+rows and 32-column groups, then writes `scale1`, `scale2`, and reciprocal scale.
+
+### Step 2: f16 to fp8 E4M3
+
+For each 256-element row:
+
+```text
+y_i = fp8_e4m3( f32(x_i) * f32(reciprocal_scale_for_group(i)) )
+```
+
+The f16 demo widens to fp32, multiplies by a broadcast reciprocal scale, narrows
+to FP8 E4M3 with round-nearest-even and saturation, then stores packed fp8
+bytes. This matches the FP16 branch of `ComputeY1ToFP8` in CCE.
 
 ---
 
-## 3. Instruction map: math → CCE → MI → VMI
+## 2. What VMI Changes
 
-| Math intent | CCE intrinsic | MI (`pto.mi`) | VMI (`pto.vmi`) |
-|-------------|---------------|---------------|-----------------|
-| Load 256 half-precision elements | `vlds` (`DINTLV_B16`) | `pto.vldsx2` + `"DINTLV_B16"` | `pto.vmi.load` → `vreg<256×T>` |
-| Broadcast scalar constants | `vbr` | `pto.vbr` → `vreg<128×T>` | `pto.vmi.broadcast` → `vreg<256×T>` |
-| Extract bf16 exponent field | `vand` (`MODE_ZEROING` + mask) | `pto.vand` + `!pto.mask<b16>` | `pto.vmi.andi` (no mask) |
-| Running max over exponents | `vmax` (`MODE_ZEROING` + mask) | `pto.vmax` + mask; **two accumulators** for even/odd halves | `pto.vmi.cmpi` + `pto.vmi.select` (single accumulator) |
-| Cross-lane block max | `vcgmax` (`MODE_ZEROING` + mask) | `pto.vcgmax` (reduce + broadcast fused) | `pto.vmi.group_reduce_maxi` + `pto.vmi.group_broadcast` |
-| Compare + conditional replace | `vcmp` + `vsel` | `pto.vcmp` + `pto.vsel` + mask | `pto.vmi.cmpi` + `pto.vmi.select` |
-| Shift exponent diff → E8M0 | `vshrs` (`MODE_ZEROING` + mask) | `pto.vshrs` + mask | `pto.vmi.shrui` |
-| Pack scale bytes | `vpack` (`LOWER`) | `pto.vpack` `"LOWER"` | `pto.vmi.trunci` |
-| Gather scale2 layout | `vlds` (`NORM`) + `vselr` | same | direct `pto.vmi.store` when lanes are uniform after broadcast |
-| Store scale / reciprocal | `vsts` (`NORM_B8` / `NORM_B16` + mask) | `pto.vsts` + `{dist}` + mask | `pto.vmi.store` / `pto.vmi.masked_store` |
-| Load reciprocal scale | `vlds` (`E2B_B16`) | `pto.vlds` `{dist = "E2B_B16"}` + `vbitcast` + `vcvt {part=EVEN}` | `pto.vmi.load` + `pto.vmi.extf` |
-| Widen f16/bf16 → f32 | `vcvt` (`PART_EVEN` / `PART_ODD`, `MODE_ZEROING`) | 4× `pto.vcvt` after DINTLV split | `pto.vmi.extf` |
-| Scale multiply in fp32 | `vmul` (`MODE_ZEROING` + mask) | 4× `pto.vmul` + `!pto.mask<b32>` | `pto.vmi.mulf` |
-| Re-order after widen | `vintlv` | 4× `pto.vintlv` to rebuild P0–P3 layout | *(compiler)* |
-| Narrow f32 → fp8 E4M3 | `vcvt` (`ROUND_R`, `RS_ENABLE`, `PART_P0`, `MODE_ZEROING`) | 4× `pto.vcvt` + `vbitcast` + 4× `pto.vsts` `{dist=PK4_B32}` | `pto.vmi.truncf` + `pto.vmi.masked_store` |
-| Tail / active lanes | `pset` / `plt_b16` / `plt_b32` / `plt_b8` | `pto.pset_b16` / `pset_b32` / `pset_b8` / `pge_*` | `pto.vmi.create_mask` |
+VMI lets the author write logical vectors such as `!pto.vmi.vreg<256xf16>` and
+semantic ops such as `vmi.load`, `vmi.extf`, `vmi.mulf`, `group_reduce_maxi`,
+`vmi.truncf`, and `vmi.masked_store`.
 
-Instruction behavior and caveats:
+Lowering still emits MI instructions with concrete:
 
-- `vmi.load` names a logical row. For `vreg<256×f16>`, the lowered MI cannot fit
-  the row into one 256-byte physical register, so it uses `DINTLV_B16` or an
-  equivalent split layout.
-- `vmi.broadcast` creates a logical vector constant. MI `vbr` broadcasts into one
-  physical register width, which is why MI scale code often carries separate
-  constants for each DINTLV half.
-- `vmi.cmpi` + `vmi.select` are written as ordinary predicate/select data flow.
-  MI uses `vcmp`/`vsel` with a concrete b16 mask, and CCE exposes the same
-  predicate register handling.
-- `group_reduce_maxi` and `group_broadcast` deliberately split the two meanings
-  hidden inside `vcgmax`: reduction across lanes and replication of the result.
-- `trunci` replaces `vpack LOWER` only at the VMI surface. Lowering still has to
-  honor the source lane layout and destination byte layout.
-- `masked_store` hides whether the MI store is `NORM_B8`, `NORM_B16`, or
-  `PK4_B32`; those are layout decisions derived from the value type and assigned
-  physical layout.
+- split-load distributions such as `DINTLV_B16`
+- part selections such as `PART_EVEN`, `PART_ODD`, and `PART_P0`
+- layout repairs such as `vintlv`
+- packing stores such as `PK4_B32`
+- mask families such as `b16`, `b32`, and `b8`
 
-### 3.1 How to use the side-by-side snippets
+The VMI conversion ops mirror MLIR `arith` naming:
 
-When reading the scale and quant walkthroughs, tag each instruction by role:
+- `extf`, `extsi`, `extui`: widen or extend each logical lane
+- `truncf`, `trunci`: narrow each logical lane
 
-| Role | Question to ask | MX examples |
-|------|-----------------|-------------|
-| **MATH** | Does this change the numeric value? | `max`, `select`, `mulf`, scale encode |
-| **TYPE** | Does this change dtype while preserving logical lane `i`? | `extf`, `truncf`, `trunci`, `vcvt`, `vpack` |
-| **LAYOUT** | Does this only move bits/lanes? | `DINTLV_B16`, `PART_EVEN/ODD`, `vintlv`, `PK4_B32`, `vselr` |
-| **MEMORY** | Does this cross the UB/register boundary? | `load`, `store`, `masked_store`, `vlds`, `vsts` |
+These names describe lane-wise meaning. `vmi.extf` over `vreg<256xf16>` is not
+one hardware instruction; the MI lowering has to split a 512-byte row, widen
+four physical streams, and repair layout.
 
-The VMI source tries to keep **MATH** and **TYPE** visible. MI/CCE show every
-**LAYOUT** and **MEMORY** step because the author is working directly against
-the 256-byte physical register model.
+---
 
-### 3.2 Expected lowering shapes for recurring VMI ops
+## 3. How to Read the Examples
 
-These are review expectations for the concrete examples, not a promise that each
-VMI op lowers to one MI instruction.
+Tag instructions by role:
 
-**256-lane f16 row load + widen in the quant path:**
+| Role | Question | MX examples |
+|------|----------|-------------|
+| **MATH** | Does it change the numeric value? | max/select, scale encode, `mulf` |
+| **TYPE** | Does it change dtype while preserving lane `i`? | `extf`, `truncf`, `trunci`, `vcvt`, `vpack` |
+| **LAYOUT** | Does it only move lanes or bytes? | `DINTLV_B16`, `PART_EVEN/ODD`, `vintlv`, `PK4_B32`, `vselr` |
+| **MEMORY** | Does it cross the UB/register boundary? | `load`, `store`, `masked_store`, `vlds`, `vsts` |
+
+VMI keeps **MATH** and **TYPE** in the source. MI/CCE expose **LAYOUT** and
+**MEMORY** because the author is programming physical registers.
+
+### Instruction Map
+
+| Math intent | CCE / MI shape | VMI shape |
+|-------------|----------------|-----------|
+| Load 256 b16 values | `vldsx2 DINTLV_B16` | `pto.vmi.load` |
+| Extract bf16 exponent bits | `vand` + b16 mask | `pto.vmi.andi` |
+| Running max | `vmax` over two split accumulators | `cmpi` + `select` over one logical vector |
+| Group max | `vcgmax` | `group_reduce_maxi` + `group_broadcast` |
+| Scale byte narrowing | `vpack LOWER` | `pto.vmi.trunci` |
+| Load reciprocal scale | `vlds E2B_B16` + bitcast + `vcvt EVEN` | `vmi.load` + `vmi.extf` |
+| Widen f16 to fp32 | 4x `vcvt EVEN/ODD` | `pto.vmi.extf` |
+| Repair widened layout | 4x `vintlv` | compiler lowering |
+| fp32 multiply | 4x `vmul` + b32 mask | `pto.vmi.mulf` |
+| fp32 to fp8 | 4x `vcvt {P0,rnd=R,sat=SAT}` | `pto.vmi.truncf` |
+| Store fp8 row | 4x `vsts PK4_B32` | `pto.vmi.masked_store` |
+
+### Expected Lowering Shapes
+
+**256-lane f16 load + widen:**
 
 ```mlir
 %x_f16 = pto.vmi.load %x_ub[%row_off] : ... -> !pto.vmi.vreg<256xf16>
@@ -191,13 +138,13 @@ Expected MI/CCE shape:
 %x0, %x1 = pto.vldsx2 %xHalf[%row_off], "DINTLV_B16" : ...
 %x0_even = pto.vcvt %x0, %mask16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
 %x0_odd  = pto.vcvt %x0, %mask16 {part = "ODD"}  : ... -> !pto.vreg<64xf32>
-// ... same for x1, then vintlv repair before contiguous fp8 conversion ...
+// same for x1, followed by vintlv repair before fp8 conversion
 ```
 
-`extf` means “produce f32 lane `i` for every logical `x[i]`.” The lowered MI
-must split the 512-byte row, widen four physical streams, and repair layout.
+`extf` means “produce f32 lane `i` for every logical `x[i]`.” MI has to expose
+the physical split and repair.
 
-**fp32 → fp8 narrow + store:**
+**fp32 to fp8 narrow + store:**
 
 ```mlir
 %y_fp8 = pto.vmi.truncf %scaled : ... -> !pto.vmi.vreg<256xf8E4M3FN>
@@ -207,14 +154,14 @@ pto.vmi.masked_store %y_fp8, %y_ub[%row_off], %mask : ...
 Expected MI/CCE shape:
 
 ```mlir
-%p0 = pto.vcvt %chunk0, %mask32 {part = "P0", rnd = "R", sat = "SAT"} : ...
-%p0_u8 = pto.vbitcast %p0 : ...
-pto.vsts %p0_u8, %y_ub[%row_off], %mask8 {dist = "PK4_B32"} : ...
-// repeated for byte offsets 64, 128, 192
+%chunk_fp8 = pto.vcvt %chunk_f32, %mask32 {part = "P0", rnd = "R", sat = "SAT"} : ...
+%chunk_u8 = pto.vbitcast %chunk_fp8 : ...
+pto.vsts %chunk_u8, %y_ub[%off], %mask8 {dist = "PK4_B32"} : ...
+// repeated at byte offsets 0, 64, 128, 192
 ```
 
-`truncf` preserves logical lane order and target FP8 semantics; `PK4_B32` is the
-physical byte extraction needed to materialize dense UB bytes.
+`truncf` preserves logical lane order and FP8 semantics. `PART_P0` and
+`PK4_B32` are the physical byte-placement protocol.
 
 **Scale-byte narrowing:**
 
@@ -228,653 +175,218 @@ Expected MI/CCE shape:
 %scale_u8 = pto.vpack %scale_u16, "LOWER" : !pto.vreg<128xi16> -> !pto.vreg<256xui8>
 ```
 
-The VMI surface says “keep the low 8 bits per logical lane”; MI spells the
-physical pack operation and later masks the first 8 meaningful scale bytes.
-
-### 3.3 MI details algorithm engineers should not have to memorize
-
-These are the hardware subtleties VMI is designed to hide in MX quant:
-
-**DINTLV_B16 load:** 256 half-precision elements in UB become **two 128-lane
-physical registers** — even indices in one register, odd indices in the other.
-Every subsequent op must reason about which half owns which logical index.
-
-**Nested part selection:** after DINTLV, widening f16→f32 splits **each** half
-again into `PART_EVEN` and `PART_ODD`, yielding **four** fp32 streams. The MI
-quant loop then uses multiple `vintlv` steps to rebuild an order compatible
-with `PART_P0` FP8 packing.
-
-**E2B_B16 scale load:** reciprocal scales are loaded with a broadcast
-distribution; valid bf16 lanes sit in a specific layout. MI must `vbitcast` and
-`vcvt {part=EVEN}` before use.
-
-**PK4_B32 store:** FP8 output requires four packed stores with 64-byte offsets.
-Each store needs `vbitcast` to `ui8` and a `b32`/`b8` mask pairing.
-
-**Mask family mismatch:** scale computation mixes `!pto.mask<b16>` (compute) with
-`!pto.mask<b8>` (scale1 store) and `!pto.mask<b16>` (reciprocal store). Quant
-mixes `b16`, `b32`, and `b8` in one loop body.
-
-VMI replaces these with “load 256 f16”, “extend to fp32”, “multiply”, “truncate
-to fp8”, and “store”.
-
-### 3.4 Common bugs VMI helps avoid
-
-- **Dropping one layout repair step:** after `DINTLV_B16` and `PART_EVEN/ODD`,
-  four f32 streams hold stride-4 logical indices. Skipping a `vintlv` produces a
-  byte-exact but lane-permuted FP8 row.
-- **Using the wrong `part` on FP8 cast:** the CCE/MI FP8 path writes into
-  `PART_P0` before `PK4_B32`; another part changes which byte the store packs.
-- **Wrong `PK4_B32` byte offset:** the four stores cover offsets
-  `0,64,128,192`; a wrong offset aliases or gaps a quarter row.
-- **Mask-family drift:** scale code mixes `b16` and `b8`; quant code mixes
-  `b16`, `b32`, and `b8`. VMI keeps a logical active-lane mask and lowering picks
-  the concrete predicate family.
-- **Confusing `vcgmax` with ordinary max:** `vcgmax` is a grouped lane reduction
-  with layout side effects. VMI names this as `group_reduce_maxi` plus
-  `group_broadcast`, making the reduction boundary easier to review.
-
-### 3.5 Physical register model (the 256-byte contract)
-
-Every A5 vector register is **256 bytes (2048 bits)** wide. That single fact
-drives almost all layout ceremony in block MX quant.
-
-| Quantity | Bytes needed | Fits in one 256B reg? |
-|----------|-------------|------------------------|
-| 128 × f16 / bf16 | 256 B | **Yes** (128 b16 lanes) |
-| 256 × f16 / bf16 | 512 B | **No** → need 2 regs or a split load |
-| 64 × f32 | 256 B | **Yes** (64 b32 lanes) |
-| 128 × f32 | 512 B | **No** → need 2 regs after widen |
-| 256 × f32 | 1024 B | **No** → need 4 regs at peak |
-| 256 × fp8 (packed in UB) | 256 B | **Yes**, but only after `PK4_B32` store packing |
-
-**Logical view (VMI):** you hold `N` elements of type `T` in index order
-`0, 1, 2, …, N−1`. The type system (`!pto.vmi.vreg<256×f16>`) promises that
-contract regardless of how many physical registers exist underneath.
-
-**Physical view (MI/CCE):** each instruction names **concrete registers** with
-**lane-granular placement rules**. A lane is not “logical index `i`” until you
-have explicitly loaded, split, widened, interleaved, and packed it into the
-right slot. Layout ops (`DINTLV`, `part=`, `vintlv`, `PK4_B32`) exist only to
-maintain or restore that index mapping.
-
-See `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
-§1–§2 for the full taxonomy. The MX quant examples exercise three layout axes:
-
-| Axis | Mechanism | What it splits or merges |
-|------|-----------|--------------------------|
-| **Width** | `vcvt` + `part=EVEN/ODD` | One 128×f16 reg → two 64×f32 regs (2× widen) |
-| **Parity** | `DINTLV_B16` load, `vintlv` | Even/odd **logical** indices into separate regs |
-| **Sub-byte pack** | `vcvt {part=P0}` + `PK4_B32` | One f32 lane → one fp8 byte in memory |
-
-VMI `extf` / `truncf` follow MLIR `arith` naming: they mean **“change element
-type, preserve logical index `i`.”** They do **not** mean the hardware performs
-one instruction. The compiler lowers them to the `vcvt` / `vintlv` / `vsts`
-sequence appropriate for the assigned physical layout.
-
-### 3.6 DINTLV load — first split (256 f16 → 2×128 f16)
-
-UB memory holds one quant row as **256 contiguous f16**:
-
-```
-Memory (logical):  x[0] x[1] x[2] x[3] x[4] x[5] ... x[254] x[255]
-                   └── 512 bytes ──┘
-```
-
-`DINTLV_B16` load (`vldsx2` / `vlds … DINTLV_B16`) cannot fit 512 B into one
-256 B register, so it **deinterleaves by logical parity** at load time:
-
-```
-x0F16 (128 lanes, 256 B):  x[0]  x[2]  x[4]  x[6]  ... x[252] x[254]
-                            phys lane k  ←→  logical index 2k
-
-x1F16 (128 lanes, 256 B):  x[1]  x[3]  x[5]  x[7]  ... x[253] x[255]
-                            phys lane k  ←→  logical index 2k+1
-```
-
-**Why load splits instead of loading 128 elements twice?** A normal `NORM` load
-only fills one register. To process 256 elements without scalar loops, the
-hardware exposes **split-load distribution modes** that populate two registers in
-one memory transaction while respecting the 256 B cap.
-
-From this point on, MI/CCE authors must track **two ownership domains**:
-everything in `x0F16` is an even logical index; everything in `x1F16` is odd.
-
-VMI `vmi.load` returns `vreg<256×f16>` — the split still happens in lowered
-MI, but the VMI type + layout metadata record the inverse map
-(`even_reg[k]→2k`, `odd_reg[k]→2k+1`).
-
-### 3.7 PART_EVEN / PART_ODD widen — second split (each 128×f16 → 2×64×f32)
-
-Widen f16→f32 doubles element width: 128 f16 (256 B) → 128 f32 (512 B). The
-hardware writes widened results into **two 64×f32 registers** using part
-selection on **physical lane parity inside each source reg**:
-
-```
-x0F16 phys lanes:     0    1    2    3    4  ...  126  127
-logical index held:     0    2    4    6    8  ...  252  254
-
-vcvt {part=EVEN}  →  x0Zero0 (64×f32):  f32(0),  f32(4),  f32(8),  ... f32(252)
-vcvt {part=ODD}   →  x0One0  (64×f32):  f32(2),  f32(6),  f32(10), ... f32(254)
-```
-
-The same pattern on `x1F16`:
-
-```
-vcvt {part=EVEN}  →  x1Zero0:  f32(1),  f32(5),  f32(9),  ... f32(253)
-vcvt {part=ODD}   →  x1One0:   f32(3),  f32(7),  f32(11), ... f32(255)
-```
-
-After four `vcvt`s you have **four 64×f32 streams**, each holding values at
-**logical stride 4**. This is the **parity-interleaved** layout: arithmetic
-(`vmul`) can run independently on each stream, but the results are **not** in
-memory order `[0,1,2,3,…]`.
-
-**What `vmi.extf` hides:** one semantic “256 f16 → 256 f32” op. Lowering emits
-four `vcvt {part=EVEN/ODD}` plus (depending on the next op) relayout. The
-author never names `x0Zero0` or chooses which part applies to which DINTLV half.
-
-### 3.8 `vintlv` — rebuilding logical order (four steps on 256 elements)
-
-`vintlv(src0, src1)` interleaves **lane-by-lane** from two source registers into
-two destination registers. Within a 128-element local window it turns
-step-2 parity streams back into contiguous order (see Pack-Unpack reference
-§2.3.1).
-
-The MI/CCE quant loop uses **four** `vintlv` calls in two stages:
-
-**Stage A — repair widen split inside each DINTLV half (2× `vintlv`):**
-
-```
-vintlv(x0Zero1, x0One1)   // after vmul on x0 streams
-  IN:  f32(0),f32(4),f32(8),...     +  f32(2),f32(6),f32(10),...
-  OUT: x0Zero2 = f32(0),f32(2),f32(4),...f32(126)   [64 lanes, stride-2 evens]
-       x0One2  = f32(128),f32(130),...f32(254)      [64 lanes, stride-2 evens, high half]
-
-vintlv(x1Zero1, x1One1)   // same for odd-index load half
-  OUT: x1Zero2 = f32(1),f32(3),f32(5),...f32(125)
-       x1One2  = f32(129),f32(131),...f32(255)
-```
-
-**Stage B — repair DINTLV load split across halves (2× `vintlv`):**
-
-```
-vintlv(x0Zero2, x1Zero2)
-  OUT: x0Zero = f32(0), f32(1), f32(2), ... f32(127)    ← logical [0..127] contiguous
-       x1Zero = (second 64-lane chunk of interleave; paired with x0Zero for FP8)
-
-vintlv(x0One2, x1One2)
-  OUT: x0One  = f32(128), f32(129), ... f32(255)        ← logical [128..255] contiguous
-       x1One  = (companion chunk)
-```
-
-CCE documents the post-cross-interleave contract explicitly:
-
-```c
-// x0ZeroFP32 + x1ZeroFP32 merge -> first 128 FP32 values (positions 0-127)
-// x0OneFP32  + x1OneFP32  merge -> last 128 FP32 values (positions 128-255)
-vintlv(x0ZeroFP32, x1ZeroFP32, x0ZeroFP32, x1ZeroFP32);
-vintlv(x0OneFP32,  x1OneFP32,  x0OneFP32,  x1OneFP32);
-```
-
-**None of the four `vintlv` ops change numeric values** — they only permute which
-physical lane holds which logical index so the subsequent FP8 path sees
-contiguous 64×f32 chunks.
-
-**Alternative (not used in this example):** keep parity-interleaved f32 through
-multiply and repair at store time with `vstsx2 … INTLV_B32` instead of four
-`vintlv` (Pack-Unpack reference §4.2). The MI demo chooses **repair-then-`PART_P0`**
-because it matches the CCE `ComputeY1ToFP8` FP16 branch structure.
-
-### 3.9 PART_P0 + PK4_B32 — FP8 narrow and store (third layout axis)
-
-After the `vintlv` chain, each 64×f32 register holds **64 contiguous logical
-values**. FP8 output still needs two more physical transforms:
-
-**Narrow (`vcvt {part=P0, rnd=R, sat=SAT}`):** each 32-bit f32 lane group
-receives one 8-bit fp8 value in the **P0 byte** of the lane; P1–P3 bytes zeroed
-(Part_T axis, 4-way sub-part placement):
-
-```
-f32 lane k (32 bits):  [ f32 val ]  →  after P0:  [ fp8(k) | 00 | 00 | 00 ]
-```
-
-**Store (`vsts {dist=PK4_B32}`):** extract the low 8 bits of each 32-bit lane
-and pack four fp8 bytes per 32-bit memory word → **64 fp8 bytes per store**.
-
-The quant loop issues **four** `vcvt` + **four** `vsts PK4_B32` at offsets
-`+0, +64, +128, +192` bytes — one 64-byte chunk per 64 fp8 values, 256 fp8
-total per row. CCE wiring (note the cross-register sources after interleave):
-
-```c
-vcvt(x0ZeroFP8, x0ZeroFP32, pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
-vcvt(x0OneFP8,  x1ZeroFP32, pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
-vcvt(x1ZeroFP8, x0OneFP32,  pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
-vcvt(x1OneFP8,  x1OneFP32,  pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
-vsts(..., PK4_B32, pregB8);  // ×4 with POST_UPDATE / offset bumps
-```
-
-**What `vmi.truncf` + `vmi.masked_store` hide:** rounding mode, saturation,
-part=P0 placement, `ui8` bitcast, PK4 lane extraction, four store addresses, and
-`b8`/`b32` predicate splitting — all derived from the logical
-`vreg<256×f8E4M3>` type and target memory layout.
+Only the first eight scale bytes are meaningful in the default 256-column row;
+the rest are padding/layout material.
 
 ---
 
-## 4. Advantage by stage (ranked)
+## 4. Running Example: f16 to fp8 E4M3
 
-Honest ranking of **VMI syntax / intuitiveness / math closeness** vs MI:
+This is the clearest VMI win. The algorithm is one multiply and one cast; MI and
+CCE spend most of the loop repairing physical layout.
 
-| Rank | Stage | VMI advantage | Why |
-|------|-------|---------------|-----|
-| 1 | **f16 → fp8 E4M3 quant** | **Very large** | MI loop body is ~17 ops; most are layout repair (`DINTLV`, `EVEN/ODD`, `vintlv`, `PK4_B32`). VMI loop body is 5 semantic ops |
-| 2 | **OCP scale (bf16)** | **Large** | Removes dual accumulators, mask-family switching, `vcgmax` opacity, and `vpack`/`vselr` ceremony |
-| 3 | **Outer DMA / tiling shell** | **Small / tie** | Same GM→UB setup, flags, and stride math in all layers |
-
-**Takeaway:** VMI pays off most where **logical width exceeds one physical
-register** or **narrow types require nested part/store choreography**. Block MX
-quant hits both pain points in step 2.
-
----
-
-## 5. Side-by-side: OCP scale (`ComputeOcp_bf16`)
-
-### 5.1 Per-row exponent accumulation
-
-**VMI** — one logical vector, one accumulator:
-
-```mlir
-%xBitsU16 = pto.vmi.load %xAddr[%loadOffset] : ... -> !pto.vmi.vreg<256xui16>
-%xExp = pto.vmi.andi (pto.vmi.bitcast %xBitsU16), %expMaskBF16 : ...
-%nextAcc = pto.vmi.select (pto.vmi.cmpi "slt", %acc, %xExp), %xExp, %acc : ...
-```
-
-**MI** — DINTLV split + dual `vmax`:
-
-```mlir
-%x0Bf16, %x1Bf16 = pto.vldsx2 %xBf[%loadOffset], "DINTLV_B16" : ...
-%x0ExpBF16 = pto.vand %x0Bits, %expMaskBF16, %pregAllB16 : ...
-%x1ExpBF16 = pto.vand %x1Bits, %expMaskBF16, %pregAllB16 : ...
-%nextAcc0 = pto.vmax %acc0, %x0ExpBF16, %pregAllB16 : ...
-%nextAcc1 = pto.vmax %acc1, %x1ExpBF16, %pregAllB16 : ...
-```
-
-**CCE** (`bmx_cce_kernels.h`) — same split as MI:
-
-```c
-vlds(x0Bf16, x1Bf16, xBf, loadOffsetOcp, DINTLV_B16);
-vand(x0ExpBF16, (vector_u16 &)x0Bf16, expMaskBF16, pregAll, MODE_ZEROING);
-vand(x1ExpBF16, (vector_u16 &)x1Bf16, expMaskBF16, pregAll, MODE_ZEROING);
-vmax(expMax1Dim2, expMax1Dim2, x0ExpBF16, pregAll, MODE_ZEROING);
-vmax(expMax2Dim2, expMax2Dim2, x1ExpBF16, pregAll, MODE_ZEROING);
-```
-
-VMI advantage: the algorithm reads as “mask exponent bits, running max over 256
-lanes”. MI/CCE force you to track **even/odd half ownership** from the first
-load.
-
-Instruction-by-instruction:
-
-- `vmi.load` reads the row as `vreg<256×ui16>` so the exponent extraction can be
-  written once over logical lanes. MI starts with `vldsx2 DINTLV_B16`, producing
-  even and odd ownership domains.
-- `vmi.bitcast` changes interpretation from unsigned bits to signed integer
-  lanes without moving data, matching MI `vbitcast`.
-- `vmi.andi` masks with `0x7F80`, keeping bf16 exponent bits `[14:7]`. MI/CCE
-  spell this as `vand` plus an all-lanes b16 predicate.
-- `vmi.cmpi "slt"` produces the predicate `acc < xExp`, and `vmi.select` chooses
-  the new maximum. MI/CCE use `vmax`, which is shorter but less explicit about
-  the comparison/select relation.
-
-**Physical layout note:** the scale path never widens to f32 per element, so it
-does **not** need the four-quadrant `vintlv` chain from §3.8. It still pays the
-**DINTLV load tax**: `acc0` owns exponent maxima for logical indices
-`0,2,4,…,254` and `acc1` for `1,3,5,…,255`. `vcgmax` fuses reduction with
-broadcast only **within each mask family** (`b16`), so the dual-accumulator
-pattern persists until VMI's `group_reduce_maxi` collapses both halves under one
-logical `vreg<256×…>` contract.
-
-### 5.2 Cross-row reduction and scale encoding
-
-**VMI:**
-
-```mlir
-%expMaxScalar32 = pto.vmi.group_reduce_maxi %expMaxRows32, %mask256 {num_groups = 1} : ...
-%expMaxDim32 = pto.vmi.group_broadcast %expMaxScalar32 {num_groups = 1} : ...
-%mxScale1Full = pto.vmi.trunci (pto.vmi.shrui ...) : !pto.vmi.vreg<256xui8>
-```
-
-**MI:**
-
-```mlir
-%expMaxDim0 = pto.vcgmax %expMaxDimPre, %pregAllB16 : ...
-%mxScale1B8 = pto.vpack %mxScaleB16_2, "LOWER" : !pto.vreg<128xi16> -> !pto.vreg<256xui8>
-```
-
-**CCE:**
-
-```c
-vmax(expMaxDim, expMax1Dim2, expMax2Dim2, pregAll, MODE_ZEROING);
-vcgmax(expMaxDim, expMaxDim, pregAll, MODE_ZEROING);
-vshrs(mxScaleB16, expMaxDim, SHR_NUM_FOR_BF16, pregAll, MODE_ZEROING);
-vpack(mxScale1B8, mxScaleB16, LOWER);
-```
-
-VMI makes reduction and narrowing **two explicit semantic steps**
-(`group_reduce_maxi`, `group_broadcast`, `trunci`). MI/CCE fuse reduction with
-broadcast (`vcgmax`) and use hardware pack (`vpack LOWER`) instead of typed
-truncate.
-
-### 5.3 scale2 and reciprocal stores
-
-MI/CCE write scale2 via **gather**:
-
-```c
-vlds(gatherIndex, gatherIndexAddr, 0, NORM);
-vselr(mxScale2B8, mxScale1B8, gatherIndex);
-vsts(mxScale2B8, mxScale2Addr, 0, NORM_B8, pregB8);
-```
-
-VMI stores the fully broadcast scale vector directly when every lane already
-holds the same post-reduction value — the gather becomes a compiler/layout
-detail, not algorithm code.
-
----
-
-## 6. Side-by-side: f16 → fp8 E4M3 quant
-
-This is the clearest VMI win in the MX quant suite.
-
-### 6.1 Loop body size
-
-| Layer | Semantic steps per 256-element row | Layout/repair ops |
-|-------|-----------------------------------|-------------------|
-| **VMI** | 5 (`load`, `extf`, `mulf`, `truncf`, `masked_store`) | 0 explicit |
-| **MI** | 17 total | ~12 (splits, converts, interleaves, bitcasts, PK stores) |
-| **CCE** | same structure as MI | same |
-
-### 6.2 VMI quant path (reads like the math)
+VMI row body:
 
 ```mlir
 %x_f16 = pto.vmi.load %x_ub[%row_off] : ... -> !pto.vmi.vreg<256xf16>
-%x_fp32 = pto.vmi.extf %x_f16 : ... -> !pto.vmi.vreg<256xf32>
-%res_fp32 = pto.vmi.mulf %x_fp32, %scale_fp32 : ...
-%res_fp8 = pto.vmi.truncf %res_fp32 : ... -> !pto.vmi.vreg<256xf8E4M3FN>
-pto.vmi.masked_store %res_fp8, %y_ub[%row_off], %full_mask : ...
+%x_f32 = pto.vmi.extf %x_f16 : ... -> !pto.vmi.vreg<256xf32>
+%scaled = pto.vmi.mulf %x_f32, %scale_f32 : ...
+%y_fp8 = pto.vmi.truncf %scaled : ... -> !pto.vmi.vreg<256xf8E4M3FN>
+pto.vmi.masked_store %y_fp8, %y_ub[%row_off], %mask : ...
 ```
 
-Each line corresponds directly to the row formula `y_i = fp8(x_i * scale_i)`:
+The same row in MI/CCE needs:
 
-- `vmi.load` establishes the logical index contract `[0..255]`.
-- `extf` widens each f16 lane to f32; in MI this is four `vcvt` ops because
-  `DINTLV_B16` and width expansion create four physical streams.
-- `mulf` is the only numerical arithmetic in this stage.
-- `truncf` narrows to FP8 E4M3 with target rounding/saturation rules. MI must
-  spell `rnd=R`, `sat=SAT`, and part placement explicitly.
-- `masked_store` writes the packed fp8 row. MI needs four `PK4_B32` stores at
-  byte offsets `0, 64, 128, 192`.
+1. `DINTLV_B16` load: 256 f16 values become two 128-lane registers.
+2. Four `vcvt {part=EVEN/ODD}`: each 128-lane f16 half becomes two 64-lane f32
+   streams.
+3. Four `vmul` operations: scale each f32 stream.
+4. Four `vintlv` operations: rebuild contiguous logical order.
+5. Four `vcvt {part=P0,rnd=R,sat=SAT}` operations: narrow f32 chunks to FP8.
+6. Four `vbitcast` + `vsts {dist=PK4_B32}` pairs: pack P0 bytes into UB.
 
-### 6.3 MI quant path (same math, hardware vocabulary)
+Physical index flow:
+
+```text
+UB f16 [0..255]
+  -> DINTLV_B16:
+       x0F16 = [0,2,4,...,254]
+       x1F16 = [1,3,5,...,255]
+  -> vcvt EVEN/ODD:
+       [0,4,8,...], [2,6,10,...], [1,5,9,...], [3,7,11,...]
+  -> vmul:
+       same index ownership, scaled
+  -> vintlv repair:
+       contiguous f32 chunks [0..127] and [128..255]
+  -> vcvt P0 + PK4_B32:
+       dense fp8 bytes [0..255]
+```
+
+VMI hides the ownership bookkeeping. It does not make the layout work disappear;
+it moves the work into lowering.
+
+---
+
+## 5. Running Example: OCP Scale
+
+The scale path is less visually dramatic than the quant path, but VMI still
+removes important split-register ceremony.
+
+VMI shape:
 
 ```mlir
-%x0F16, %x1F16 = pto.vldsx2 %xHalf[%blockBase], "DINTLV_B16" : ...
-%x0Zero0 = pto.vcvt %x0F16, %pregAllB16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
-%x0One0  = pto.vcvt %x0F16, %pregAllB16 {part = "ODD"}  : ... -> !pto.vreg<64xf32>
-%x0Zero1 = pto.vmul %x0Zero0, %scaleForMulFP32, %pregAllB32 : ...
-// ... two more vmul, four vintlv, four vcvt {rnd=R, sat=SAT, part=P0},
-//     four vbitcast, four vsts {dist = "PK4_B32"} ...
+%x_bits = pto.vmi.load %xAddr[%load_off] : ... -> !pto.vmi.vreg<256xui16>
+%x_exp = pto.vmi.andi %x_bits, %expMaskBF16 : ...
+%is_larger = pto.vmi.cmpi "slt", %acc, %x_exp : ...
+%acc_next = pto.vmi.select %is_larger, %x_exp, %acc : ...
 ```
 
-### 6.4 CCE reference (FP16 branch excerpt)
+MI/CCE shape:
 
-```c
-vlds(x0F16, x1F16, xHalf, loadStrideY8, DINTLV_B16, POST_UPDATE);
-vcvt(x0ZeroFP32, x0F16, pregAll, PART_EVEN, MODE_ZEROING);
-vcvt(x0OneFP32,  x0F16, pregAll, PART_ODD,  MODE_ZEROING);
-vmul(x0ZeroFP32, x0ZeroFP32, scaleForMulFP32, pregB32, MODE_ZEROING);
-vintlv(x0ZeroFP32, x0OneFP32, x0ZeroFP32, x0OneFP32);
-// ... mirror for x1, cross-vintlv, four vcvt(..., ROUND_R, RS_ENABLE, PART_P0, ...),
-//     four vsts(..., PK4_B32, pregB8)
+```mlir
+%x0, %x1 = pto.vldsx2 %xBf[%load_off], "DINTLV_B16" : ...
+%x0_exp = pto.vand %x0_bits, %expMaskBF16, %pregAllB16 : ...
+%x1_exp = pto.vand %x1_bits, %expMaskBF16, %pregAllB16 : ...
+%acc0 = pto.vmax %acc0, %x0_exp, %pregAllB16 : ...
+%acc1 = pto.vmax %acc1, %x1_exp, %pregAllB16 : ...
 ```
 
-Same story as RoPE interleave, but longer: **the quant algorithm is a multiply
-and a cast**; MI/CCE spend most lines rebuilding **logical index order** after
-every hardware split.
+The math is “extract exponent and take a running max.” MI/CCE must track two
+accumulators because `DINTLV_B16` split the row into even and odd logical
+indices.
 
-### 6.5 End-to-end physical register pipeline (256 f16 row)
+After row accumulation:
 
-The table below tracks **which logical indices** each named register holds after
-each MI/CCE step. This is the ground truth for debugging lane swaps.
+- MI/CCE use `vcgmax` to reduce within grouped lanes and broadcast results.
+- VMI names this as `group_reduce_maxi` plus `group_broadcast`.
+- MI/CCE use `vpack LOWER` for compact E8M0 bytes.
+- VMI names that semantic byte narrowing as `trunci`.
 
-| Step | Instruction(s) | Register | Logical indices held (64 lanes shown as range) |
-|------|----------------|----------|--------------------------------------------------|
-| 0 | *(UB memory)* | — | `[0..255]` contiguous f16 |
-| 1 | `vldsx2 DINTLV_B16` | `x0F16` | `[0,2,4,…,254]` — 128 lanes |
-| 1 | | `x1F16` | `[1,3,5,…,255]` — 128 lanes |
-| 2a | `vcvt EVEN` | `x0Zero0` | `[0,4,8,…,252]` stride 4 |
-| 2b | `vcvt ODD` | `x0One0` | `[2,6,10,…,254]` stride 4 |
-| 2c | `vcvt EVEN` | `x1Zero0` | `[1,5,9,…,253]` stride 4 |
-| 2d | `vcvt ODD` | `x1One0` | `[3,7,11,…,255]` stride 4 |
-| 3 | `vmul` ×4 | same 4 regs | same indices, scaled f32 values |
-| 4a | `vintlv` (intra x0) | `x0Zero2` | `[0,2,4,…,126]` stride 2 |
-| 4a | | `x0One2` | `[128,130,…,254]` stride 2 |
-| 4b | `vintlv` (intra x1) | `x1Zero2` | `[1,3,5,…,125]` stride 2 |
-| 4b | | `x1One2` | `[129,131,…,255]` stride 2 |
-| 5a | `vintlv` (cross, low) | `x0Zero` | **`[0..127]` contiguous** |
-| 5a | | `x1Zero` | companion 64-lane chunk for FP8 path |
-| 5b | `vintlv` (cross, high) | `x0One` | **`[128..255]` contiguous** |
-| 5b | | `x1One` | companion chunk |
-| 6 | `vcvt P0` ×4 | 4× fp8 regs | 64 fp8 each, P0-packed in 256B reg |
-| 7 | `vsts PK4_B32` ×4 | UB | `[0..255]` contiguous fp8 bytes |
-
-Steps 1–5 are **pure layout**; step 3 is the only **algorithm** (`× scale`);
-steps 6–7 are **typed narrow + memory pack**.
-
-### 6.6 Why VMI needs only `extf` and `truncf`
-
-VMI and MI implement the **same row math**. The difference is **where** layout
-is expressed:
-
-| Concern | VMI surface | MI/CCE surface |
-|---------|-------------|----------------|
-| Index contract | `vreg<256×T>` — lane `i` is element `i` | Per-register index map (table above) |
-| Widen f16→f32 | `vmi.extf` | 4× `vcvt {part=EVEN/ODD}` |
-| Repair parity + DINTLV | *(compiler)* | 4× `vintlv` |
-| Narrow f32→fp8 | `vmi.truncf` | 4× `vcvt {part=P0,rnd,sat}` + bitcast |
-| Write fp8 row | `vmi.masked_store` | 4× `vsts {dist=PK4_B32}` |
-
-`extf` is **not** a single hardware widen. It is a **semantic extension** (like
-MLIR `arith.extf`): “for all `i ∈ [0,255]`, produce `f32(x[i])`.” The VMI
-compiler already knows the value arriving from `vmi.load` was DINTLV-split; it
-inserts the four `vcvt`s and, if the next op requires contiguous f32 (`vmi.mulf`
-on a dense 256×f32 scale vector), schedules the four `vintlv`s **between**
-widen and multiply in lowered MI.
-
-Similarly, `truncf` is **not** one `vcvt`. It means “for all `i`, produce
-`fp8_e4m3(f32[i])` with target-default rounding and saturation.” Lowering must
-place each result into P0 slots and emit PK4 stores — work that MI authors write
-by hand.
-
-**Honest boundary:** VMI removes layout **authorship**, not layout **work**.
-Cycle count after lowering is in the same ballpark as a well-written MI kernel;
-the win is correctness and reviewability when logical width exceeds one physical
-register.
-
-### 6.7 Register diagram — MI path vs VMI logical view
-
-**VMI (one logical vector throughout compute):**
-
-```
-UB f16 [0..255]
-        │ vmi.load
-        ▼
-   vreg<256×f16>  logical [0..255]
-        │ vmi.extf                    ┐ compiler lowers to:
-        ▼                             │  4× vcvt EVEN/ODD + 4× vintlv
-   vreg<256×f32>  logical [0..255]    ┘
-        │ vmi.mulf (× scale)
-        ▼
-   vreg<256×f32>  logical [0..255]
-        │ vmi.truncf                  ┐ compiler lowers to:
-        ▼                             │  4× vcvt P0 + 4× vsts PK4_B32
-   vreg<256×fp8>  logical [0..255]    ┘
-        │ vmi.masked_store
-        ▼
-UB fp8 [0..255]
-```
-
-**MI/CCE (four physical registers at peak, explicit repair):**
-
-```
-UB f16 [0..255]
-        │ DINTLV_B16
-        ├──────────────────┬──────────────────
-        ▼                  ▼
-   x0F16 [0,2,4..]    x1F16 [1,3,5..]     ← 2 regs (parity axis)
-        │ EVEN/ODD           │ EVEN/ODD
-        ├────┬────           ├────┬────
-        ▼    ▼               ▼    ▼
-     x0Z0 x0O0            x1Z0 x1O0         ← 4 regs (stride-4)
-        │ vmul×4
-        │ vintlv×2 (intra)   │ vintlv×2
-        ├────┬────           ├────┬────
-        ▼    ▼               ▼    ▼
-     x0Z2 x0O2            x1Z2 x1O2         ← stride-2 within each half
-        │ vintlv×2 (cross low)  │ vintlv×2 (cross high)
-        ▼                     ▼
-     x0Zero [0..127]      x0One [128..255]  ← contiguous f32 (algorithm done)
-        │ vcvt P0 + PK4         │ vcvt P0 + PK4 (×4 total)
-        ▼                     ▼
-UB fp8 [0..255]
-```
-
-### 6.8 Scale vector layout (reciprocal load, same axes)
-
-The quant loop also loads a **bf16 reciprocal scale** vector. MI uses `E2B_B16`
-broadcast distribution + `vbitcast` + `vcvt {part=EVEN}` to obtain a 64×f32
-register usable by all four `vmul`s:
-
-```
-E2B_B16 load  →  128×ui16 in broadcast layout (valid bf16 in EVEN physical lanes)
-vbitcast      →  128×bf16
-vcvt EVEN     →  64×f32 scale (one value per 32-column block, broadcast within lanes)
-```
-
-VMI loads `vreg<256×bf16>` and `vmi.extf` to `vreg<256×f32>`. The compiler
-chooses E2B vs dense load based on how the scale sits in UB; the author only
-writes “widen scale to f32 for multiply.”
-
-When scale lanes are uniform after block reduction (as in the full VMI kernel),
-`vmi.mulf` is a true 256-lane semantic multiply. MI reuses one 64×f32 scale reg
-for four stride-4 streams because **the scale is constant across the four
-parity streams** — but the author must still bind `mask<b32>` on each `vmul`.
-
-### 6.9 MI loop body inventory (17 core ops + store pack)
-
-The MI example comments cite **17 instructions** in the loop body, counting
-main vector ops (`vldsx2`, `vcvt`, `vmul`, `vintlv`) and the four FP8 `vcvt`s,
-but **not** the four `vbitcast` + four `vsts PK4_B32` pairs (those add 8 more
-lines for store typing and pack mode).
-
-| # | MI op | Layout or math? | Physical effect |
-|---|-------|-------------------|-----------------|
-| 1 | `vldsx2 DINTLV_B16` | Layout | Split 256 f16 → 2×128 parity regs |
-| 2–5 | `vcvt EVEN/ODD` ×2 + `vmul` ×2 on x0 | Widen + **math** | x0 → 2×64 f32 stride-4, scaled |
-| 6 | `vintlv` (intra x0) | Layout | x0 stride-4 → stride-2 within even half |
-| 7–10 | `vcvt EVEN/ODD` ×2 + `vmul` ×2 on x1 | Widen + **math** | x1 → 2×64 f32 stride-4, scaled |
-| 11 | `vintlv` (intra x1) | Layout | x1 stride-4 → stride-2 within odd half |
-| 12–13 | `vintlv` ×2 (cross) | Layout | Merge halves → `[0..127]`, `[128..255]` f32 |
-| 14–17 | `vcvt {P0,rnd,sat}` ×4 | Narrow (**math** + Part_T) | 64 f32 → P0-packed fp8 reg each |
-| +8 | `vbitcast` + `vsts PK4_B32` ×4 | Layout | Extract P0 bytes → contiguous UB fp8 |
-
-VMI collapses rows 1–6 and 7–13 into `load` + `extf`, rows 14–17 and the +8
-store pack into `truncf` + `masked_store`, leaving one `mulf` as the only
-visible arithmetic.
+The scale path does not need the four-stream f32 `vintlv` repair from the quant
+path, because it stays in b16 integer/exponent fields.
 
 ---
 
-## 7. What VMI does *not* simplify
+## 6. Debug Appendix: Physical Rules
 
-Be explicit about remaining low-level work:
+Use this section when inspecting lowered MI or comparing against the CCE comments
+in `bmx_cce_kernels.h`.
 
-| Concern | Still visible in VMI examples? |
-|---------|-------------------------------|
-| Row/block loop structure | **Yes** — `scf.for` over rows or blocks |
-| `vlForHalfNumber`, `ubBlockSize`, stride products | **Yes** |
-| Special-case scale math (Inf/NaN/zero/clamp) | **Yes** — still authored, just without per-op masks |
-| DMA GM↔UB, pipeline `set_flag` / `wait_flag` | **Yes** in the full VMI kernel wrapper |
-| FP16 scale path inside `ComputeOcp` | **Not in bf16 demo** — production CCE still has FP16-only Inf/NaN handling before widen |
-| Verifying PK4 lane placement | **Harder from VMI source** — use lowered MI or CCE sim when debugging store artifacts |
+### 256-Byte Register Model
+
+| Quantity | Bytes | Physical consequence |
+|----------|-------|----------------------|
+| 128 x f16/bf16/ui16 | 256 B | fits one b16 register |
+| 256 x f16/bf16/ui16 | 512 B | needs split load or two registers |
+| 64 x f32 | 256 B | fits one b32 register |
+| 256 x f32 | 1024 B | four f32 registers at peak |
+| 256 x fp8 bytes | 256 B | fits after P0 placement and PK4 packing |
+
+### DINTLV_B16
+
+`DINTLV_B16` loads one 256-element b16 row into two registers:
+
+```text
+x0: [x0, x2, x4, ..., x254]
+x1: [x1, x3, x5, ..., x255]
+```
+
+Everything downstream must remember which register owns which logical indices.
+VMI records that ownership in layout metadata instead of source variable names.
+
+### PART_EVEN / PART_ODD
+
+Widening 128 f16 values to f32 doubles byte size, so each source register splits
+again:
+
+```text
+x0F16 logical indices: [0,2,4,6,...]
+vcvt EVEN -> [0,4,8,...]
+vcvt ODD  -> [2,6,10,...]
+```
+
+The same happens to `x1F16`, yielding four f32 streams at stride 4.
+
+### vintlv Repair
+
+`vintlv` merges lane streams to restore contiguous logical chunks. The f16→fp8
+path uses two intra-half interleaves and two cross-half interleaves before FP8
+conversion. These operations do not change values; they only repair lane order.
+
+### PART_P0 and PK4_B32
+
+FP8 conversion writes the 8-bit result into the P0 byte of each 32-bit lane:
+
+```text
+f32 lane -> [fp8_byte, 0, 0, 0]
+```
+
+`PK4_B32` stores extract those P0 bytes densely. The quant row uses four
+64-byte stores at offsets `0`, `64`, `128`, and `192`.
+
+### E2B_B16 Scale Load
+
+The reciprocal scale is stored as bf16 exponent fields. MI loads it with
+`E2B_B16`, bitcasts to bf16, and widens with `PART_EVEN`. VMI expresses this as
+logical `load` plus `extf`; lowering chooses the broadcast distribution.
+
+### Common Bugs VMI Helps Avoid
+
+- forgetting one `vintlv` repair and producing a permuted but byte-valid row
+- using the wrong `part` for FP8 conversion
+- using the wrong `PK4_B32` store offset
+- mixing `b16`, `b32`, and `b8` masks in the quant loop
+- treating `vcgmax` as an ordinary max instead of a grouped reduction/broadcast
 
 ---
 
-## 8. Practical guidance
+## 7. Practical Guidance
 
 | Task | Prefer |
 |------|--------|
-| Author or review MX scale + quant math | **VMI** |
-| Bit-exact compare against CCE sim / intrinsics golden | **MI** or **`bmx_cce_kernels.h`** |
-| Debug wrong FP8 lanes / PK offsets / padding | Lowered **MI** (VMI hides the failure point) |
-| Learn DINTLV + part + PK rules hands-on | **MI** + `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` |
+| Author or review scale and quant math | **VMI** |
+| Verify bit-exact behavior against intrinsics | **CCE** or lowered **MI** |
+| Debug lane permutations or packed stores | Lowered **MI** plus CCE comments |
+| Learn DINTLV/part/PK rules | MI examples and Pack/Unpack reference |
 
-**Review checklist for VMI MX quant code:**
+Review checklist for VMI MX quant:
 
-1. Confirm the logical vector width matches the row contract (`256` lanes for
-   the covered scale and quant bodies).
-2. Confirm scale math still spells special cases explicitly: Inf/NaN, zero,
-   clamp/range handling, and reciprocal edge cases.
-3. Confirm dtype transitions match the intended stage: `extf` before fp32
-   multiply, `truncf` for FP8/FP4 output, and `trunci` for compact scale bytes.
-4. Inspect lowered MI for the expected `DINTLV_B16` split, `PART_EVEN/ODD`
-   widen, `vintlv` repair, `PART_P0` FP8 cast, and four `PK4_B32` stores on the
-   f16→fp8 path.
-5. Compare against `bmx_cce_kernels.h` when debugging: start at the
-   `Expected UB effect` block, then the register allocation and phase comments
-   for `ComputeOcp`, `ComputeDdr`, `ComputeY1ToFP4`, or `ComputeY1ToFP8`.
+1. Logical vector width matches the row shape (`256` lanes).
+2. Scale math still spells Inf/NaN, zero, clamp, and reciprocal edge cases.
+3. `extf` appears before fp32 multiply; `truncf` handles FP8/FP4 output;
+   `trunci` handles compact scale bytes.
+4. Lowered MI for f16→fp8 has the expected `DINTLV_B16`, `PART_EVEN/ODD`,
+   `vintlv`, `PART_P0`, and four `PK4_B32` stores.
+5. For CCE comparison, start from the `Expected UB effect` block and then read
+   the register allocation and phase comments in `ComputeOcp`, `ComputeDdr`,
+   `ComputeY1ToFP4`, or `ComputeY1ToFP8`.
 
-**Suggested reading order:**
+Suggested reading order:
 
-1. Section 1 of this doc (math)
-2. **§3.5–§3.9** (physical register model — read before MI/CCE examples)
-3. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` — best “before/after” showcase
-4. **§6.5–§6.9** (quant pipeline index map + VMI vs MI diagrams)
-5. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` — see what VMI removed
-6. `mx_block_quant_scale_ocp_bf16.vmi.pto` vs `.mi.pto` — scale path
-7. `bmx_cce_kernels.h` `ComputeOcp` / `ComputeY1ToFP8` — annotated ground truth
-8. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` — full layout taxonomy
+1. Section 1 for math.
+2. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto`.
+3. Section 4 here for the quant lowering shape.
+4. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto`.
+5. `mx_block_quant_scale_ocp_bf16.vmi.pto` and `.mi.pto`.
+6. `bmx_cce_kernels.h` `ComputeOcp` and `ComputeY1ToFP8`.
+7. Section 6 here when debugging physical lanes.
+8. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`.
 
 ---
 
-## 9. One-page summary
-
-| Question | Answer |
-|----------|--------|
-| Same MX semantics? | **Yes**, for the covered bf16 scale + f16→E4M3 quant paths |
-| Cleaner syntax? | **Yes** — largest on quant loop bodies, large on scale compute |
-| Closer to math? | **Yes** — VMI keeps “max exponent → scale → multiply → cast” visible |
-| Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling |
-| Biggest win? | **f16→fp8 quant**, where MI spends most lines on layout repair |
-| Why `extf`/`truncf` vs `vintlv`? | VMI ops preserve **logical index `i`**; MI `vintlv` repairs **physical lane placement** after DINTLV + PART widen (§3.6–§3.9, §6.5–§6.7) |
-
-VMI is not “MX quant in five lines.” It is **MX quant with the split/part/PK
-contract moved into the compiler** — most valuable exactly where block quant
-touches **256-wide logical tiles**, **mixed precisions**, and **sub-byte output
-packing**.
-
----
-
-## Example file index
+## Example File Index
 
 | File | Layer | Stage | Notes |
 |------|-------|-------|-------|
-| `mx_block_quant_scale_ocp_bf16.vmi.pto` | VMI | Scale (OCP) | 256-wide vectors, explicit group reduce/broadcast |
-| `mx_block_quant_scale_ocp_bf16.mi.pto` | MI | Scale (OCP) | DINTLV + dual accumulators + `vcgmax` + `vpack` |
-| `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` | VMI | Quant | Full kernel with DMA; **best VMI demo** |
-| `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` | MI | Quant | 17-op loop body, CCE-faithful layout |
-| `bmx_cce_kernels.h` | CCE | Both | `ComputeOcp`, `ComputeY1ToFP8` ground truth |
+| `mx_block_quant_scale_ocp_bf16.vmi.pto` | VMI | Scale | Logical 256-lane exponent/reduction flow |
+| `mx_block_quant_scale_ocp_bf16.mi.pto` | MI | Scale | DINTLV split, dual accumulators, `vcgmax`, `vpack` |
+| `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` | VMI | Quant | Best MX VMI demo |
+| `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` | MI | Quant | CCE-faithful split/part/vintlv/PK path |
+| `bmx_cce_kernels.h` | CCE | Both | Intrinsics ground truth |
 
 Related docs:
 
-- `ROPE_VMI_vs_MI.md` — same three-layer comparison pattern on RoPE
+- `ROPE_VMI_vs_MI.md`
 - `PTO-Gym-vmi/docs/PTO-vmi-design.en.md`
 - `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
+- `PTO-Gym-vmi/docs/PTO-micro-Instruction-SPEC.md`

--- a/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
+++ b/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
@@ -1,0 +1,357 @@
+# Block MX Quant on PTO: Why VMI Helps Algorithm Engineers
+
+This note compares the block MX quantization example kernels in this directory
+across three expression layers. The examples cover the two main compute stages
+of OCP Microscaling (MX) block quantization:
+
+| Layer | Example files | Who it is for |
+|-------|---------------|---------------|
+| **CCE** | `bmx_cce_kernels.h` | Ground-truth intrinsics execution |
+| **MI** (`pto.mi`) | `mx_block_quant_scale_ocp_bf16.mi.pto`, `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` | Hardware-faithful PTO micro-ops |
+| **VMI** (`pto.vmi`) | `mx_block_quant_scale_ocp_bf16.vmi.pto`, `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` | Logical-vector authoring |
+
+**Audience:** algorithm engineers implementing or reviewing MX block quant who
+want scale math and quant math visible in code, without hand-managing DINTLV
+splits, part selection, mask families, or store packing modes.
+
+**Scope:** two paired demos on a fixed tile shape — **256 half-precision
+elements per row**, **32-element column blocks**, OCP scale path on **bf16**
+input, and **f16 → fp8 E4M3** quant execution using a precomputed reciprocal
+scale. DMA shells differ between the full-kernel VMI quant example and the
+compute-only MI/CCE excerpts; this doc focuses on the **vector compute bodies**.
+
+This document is intentionally honest: VMI is a large win on the quant path and
+a solid win on scale computation, but it does not remove tiling, stride math, or
+pipeline synchronization.
+
+---
+
+## 1. Block MX quant math (what both stages implement)
+
+OCP MX block quantization processes input `X` in **32×32 element super-blocks**
+(32 columns × 32 rows). Each super-block shares one **scale1** (E8M0, `uint8`)
+and produces a **reciprocal scale** used to normalize values before casting to
+FP8/FP4.
+
+### 1.1 Step 1 — shared scale (`ComputeOcp`)
+
+For each 32-element column group inside the super-block:
+
+```
+max_exp = max( biased_exponent(x_i) )     // over all rows and lanes in the block
+scale1  = encode_E8M0( clamp(max_exp - emax_target) )
+recip   = bias - max_exp                  // bf16 exponent field for dequant in step 2
+```
+
+Special cases handled in all three layers:
+
+- **Inf/NaN block** → scale1 = `0xFF`, reciprocal → custom NaN pattern
+- **All-zero block** → scale1 = 0, reciprocal = 0
+- **Exponent below representable range** → clamp to `yMaxExp` before encoding
+- **Subnormal reciprocal edge** → substitute a special exponent threshold
+
+The bf16 demo (`ComputeOcp_bf16`) extracts exponents with `x & 0x7F80`, reduces
+across rows, then writes **scale1**, **scale2** (interleaved layout), and
+**reciprocal** to UB.
+
+### 1.2 Step 2 — quantize to FP8 (`ComputeY1ToFP8`, f16 path)
+
+For each row of 256 f16 elements:
+
+```
+y_i = quant_fp8( widen_f32(x_i) * widen_f32(reciprocal_scale) )
+```
+
+The f16 demo uses **fp32 intermediate arithmetic** before narrowing to **fp8
+E4M3** with round-nearest-even and saturation — matching the CCE reference
+(`ComputeY1ToFP8`, FP16 branch).
+
+---
+
+## 2. What VMI actually is
+
+VMI (`pto.vmi`) sits between your algorithm and MI (`pto.mi`). You write
+**logical contiguous vectors** (`!pto.vmi.vreg<N×T>`) and **semantic ops**
+(`vmi.load`, `vmi.extf`, `vmi.mulf`, `vmi.truncf`, `group_reduce_maxi`, …).
+The compiler lowers to MI with the correct `dist`, `part`, `PK/UNPK`, and mask
+granularity.
+
+See `PTO-Gym-vmi/docs/PTO-vmi-design.en.md` and
+`PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
+for the underlying layout rules VMI hides.
+
+**VMI removes:** DINTLV even/odd register splitting, dual accumulators caused
+by that split, per-op mask plumbing, explicit `part`/`rnd`/`sat` on every
+convert, and multi-store PK packing choreography.
+
+**VMI does not remove:** row/block loop nesting, UB stride math, gather-index
+setup at the API boundary, DMA, or pipeline flags.
+
+---
+
+## 3. Instruction map: math → CCE → MI → VMI
+
+| Math intent | CCE intrinsic | MI (`pto.mi`) | VMI (`pto.vmi`) |
+|-------------|---------------|---------------|-----------------|
+| Load 256 half-precision elements | `vlds` (`DINTLV_B16`) | `pto.vldsx2` + `"DINTLV_B16"` | `pto.vmi.load` → `vreg<256×T>` |
+| Broadcast scalar constants | `vbr` | `pto.vbr` → `vreg<128×T>` | `pto.vmi.broadcast` → `vreg<256×T>` |
+| Extract bf16 exponent field | `vand` (`MODE_ZEROING` + mask) | `pto.vand` + `!pto.mask<b16>` | `pto.vmi.andi` (no mask) |
+| Running max over exponents | `vmax` (`MODE_ZEROING` + mask) | `pto.vmax` + mask; **two accumulators** for even/odd halves | `pto.vmi.cmpi` + `pto.vmi.select` (single accumulator) |
+| Cross-lane block max | `vcgmax` (`MODE_ZEROING` + mask) | `pto.vcgmax` (reduce + broadcast fused) | `pto.vmi.group_reduce_maxi` + `pto.vmi.group_broadcast` |
+| Compare + conditional replace | `vcmp` + `vsel` | `pto.vcmp` + `pto.vsel` + mask | `pto.vmi.cmpi` + `pto.vmi.select` |
+| Shift exponent diff → E8M0 | `vshrs` (`MODE_ZEROING` + mask) | `pto.vshrs` + mask | `pto.vmi.shrui` |
+| Pack scale bytes | `vpack` (`LOWER`) | `pto.vpack` `"LOWER"` | `pto.vmi.trunci` |
+| Gather scale2 layout | `vlds` (`NORM`) + `vselr` | same | direct `pto.vmi.store` when lanes are uniform after broadcast |
+| Store scale / reciprocal | `vsts` (`NORM_B8` / `NORM_B16` + mask) | `pto.vsts` + `{dist}` + mask | `pto.vmi.store` / `pto.vmi.masked_store` |
+| Load reciprocal scale | `vlds` (`E2B_B16`) | `pto.vlds` `{dist = "E2B_B16"}` + `vbitcast` + `vcvt {part=EVEN}` | `pto.vmi.load` + `pto.vmi.extf` |
+| Widen f16/bf16 → f32 | `vcvt` (`PART_EVEN` / `PART_ODD`, `MODE_ZEROING`) | 4× `pto.vcvt` after DINTLV split | `pto.vmi.extf` |
+| Scale multiply in fp32 | `vmul` (`MODE_ZEROING` + mask) | 4× `pto.vmul` + `!pto.mask<b32>` | `pto.vmi.mulf` |
+| Re-order after widen | `vintlv` | 4× `pto.vintlv` to rebuild P0–P3 layout | *(compiler)* |
+| Narrow f32 → fp8 E4M3 | `vcvt` (`ROUND_R`, `RS_ENABLE`, `PART_P0`, `MODE_ZEROING`) | 4× `pto.vcvt` + `vbitcast` + 4× `pto.vsts` `{dist=PK4_B32}` | `pto.vmi.truncf` + `pto.vmi.masked_store` |
+| Tail / active lanes | `pset` / `plt_b16` / `plt_b32` / `plt_b8` | `pto.pset_b16` / `pset_b32` / `pset_b8` / `pge_*` | `pto.vmi.create_mask` |
+
+### 3.1 MI details algorithm engineers should not have to memorize
+
+These are the hardware subtleties VMI is designed to hide in MX quant:
+
+**DINTLV_B16 load:** 256 half-precision elements in UB become **two 128-lane
+physical registers** — even indices in one register, odd indices in the other.
+Every subsequent op must reason about which half owns which logical index.
+
+**Nested part selection:** after DINTLV, widening f16→f32 splits **each** half
+again into `PART_EVEN` and `PART_ODD`, yielding **four** fp32 streams. The MI
+quant loop then uses multiple `vintlv` steps to rebuild an order compatible
+with `PART_P0` FP8 packing.
+
+**E2B_B16 scale load:** reciprocal scales are loaded with a broadcast
+distribution; valid bf16 lanes sit in a specific layout. MI must `vbitcast` and
+`vcvt {part=EVEN}` before use.
+
+**PK4_B32 store:** FP8 output requires four packed stores with 64-byte offsets.
+Each store needs `vbitcast` to `ui8` and a `b32`/`b8` mask pairing.
+
+**Mask family mismatch:** scale computation mixes `!pto.mask<b16>` (compute) with
+`!pto.mask<b8>` (scale1 store) and `!pto.mask<b16>` (reciprocal store). Quant
+mixes `b16`, `b32`, and `b8` in one loop body.
+
+VMI replaces these with “load 256 f16”, “extend to fp32”, “multiply”, “truncate
+to fp8”, and “store”.
+
+---
+
+## 4. Advantage by stage (ranked)
+
+Honest ranking of **VMI syntax / intuitiveness / math closeness** vs MI:
+
+| Rank | Stage | VMI advantage | Why |
+|------|-------|---------------|-----|
+| 1 | **f16 → fp8 E4M3 quant** | **Very large** | MI loop body is ~17 ops; most are layout repair (`DINTLV`, `EVEN/ODD`, `vintlv`, `PK4_B32`). VMI loop body is 5 semantic ops |
+| 2 | **OCP scale (bf16)** | **Large** | Removes dual accumulators, mask-family switching, `vcgmax` opacity, and `vpack`/`vselr` ceremony |
+| 3 | **Outer DMA / tiling shell** | **Small / tie** | Same GM→UB setup, flags, and stride math in all layers |
+
+**Takeaway:** VMI pays off most where **logical width exceeds one physical
+register** or **narrow types require nested part/store choreography**. Block MX
+quant hits both pain points in step 2.
+
+---
+
+## 5. Side-by-side: OCP scale (`ComputeOcp_bf16`)
+
+### 5.1 Per-row exponent accumulation
+
+**VMI** — one logical vector, one accumulator:
+
+```mlir
+%xBitsU16 = pto.vmi.load %xAddr[%loadOffset] : ... -> !pto.vmi.vreg<256xui16>
+%xExp = pto.vmi.andi (pto.vmi.bitcast %xBitsU16), %expMaskBF16 : ...
+%nextAcc = pto.vmi.select (pto.vmi.cmpi "slt", %acc, %xExp), %xExp, %acc : ...
+```
+
+**MI** — DINTLV split + dual `vmax`:
+
+```mlir
+%x0Bf16, %x1Bf16 = pto.vldsx2 %xBf[%loadOffset], "DINTLV_B16" : ...
+%x0ExpBF16 = pto.vand %x0Bits, %expMaskBF16, %pregAllB16 : ...
+%x1ExpBF16 = pto.vand %x1Bits, %expMaskBF16, %pregAllB16 : ...
+%nextAcc0 = pto.vmax %acc0, %x0ExpBF16, %pregAllB16 : ...
+%nextAcc1 = pto.vmax %acc1, %x1ExpBF16, %pregAllB16 : ...
+```
+
+**CCE** (`bmx_cce_kernels.h`) — same split as MI:
+
+```c
+vlds(x0Bf16, x1Bf16, xBf, loadOffsetOcp, DINTLV_B16);
+vand(x0ExpBF16, (vector_u16 &)x0Bf16, expMaskBF16, pregAll, MODE_ZEROING);
+vand(x1ExpBF16, (vector_u16 &)x1Bf16, expMaskBF16, pregAll, MODE_ZEROING);
+vmax(expMax1Dim2, expMax1Dim2, x0ExpBF16, pregAll, MODE_ZEROING);
+vmax(expMax2Dim2, expMax2Dim2, x1ExpBF16, pregAll, MODE_ZEROING);
+```
+
+VMI advantage: the algorithm reads as “mask exponent bits, running max over 256
+lanes”. MI/CCE force you to track **even/odd half ownership** from the first
+load.
+
+### 5.2 Cross-row reduction and scale encoding
+
+**VMI:**
+
+```mlir
+%expMaxScalar32 = pto.vmi.group_reduce_maxi %expMaxRows32, %mask256 {num_groups = 1} : ...
+%expMaxDim32 = pto.vmi.group_broadcast %expMaxScalar32 {num_groups = 1} : ...
+%mxScale1Full = pto.vmi.trunci (pto.vmi.shrui ...) : !pto.vmi.vreg<256xui8>
+```
+
+**MI:**
+
+```mlir
+%expMaxDim0 = pto.vcgmax %expMaxDimPre, %pregAllB16 : ...
+%mxScale1B8 = pto.vpack %mxScaleB16_2, "LOWER" : !pto.vreg<128xi16> -> !pto.vreg<256xui8>
+```
+
+**CCE:**
+
+```c
+vmax(expMaxDim, expMax1Dim2, expMax2Dim2, pregAll, MODE_ZEROING);
+vcgmax(expMaxDim, expMaxDim, pregAll, MODE_ZEROING);
+vshrs(mxScaleB16, expMaxDim, SHR_NUM_FOR_BF16, pregAll, MODE_ZEROING);
+vpack(mxScale1B8, mxScaleB16, LOWER);
+```
+
+VMI makes reduction and narrowing **two explicit semantic steps**
+(`group_reduce_maxi`, `group_broadcast`, `trunci`). MI/CCE fuse reduction with
+broadcast (`vcgmax`) and use hardware pack (`vpack LOWER`) instead of typed
+truncate.
+
+### 5.3 scale2 and reciprocal stores
+
+MI/CCE write scale2 via **gather**:
+
+```c
+vlds(gatherIndex, gatherIndexAddr, 0, NORM);
+vselr(mxScale2B8, mxScale1B8, gatherIndex);
+vsts(mxScale2B8, mxScale2Addr, 0, NORM_B8, pregB8);
+```
+
+VMI stores the fully broadcast scale vector directly when every lane already
+holds the same post-reduction value — the gather becomes a compiler/layout
+detail, not algorithm code.
+
+---
+
+## 6. Side-by-side: f16 → fp8 E4M3 quant
+
+This is the clearest VMI win in the MX quant suite.
+
+### 6.1 Loop body size
+
+| Layer | Semantic steps per 256-element row | Layout/repair ops |
+|-------|-----------------------------------|-------------------|
+| **VMI** | 5 (`load`, `extf`, `mulf`, `truncf`, `masked_store`) | 0 explicit |
+| **MI** | 17 total | ~12 (splits, converts, interleaves, bitcasts, PK stores) |
+| **CCE** | same structure as MI | same |
+
+### 6.2 VMI quant path (reads like the math)
+
+```mlir
+%x_f16 = pto.vmi.load %x_ub[%row_off] : ... -> !pto.vmi.vreg<256xf16>
+%x_fp32 = pto.vmi.extf %x_f16 : ... -> !pto.vmi.vreg<256xf32>
+%res_fp32 = pto.vmi.mulf %x_fp32, %scale_fp32 : ...
+%res_fp8 = pto.vmi.truncf %res_fp32 : ... -> !pto.vmi.vreg<256xf8E4M3FN>
+pto.vmi.masked_store %res_fp8, %y_ub[%row_off], %full_mask : ...
+```
+
+### 6.3 MI quant path (same math, hardware vocabulary)
+
+```mlir
+%x0F16, %x1F16 = pto.vldsx2 %xHalf[%blockBase], "DINTLV_B16" : ...
+%x0Zero0 = pto.vcvt %x0F16, %pregAllB16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
+%x0One0  = pto.vcvt %x0F16, %pregAllB16 {part = "ODD"}  : ... -> !pto.vreg<64xf32>
+%x0Zero1 = pto.vmul %x0Zero0, %scaleForMulFP32, %pregAllB32 : ...
+// ... two more vmul, four vintlv, four vcvt {rnd=R, sat=SAT, part=P0},
+//     four vbitcast, four vsts {dist = "PK4_B32"} ...
+```
+
+### 6.4 CCE reference (FP16 branch excerpt)
+
+```c
+vlds(x0F16, x1F16, xHalf, loadStrideY8, DINTLV_B16, POST_UPDATE);
+vcvt(x0ZeroFP32, x0F16, pregAll, PART_EVEN, MODE_ZEROING);
+vcvt(x0OneFP32,  x0F16, pregAll, PART_ODD,  MODE_ZEROING);
+vmul(x0ZeroFP32, x0ZeroFP32, scaleForMulFP32, pregB32, MODE_ZEROING);
+vintlv(x0ZeroFP32, x0OneFP32, x0ZeroFP32, x0OneFP32);
+// ... mirror for x1, cross-vintlv, four vcvt(..., ROUND_R, RS_ENABLE, PART_P0, ...),
+//     four vsts(..., PK4_B32, pregB8)
+```
+
+Same story as RoPE interleave, but longer: **the quant algorithm is a multiply
+and a cast**; MI/CCE spend most lines rebuilding **logical index order** after
+every hardware split.
+
+---
+
+## 7. What VMI does *not* simplify
+
+Be explicit about remaining low-level work:
+
+| Concern | Still visible in VMI examples? |
+|---------|-------------------------------|
+| Row/block loop structure | **Yes** — `scf.for` over rows or blocks |
+| `vlForHalfNumber`, `ubBlockSize`, stride products | **Yes** |
+| Special-case scale math (Inf/NaN/zero/clamp) | **Yes** — still authored, just without per-op masks |
+| DMA GM↔UB, pipeline `set_flag` / `wait_flag` | **Yes** in the full VMI kernel wrapper |
+| FP16 scale path inside `ComputeOcp` | **Not in bf16 demo** — production CCE still has FP16-only Inf/NaN handling before widen |
+| Verifying PK4 lane placement | **Harder from VMI source** — use lowered MI or CCE sim when debugging store artifacts |
+
+---
+
+## 8. Practical guidance
+
+| Task | Prefer |
+|------|--------|
+| Author or review MX scale + quant math | **VMI** |
+| Bit-exact compare against CCE sim / intrinsics golden | **MI** or **`bmx_cce_kernels.h`** |
+| Debug wrong FP8 lanes / PK offsets / padding | Lowered **MI** (VMI hides the failure point) |
+| Learn DINTLV + part + PK rules hands-on | **MI** + `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` |
+
+**Suggested reading order:**
+
+1. Section 1 of this doc (math)
+2. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` — best “before/after” showcase
+3. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` — see what VMI removed
+4. `mx_block_quant_scale_ocp_bf16.vmi.pto` vs `.mi.pto` — scale path
+5. `bmx_cce_kernels.h` `ComputeOcp` / `ComputeY1ToFP8` — annotated ground truth
+
+---
+
+## 9. One-page summary
+
+| Question | Answer |
+|----------|--------|
+| Same MX semantics? | **Yes**, for the covered bf16 scale + f16→E4M3 quant paths |
+| Cleaner syntax? | **Yes** — largest on quant loop bodies, large on scale compute |
+| Closer to math? | **Yes** — VMI keeps “max exponent → scale → multiply → cast” visible |
+| Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling |
+| Biggest win? | **f16→fp8 quant**, where MI spends most lines on layout repair |
+
+VMI is not “MX quant in five lines.” It is **MX quant with the split/part/PK
+contract moved into the compiler** — most valuable exactly where block quant
+touches **256-wide logical tiles**, **mixed precisions**, and **sub-byte output
+packing**.
+
+---
+
+## Example file index
+
+| File | Layer | Stage | Notes |
+|------|-------|-------|-------|
+| `mx_block_quant_scale_ocp_bf16.vmi.pto` | VMI | Scale (OCP) | 256-wide vectors, explicit group reduce/broadcast |
+| `mx_block_quant_scale_ocp_bf16.mi.pto` | MI | Scale (OCP) | DINTLV + dual accumulators + `vcgmax` + `vpack` |
+| `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` | VMI | Quant | Full kernel with DMA; **best VMI demo** |
+| `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` | MI | Quant | 17-op loop body, CCE-faithful layout |
+| `bmx_cce_kernels.h` | CCE | Both | `ComputeOcp`, `ComputeY1ToFP8` ground truth |
+
+Related docs:
+
+- `ROPE_VMI_vs_MI.md` — same three-layer comparison pattern on RoPE
+- `PTO-Gym-vmi/docs/PTO-vmi-design.en.md`
+- `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`

--- a/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
+++ b/docs/examples/vmi/BLOCK_MX_QUANT_VMI_vs_MI.md
@@ -137,6 +137,191 @@ mixes `b16`, `b32`, and `b8` in one loop body.
 VMI replaces these with “load 256 f16”, “extend to fp32”, “multiply”, “truncate
 to fp8”, and “store”.
 
+### 3.2 Physical register model (the 256-byte contract)
+
+Every A5 vector register is **256 bytes (2048 bits)** wide. That single fact
+drives almost all layout ceremony in block MX quant.
+
+| Quantity | Bytes needed | Fits in one 256B reg? |
+|----------|-------------|------------------------|
+| 128 × f16 / bf16 | 256 B | **Yes** (128 b16 lanes) |
+| 256 × f16 / bf16 | 512 B | **No** → need 2 regs or a split load |
+| 64 × f32 | 256 B | **Yes** (64 b32 lanes) |
+| 128 × f32 | 512 B | **No** → need 2 regs after widen |
+| 256 × f32 | 1024 B | **No** → need 4 regs at peak |
+| 256 × fp8 (packed in UB) | 256 B | **Yes**, but only after `PK4_B32` store packing |
+
+**Logical view (VMI):** you hold `N` elements of type `T` in index order
+`0, 1, 2, …, N−1`. The type system (`!pto.vmi.vreg<256×f16>`) promises that
+contract regardless of how many physical registers exist underneath.
+
+**Physical view (MI/CCE):** each instruction names **concrete registers** with
+**lane-granular placement rules**. A lane is not “logical index `i`” until you
+have explicitly loaded, split, widened, interleaved, and packed it into the
+right slot. Layout ops (`DINTLV`, `part=`, `vintlv`, `PK4_B32`) exist only to
+maintain or restore that index mapping.
+
+See `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
+§1–§2 for the full taxonomy. The MX quant examples exercise three layout axes:
+
+| Axis | Mechanism | What it splits or merges |
+|------|-----------|--------------------------|
+| **Width** | `vcvt` + `part=EVEN/ODD` | One 128×f16 reg → two 64×f32 regs (2× widen) |
+| **Parity** | `DINTLV_B16` load, `vintlv` | Even/odd **logical** indices into separate regs |
+| **Sub-byte pack** | `vcvt {part=P0}` + `PK4_B32` | One f32 lane → one fp8 byte in memory |
+
+VMI `extf` / `truncf` follow MLIR `arith` naming: they mean **“change element
+type, preserve logical index `i`.”** They do **not** mean the hardware performs
+one instruction. The compiler lowers them to the `vcvt` / `vintlv` / `vsts`
+sequence appropriate for the assigned physical layout.
+
+### 3.3 DINTLV load — first split (256 f16 → 2×128 f16)
+
+UB memory holds one quant row as **256 contiguous f16**:
+
+```
+Memory (logical):  x[0] x[1] x[2] x[3] x[4] x[5] ... x[254] x[255]
+                   └── 512 bytes ──┘
+```
+
+`DINTLV_B16` load (`vldsx2` / `vlds … DINTLV_B16`) cannot fit 512 B into one
+256 B register, so it **deinterleaves by logical parity** at load time:
+
+```
+x0F16 (128 lanes, 256 B):  x[0]  x[2]  x[4]  x[6]  ... x[252] x[254]
+                            phys lane k  ←→  logical index 2k
+
+x1F16 (128 lanes, 256 B):  x[1]  x[3]  x[5]  x[7]  ... x[253] x[255]
+                            phys lane k  ←→  logical index 2k+1
+```
+
+**Why load splits instead of loading 128 elements twice?** A normal `NORM` load
+only fills one register. To process 256 elements without scalar loops, the
+hardware exposes **split-load distribution modes** that populate two registers in
+one memory transaction while respecting the 256 B cap.
+
+From this point on, MI/CCE authors must track **two ownership domains**:
+everything in `x0F16` is an even logical index; everything in `x1F16` is odd.
+
+VMI `vmi.load` returns `vreg<256×f16>` — the split still happens in lowered
+MI, but the VMI type + layout metadata record the inverse map
+(`even_reg[k]→2k`, `odd_reg[k]→2k+1`).
+
+### 3.4 PART_EVEN / PART_ODD widen — second split (each 128×f16 → 2×64×f32)
+
+Widen f16→f32 doubles element width: 128 f16 (256 B) → 128 f32 (512 B). The
+hardware writes widened results into **two 64×f32 registers** using part
+selection on **physical lane parity inside each source reg**:
+
+```
+x0F16 phys lanes:     0    1    2    3    4  ...  126  127
+logical index held:     0    2    4    6    8  ...  252  254
+
+vcvt {part=EVEN}  →  x0Zero0 (64×f32):  f32(0),  f32(4),  f32(8),  ... f32(252)
+vcvt {part=ODD}   →  x0One0  (64×f32):  f32(2),  f32(6),  f32(10), ... f32(254)
+```
+
+The same pattern on `x1F16`:
+
+```
+vcvt {part=EVEN}  →  x1Zero0:  f32(1),  f32(5),  f32(9),  ... f32(253)
+vcvt {part=ODD}   →  x1One0:   f32(3),  f32(7),  f32(11), ... f32(255)
+```
+
+After four `vcvt`s you have **four 64×f32 streams**, each holding values at
+**logical stride 4**. This is the **parity-interleaved** layout: arithmetic
+(`vmul`) can run independently on each stream, but the results are **not** in
+memory order `[0,1,2,3,…]`.
+
+**What `vmi.extf` hides:** one semantic “256 f16 → 256 f32” op. Lowering emits
+four `vcvt {part=EVEN/ODD}` plus (depending on the next op) relayout. The
+author never names `x0Zero0` or chooses which part applies to which DINTLV half.
+
+### 3.5 `vintlv` — rebuilding logical order (four steps on 256 elements)
+
+`vintlv(src0, src1)` interleaves **lane-by-lane** from two source registers into
+two destination registers. Within a 128-element local window it turns
+step-2 parity streams back into contiguous order (see Pack-Unpack reference
+§2.3.1).
+
+The MI/CCE quant loop uses **four** `vintlv` calls in two stages:
+
+**Stage A — repair widen split inside each DINTLV half (2× `vintlv`):**
+
+```
+vintlv(x0Zero1, x0One1)   // after vmul on x0 streams
+  IN:  f32(0),f32(4),f32(8),...     +  f32(2),f32(6),f32(10),...
+  OUT: x0Zero2 = f32(0),f32(2),f32(4),...f32(126)   [64 lanes, stride-2 evens]
+       x0One2  = f32(128),f32(130),...f32(254)      [64 lanes, stride-2 evens, high half]
+
+vintlv(x1Zero1, x1One1)   // same for odd-index load half
+  OUT: x1Zero2 = f32(1),f32(3),f32(5),...f32(125)
+       x1One2  = f32(129),f32(131),...f32(255)
+```
+
+**Stage B — repair DINTLV load split across halves (2× `vintlv`):**
+
+```
+vintlv(x0Zero2, x1Zero2)
+  OUT: x0Zero = f32(0), f32(1), f32(2), ... f32(127)    ← logical [0..127] contiguous
+       x1Zero = (second 64-lane chunk of interleave; paired with x0Zero for FP8)
+
+vintlv(x0One2, x1One2)
+  OUT: x0One  = f32(128), f32(129), ... f32(255)        ← logical [128..255] contiguous
+       x1One  = (companion chunk)
+```
+
+CCE documents the post-cross-interleave contract explicitly:
+
+```c
+// x0ZeroFP32 + x1ZeroFP32 merge -> first 128 FP32 values (positions 0-127)
+// x0OneFP32  + x1OneFP32  merge -> last 128 FP32 values (positions 128-255)
+vintlv(x0ZeroFP32, x1ZeroFP32, x0ZeroFP32, x1ZeroFP32);
+vintlv(x0OneFP32,  x1OneFP32,  x0OneFP32,  x1OneFP32);
+```
+
+**None of the four `vintlv` ops change numeric values** — they only permute which
+physical lane holds which logical index so the subsequent FP8 path sees
+contiguous 64×f32 chunks.
+
+**Alternative (not used in this example):** keep parity-interleaved f32 through
+multiply and repair at store time with `vstsx2 … INTLV_B32` instead of four
+`vintlv` (Pack-Unpack reference §4.2). The MI demo chooses **repair-then-`PART_P0`**
+because it matches the CCE `ComputeY1ToFP8` FP16 branch structure.
+
+### 3.6 PART_P0 + PK4_B32 — FP8 narrow and store (third layout axis)
+
+After the `vintlv` chain, each 64×f32 register holds **64 contiguous logical
+values**. FP8 output still needs two more physical transforms:
+
+**Narrow (`vcvt {part=P0, rnd=R, sat=SAT}`):** each 32-bit f32 lane group
+receives one 8-bit fp8 value in the **P0 byte** of the lane; P1–P3 bytes zeroed
+(Part_T axis, 4-way sub-part placement):
+
+```
+f32 lane k (32 bits):  [ f32 val ]  →  after P0:  [ fp8(k) | 00 | 00 | 00 ]
+```
+
+**Store (`vsts {dist=PK4_B32}`):** extract the low 8 bits of each 32-bit lane
+and pack four fp8 bytes per 32-bit memory word → **64 fp8 bytes per store**.
+
+The quant loop issues **four** `vcvt` + **four** `vsts PK4_B32` at offsets
+`+0, +64, +128, +192` bytes — one 64-byte chunk per 64 fp8 values, 256 fp8
+total per row. CCE wiring (note the cross-register sources after interleave):
+
+```c
+vcvt(x0ZeroFP8, x0ZeroFP32, pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
+vcvt(x0OneFP8,  x1ZeroFP32, pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
+vcvt(x1ZeroFP8, x0OneFP32,  pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
+vcvt(x1OneFP8,  x1OneFP32,  pregB32, ROUND_R, RS_ENABLE, PART_P0, MODE_ZEROING);
+vsts(..., PK4_B32, pregB8);  // ×4 with POST_UPDATE / offset bumps
+```
+
+**What `vmi.truncf` + `vmi.masked_store` hide:** rounding mode, saturation,
+part=P0 placement, `ui8` bitcast, PK4 lane extraction, four store addresses, and
+`b8`/`b32` predicate splitting — all derived from the logical
+`vreg<256×f8E4M3>` type and target memory layout.
+
 ---
 
 ## 4. Advantage by stage (ranked)
@@ -190,6 +375,14 @@ vmax(expMax2Dim2, expMax2Dim2, x1ExpBF16, pregAll, MODE_ZEROING);
 VMI advantage: the algorithm reads as “mask exponent bits, running max over 256
 lanes”. MI/CCE force you to track **even/odd half ownership** from the first
 load.
+
+**Physical layout note:** the scale path never widens to f32 per element, so it
+does **not** need the four-quadrant `vintlv` chain from §3.5. It still pays the
+**DINTLV load tax**: `acc0` owns exponent maxima for logical indices
+`0,2,4,…,254` and `acc1` for `1,3,5,…,255`. `vcgmax` fuses reduction with
+broadcast only **within each mask family** (`b16`), so the dual-accumulator
+pattern persists until VMI's `group_reduce_maxi` collapses both halves under one
+logical `vreg<256×…>` contract.
 
 ### 5.2 Cross-row reduction and scale encoding
 
@@ -287,6 +480,156 @@ Same story as RoPE interleave, but longer: **the quant algorithm is a multiply
 and a cast**; MI/CCE spend most lines rebuilding **logical index order** after
 every hardware split.
 
+### 6.5 End-to-end physical register pipeline (256 f16 row)
+
+The table below tracks **which logical indices** each named register holds after
+each MI/CCE step. This is the ground truth for debugging lane swaps.
+
+| Step | Instruction(s) | Register | Logical indices held (64 lanes shown as range) |
+|------|----------------|----------|--------------------------------------------------|
+| 0 | *(UB memory)* | — | `[0..255]` contiguous f16 |
+| 1 | `vldsx2 DINTLV_B16` | `x0F16` | `[0,2,4,…,254]` — 128 lanes |
+| 1 | | `x1F16` | `[1,3,5,…,255]` — 128 lanes |
+| 2a | `vcvt EVEN` | `x0Zero0` | `[0,4,8,…,252]` stride 4 |
+| 2b | `vcvt ODD` | `x0One0` | `[2,6,10,…,254]` stride 4 |
+| 2c | `vcvt EVEN` | `x1Zero0` | `[1,5,9,…,253]` stride 4 |
+| 2d | `vcvt ODD` | `x1One0` | `[3,7,11,…,255]` stride 4 |
+| 3 | `vmul` ×4 | same 4 regs | same indices, scaled f32 values |
+| 4a | `vintlv` (intra x0) | `x0Zero2` | `[0,2,4,…,126]` stride 2 |
+| 4a | | `x0One2` | `[128,130,…,254]` stride 2 |
+| 4b | `vintlv` (intra x1) | `x1Zero2` | `[1,3,5,…,125]` stride 2 |
+| 4b | | `x1One2` | `[129,131,…,255]` stride 2 |
+| 5a | `vintlv` (cross, low) | `x0Zero` | **`[0..127]` contiguous** |
+| 5a | | `x1Zero` | companion 64-lane chunk for FP8 path |
+| 5b | `vintlv` (cross, high) | `x0One` | **`[128..255]` contiguous** |
+| 5b | | `x1One` | companion chunk |
+| 6 | `vcvt P0` ×4 | 4× fp8 regs | 64 fp8 each, P0-packed in 256B reg |
+| 7 | `vsts PK4_B32` ×4 | UB | `[0..255]` contiguous fp8 bytes |
+
+Steps 1–5 are **pure layout**; step 3 is the only **algorithm** (`× scale`);
+steps 6–7 are **typed narrow + memory pack**.
+
+### 6.6 Why VMI needs only `extf` and `truncf`
+
+VMI and MI implement the **same row math**. The difference is **where** layout
+is expressed:
+
+| Concern | VMI surface | MI/CCE surface |
+|---------|-------------|----------------|
+| Index contract | `vreg<256×T>` — lane `i` is element `i` | Per-register index map (table above) |
+| Widen f16→f32 | `vmi.extf` | 4× `vcvt {part=EVEN/ODD}` |
+| Repair parity + DINTLV | *(compiler)* | 4× `vintlv` |
+| Narrow f32→fp8 | `vmi.truncf` | 4× `vcvt {part=P0,rnd,sat}` + bitcast |
+| Write fp8 row | `vmi.masked_store` | 4× `vsts {dist=PK4_B32}` |
+
+`extf` is **not** a single hardware widen. It is a **semantic extension** (like
+MLIR `arith.extf`): “for all `i ∈ [0,255]`, produce `f32(x[i])`.” The VMI
+compiler already knows the value arriving from `vmi.load` was DINTLV-split; it
+inserts the four `vcvt`s and, if the next op requires contiguous f32 (`vmi.mulf`
+on a dense 256×f32 scale vector), schedules the four `vintlv`s **between**
+widen and multiply in lowered MI.
+
+Similarly, `truncf` is **not** one `vcvt`. It means “for all `i`, produce
+`fp8_e4m3(f32[i])` with target-default rounding and saturation.” Lowering must
+place each result into P0 slots and emit PK4 stores — work that MI authors write
+by hand.
+
+**Honest boundary:** VMI removes layout **authorship**, not layout **work**.
+Cycle count after lowering is in the same ballpark as a well-written MI kernel;
+the win is correctness and reviewability when logical width exceeds one physical
+register.
+
+### 6.7 Register diagram — MI path vs VMI logical view
+
+**VMI (one logical vector throughout compute):**
+
+```
+UB f16 [0..255]
+        │ vmi.load
+        ▼
+   vreg<256×f16>  logical [0..255]
+        │ vmi.extf                    ┐ compiler lowers to:
+        ▼                             │  4× vcvt EVEN/ODD + 4× vintlv
+   vreg<256×f32>  logical [0..255]    ┘
+        │ vmi.mulf (× scale)
+        ▼
+   vreg<256×f32>  logical [0..255]
+        │ vmi.truncf                  ┐ compiler lowers to:
+        ▼                             │  4× vcvt P0 + 4× vsts PK4_B32
+   vreg<256×fp8>  logical [0..255]    ┘
+        │ vmi.masked_store
+        ▼
+UB fp8 [0..255]
+```
+
+**MI/CCE (four physical registers at peak, explicit repair):**
+
+```
+UB f16 [0..255]
+        │ DINTLV_B16
+        ├──────────────────┬──────────────────
+        ▼                  ▼
+   x0F16 [0,2,4..]    x1F16 [1,3,5..]     ← 2 regs (parity axis)
+        │ EVEN/ODD           │ EVEN/ODD
+        ├────┬────           ├────┬────
+        ▼    ▼               ▼    ▼
+     x0Z0 x0O0            x1Z0 x1O0         ← 4 regs (stride-4)
+        │ vmul×4
+        │ vintlv×2 (intra)   │ vintlv×2
+        ├────┬────           ├────┬────
+        ▼    ▼               ▼    ▼
+     x0Z2 x0O2            x1Z2 x1O2         ← stride-2 within each half
+        │ vintlv×2 (cross low)  │ vintlv×2 (cross high)
+        ▼                     ▼
+     x0Zero [0..127]      x0One [128..255]  ← contiguous f32 (algorithm done)
+        │ vcvt P0 + PK4         │ vcvt P0 + PK4 (×4 total)
+        ▼                     ▼
+UB fp8 [0..255]
+```
+
+### 6.8 Scale vector layout (reciprocal load, same axes)
+
+The quant loop also loads a **bf16 reciprocal scale** vector. MI uses `E2B_B16`
+broadcast distribution + `vbitcast` + `vcvt {part=EVEN}` to obtain a 64×f32
+register usable by all four `vmul`s:
+
+```
+E2B_B16 load  →  128×ui16 in broadcast layout (valid bf16 in EVEN physical lanes)
+vbitcast      →  128×bf16
+vcvt EVEN     →  64×f32 scale (one value per 32-column block, broadcast within lanes)
+```
+
+VMI loads `vreg<256×bf16>` and `vmi.extf` to `vreg<256×f32>`. The compiler
+chooses E2B vs dense load based on how the scale sits in UB; the author only
+writes “widen scale to f32 for multiply.”
+
+When scale lanes are uniform after block reduction (as in the full VMI kernel),
+`vmi.mulf` is a true 256-lane semantic multiply. MI reuses one 64×f32 scale reg
+for four stride-4 streams because **the scale is constant across the four
+parity streams** — but the author must still bind `mask<b32>` on each `vmul`.
+
+### 6.9 MI loop body inventory (17 core ops + store pack)
+
+The MI example comments cite **17 instructions** in the loop body, counting
+main vector ops (`vldsx2`, `vcvt`, `vmul`, `vintlv`) and the four FP8 `vcvt`s,
+but **not** the four `vbitcast` + four `vsts PK4_B32` pairs (those add 8 more
+lines for store typing and pack mode).
+
+| # | MI op | Layout or math? | Physical effect |
+|---|-------|-------------------|-----------------|
+| 1 | `vldsx2 DINTLV_B16` | Layout | Split 256 f16 → 2×128 parity regs |
+| 2–5 | `vcvt EVEN/ODD` ×2 + `vmul` ×2 on x0 | Widen + **math** | x0 → 2×64 f32 stride-4, scaled |
+| 6 | `vintlv` (intra x0) | Layout | x0 stride-4 → stride-2 within even half |
+| 7–10 | `vcvt EVEN/ODD` ×2 + `vmul` ×2 on x1 | Widen + **math** | x1 → 2×64 f32 stride-4, scaled |
+| 11 | `vintlv` (intra x1) | Layout | x1 stride-4 → stride-2 within odd half |
+| 12–13 | `vintlv` ×2 (cross) | Layout | Merge halves → `[0..127]`, `[128..255]` f32 |
+| 14–17 | `vcvt {P0,rnd,sat}` ×4 | Narrow (**math** + Part_T) | 64 f32 → P0-packed fp8 reg each |
+| +8 | `vbitcast` + `vsts PK4_B32` ×4 | Layout | Extract P0 bytes → contiguous UB fp8 |
+
+VMI collapses rows 1–6 and 7–13 into `load` + `extf`, rows 14–17 and the +8
+store pack into `truncf` + `masked_store`, leaving one `mulf` as the only
+visible arithmetic.
+
 ---
 
 ## 7. What VMI does *not* simplify
@@ -316,10 +659,13 @@ Be explicit about remaining low-level work:
 **Suggested reading order:**
 
 1. Section 1 of this doc (math)
-2. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` — best “before/after” showcase
-3. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` — see what VMI removed
-4. `mx_block_quant_scale_ocp_bf16.vmi.pto` vs `.mi.pto` — scale path
-5. `bmx_cce_kernels.h` `ComputeOcp` / `ComputeY1ToFP8` — annotated ground truth
+2. **§3.2–§3.6** (physical register model — read before MI/CCE examples)
+3. `mx_block_quant_y1_fp8_f16_e4m3.vmi.pto` — best “before/after” showcase
+4. **§6.5–§6.9** (quant pipeline index map + VMI vs MI diagrams)
+5. `mx_block_quant_y1_fp8_f16_e4m3.mi.pto` — see what VMI removed
+6. `mx_block_quant_scale_ocp_bf16.vmi.pto` vs `.mi.pto` — scale path
+7. `bmx_cce_kernels.h` `ComputeOcp` / `ComputeY1ToFP8` — annotated ground truth
+8. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` — full layout taxonomy
 
 ---
 
@@ -332,6 +678,7 @@ Be explicit about remaining low-level work:
 | Closer to math? | **Yes** — VMI keeps “max exponent → scale → multiply → cast” visible |
 | Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling |
 | Biggest win? | **f16→fp8 quant**, where MI spends most lines on layout repair |
+| Why `extf`/`truncf` vs `vintlv`? | VMI ops preserve **logical index `i`**; MI `vintlv` repairs **physical lane placement** after DINTLV + PART widen (§3.3–§3.6, §6.5–§6.7) |
 
 VMI is not “MX quant in five lines.” It is **MX quant with the split/part/PK
 contract moved into the compiler** — most valuable exactly where block quant

--- a/docs/examples/vmi/ROPE_VMI_vs_MI.md
+++ b/docs/examples/vmi/ROPE_VMI_vs_MI.md
@@ -134,6 +134,206 @@ mapping. Correct for performance, opaque for reading.
 VMI replaces these with “load 64 bf16”, “extend to fp32”, “store bf16”, and
 “split/merge even/odd channels”.
 
+### 3.2 Physical register model (256-byte contract, D=64 demo)
+
+Every A5 vector register is **256 bytes**. The RoPE examples process one head row
+of **D=64** elements per inner tile. How those 64 elements map to physical
+registers depends on **dtype** and **layout mode**:
+
+| Case | Memory bytes (64 elems) | Typical physical reg | Load `dist` |
+|------|-------------------------|----------------------|-------------|
+| f16 / fp16 dense | 128 B | `vreg<128×f16>` (64 active lanes) | `NORM` |
+| bf16 dense | 128 B | `vreg<128×bf16>` after UNPK | `UNPK_B16` |
+| f32 dense | 256 B | `vreg<64×f32>` | `NORM` |
+| GPT-J interleaved (all dtypes) | same as above | one dense reg, then parity split | as above + `vdintlv` |
+
+**Logical view (VMI):** `!pto.vmi.vreg<64×T>` or `!pto.vmi.vreg<128×T>` means
+elements `0..N−1` in algorithm order. HALF mode treats indices `[0..D/2−1]` and
+`[D/2..D−1]` as **partner halves**. INTERLEAVE mode treats `(2k, 2k+1)` as
+**rotation pairs**.
+
+**Physical view (MI/CCE):** each register has **lane slots** with placement
+rules. UNPK, `part=EVEN/ODD`, `vdintlv`/`vintlv`, and `PK_B32` are not math —
+they maintain the mapping between lane slot and logical index.
+
+RoPE at D=64 is **smaller** than block MX quant (256-wide rows), so you rarely
+need `DINTLV_B16` split loads in these examples. The dominant layout axes here
+are **UNPK/PK** (bf16), **parity shuffle** (INTERLEAVE), and **mask family**
+(b16 vs b32).
+
+See also `BLOCK_MX_QUANT_VMI_vs_MI.md` §3.2–§3.6 for the same 256B contract
+applied to 256-element quant rows (where `DINTLV` + four `vintlv` steps appear).
+
+### 3.3 UNPK_B16 load and PK_B32 store (bf16 / fp16 dense paths)
+
+bf16 RoPE loads **64 dense halfwords** from UB, but a b16 register holds
+**128 lanes**. `UNPK_B16` expands each memory element into an **even physical
+lane**, leaving odd lanes as zero/padding:
+
+```
+Memory (32 dense bf16 in one HALF tile, D/2=32):
+  [b0, b1, b2, ..., b31]   ← 64 bytes
+
+After UNPK_B16 → vreg<128×bf16> (256 B):
+  phys lane:  0    1    2    3    4  ...  62   63   64  ... 127
+  holds:      b0   __   b1   __   b2  ...  b31  __   __  ...  __
+              ↑ even only; odd lanes are padding
+```
+
+**Widen:** `vcvt {part=EVEN}` reads lanes `0,2,4,…,126` → **64×f32** register
+with the 32 meaningful values in the active mask lanes. Using `part=ODD` would
+read the padding lanes and produce garbage — CCE documents this explicitly in
+`ComputeBf16`.
+
+**Narrow + store:** `vcvt {part=EVEN}` writes fp32 results back into even b16
+lanes, then `vsts {dist=PK_B32}` extracts even lanes and packs them into **dense
+memory**:
+
+```
+After PART_EVEN narrow → vreg<128×bf16>:
+  [y0, __, y1, __, y2, __, ...]
+
+PK_B32 store → memory:
+  [y0, y1, y2, ...]   ← dense again
+```
+
+**VMI:** `vmi.load` → `vreg<64×bf16>`, `vmi.extf` / `vmi.truncf`, `vmi.masked_store`.
+The UNPK → EVEN → PK chain is compiler lowering, not author code.
+
+### 3.4 HALF mode — contiguous halves (NeoX layout)
+
+HALF mode splits **D=64** into two partner blocks of **32 elements** each. No
+parity deinterleave is required — partners are already contiguous in memory:
+
+```
+Logical head row (D=64):
+  x[0..31]  = low half (x1)     partner with  x[32..63] = high half (x2)
+
+Memory layout (HALF):
+  ┌─────────────────┬─────────────────┐
+  │  x[0] … x[31]   │ x[32] … x[63]   │
+  └─────────────────┴─────────────────┘
+     load x_lo          load x_hi  (+halfD or +halfD_aligned offset)
+```
+
+**f16 / f32 HALF (dense):** each half fits in one register. MI loads
+`vreg<128×f16>` with a **32-lane tail mask** (`pge_b16 "PAT_VL32"` or dynamic
+`plt_b16` in v2). Only the low 32 physical lanes hold data; the register is
+128-wide because that is the native b16 vector width.
+
+**bf16 HALF:** each half uses UNPK (§3.3) + fp32 compute + PK store. MI needs
+**two mask families** in one loop body: `mask<b16>` for UNPK load and PART_EVEN
+widen of cos/sin, `mask<b32>` for fp32 `vmul`/`vsub`/`vadd`.
+
+**Physical register picture (bf16 HALF, one partner half):**
+
+```
+cos_lo_16  ──UNPK──► [c0,__,c1,__,…] ──PART_EVEN──► cos_lo (64×f32, 32 active)
+x_lo_16    ──UNPK──► [x0,__,x1,__,…] ──PART_EVEN──► x_lo  (64×f32, 32 active)
+                              │
+                              ├── vmul / vsub / vadd  (mask<b32>)
+                              ▼
+y_lo_f32 (64×f32) ──PART_EVEN narrow──► [y0,__,y1,__,…] ──PK_B32──► dense UB
+```
+
+VMI names the same math on logical `vreg<64×bf16>` / `vreg<64×f32>` without
+ exposing the even-lane landing zone.
+
+### 3.5 INTERLEAVE mode — parity axis (GPT-J layout)
+
+GPT-J layout stores rotation pairs as **adjacent elements**:
+
+```
+Logical (D=64 interleaved):
+  [x0, x1,  x2, x3,  x4, x5, ... x62, x63]
+   └── pair 0 ──┘  └── pair 1 ──┘
+```
+
+Hardware `vdintlv` / `vintlv` implement the **parity axis** — the same axis
+used by `PART_EVEN`/`PART_ODD` on widen, but here applied to **already-widened
+or dense b16/f16 vectors** to separate even- and odd-indexed streams:
+
+```
+Dense reg x (128 lanes, 64 active interleaved):
+  [x0, x1, x2, x3, x4, x5, x6, x7, ...]
+
+vdintlv(x, x) →
+  x_even: [x0, x2, x4, x6, ...]     ← even logical indices
+  x_odd:  [x1, x3, x5, x7, ...]     ← odd logical indices
+```
+
+**Complex-multiply form** (CCE, `rope_f16_v2.mi.pto`, f16/bf16 VMI): build
+`(i·x)` in interleaved layout without splitting cos/sin:
+
+```
+x_even, x_odd = vdintlv(x)
+neg_x_odd     = x_odd * (-1)
+x_rot, _      = vintlv(neg_x_odd, x_even)   → [-x1, x0, -x3, x2, ...]
+
+y = x*cos + x_rot*sin                     ← 3 arithmetic ops on dense regs
+```
+
+Physical effect of `vintlv(neg_x_odd, x_even)` (8-element sketch):
+
+```
+neg_x_odd:  [-x1, -x3, -x5, -x7]
+x_even:     [ x0,  x2,  x4,  x6]
+
+x_rot:      [-x1, x0, -x3, x2, -x5, x4, -x7, x6]   ← interleaved (i·x)
+```
+
+**Cartesian expansion form** (MI v1, f32 VMI interleave): deinterleave **all**
+streams, compute even/odd updates separately, merge back:
+
+```
+cos_even, cos_odd = vdintlv(cos)
+sin_even, sin_odd = vdintlv(sin)
+x_even,   x_odd   = vdintlv(x)
+
+y_even = x_even*cos_even - x_odd*sin_even
+y_odd  = x_odd*cos_odd  + x_even*sin_odd
+
+y, _ = vintlv(y_even, y_odd)    ← re-pack to [y0,y1,y2,y3,...]
+```
+
+Same RoPE result; **more layout ops** in the Cartesian path (three `vdintlv` on
+tables + one `vintlv` repack vs one `vdintlv` + one `vintlv` on `x` only).
+
+**VMI mapping:**
+
+| MI/CCE | VMI | Physical meaning |
+|--------|-----|------------------|
+| `vdintlv` | `channel_split` | dense → even/odd parity streams |
+| `vintlv` | `channel_merge` | even/odd → dense interleaved |
+| `vmul` + `vbr(-1)` | `negf` | negate odd stream |
+
+### 3.6 Mask families and predicate width
+
+MI RoPE kernels often carry **two predicate granularities** in one loop:
+
+| Mask type | Used for | Example |
+|-----------|----------|---------|
+| `!pto.mask<b16>` | UNPK loads, b16 `vcvt`, dense f16 `vmul`, `plt_b16` tails | bf16 load/widen; f16 interleave |
+| `!pto.mask<b32>` | fp32 `vmul`/`vsub`/`vadd`, PART_EVEN narrow, `PK_B32` store | bf16 HALF compute body |
+
+A bf16 HALF loop typically creates **both** `%mask16_all` and `%mask32_half`.
+Using a b16 mask on a b32 op (or vice versa) is a silent wrong-lane bug.
+
+VMI uses one logical `!pto.vmi.mask<N×pred>` per tile; the compiler lowers to
+the correct `pset`/`plt`/`punpack` family.
+
+### 3.7 Variant → layout complexity (honest map)
+
+| Variant | Physical layout burden | Dominant MI ops beyond arithmetic |
+|---------|------------------------|-----------------------------------|
+| **f32 HALF** | Low | Tail mask only |
+| **f16 HALF** | Low | Tail mask; 128-wide reg, 32 active lanes |
+| **bf16 HALF** | **High** | UNPK, PART_EVEN ×2, PK_B32, dual masks |
+| **f16 INTERLEAVE v2** | Medium | `vdintlv`, `vbr`, `vintlv` on `x`; dense cos/sin |
+| **f16 INTERLEAVE v1** | **High** | `vdintlv` ×3, 8 arith, `vintlv` repack |
+| **bf16 INTERLEAVE** | **High** | UNPK/PK chain + parity shuffle in fp32 |
+| **f32 INTERLEAVE VMI** | Medium | Cartesian `channel_split/merge`; no UNPK |
+
 ---
 
 ## 4. Advantage by variant (ranked)
@@ -211,6 +411,20 @@ families.
 **CCE** (`ComputeBf16` HALF) documents the same protocol explicitly in comments
 — excellent for verification, heavy for authoring.
 
+**Physical layout (bf16 HALF, one 32-element partner half):**
+
+| Step | MI/CCE op | Register state (logical indices) |
+|------|-----------|----------------------------------|
+| 0 | UB memory | 32 dense bf16: `x[0..31]` or `x[32..63]` |
+| 1 | `vlds UNPK_B16` | 128×bf16 even lanes: phys `2k → x[k]` |
+| 2 | `vcvt PART_EVEN` | 64×f32: active lanes hold same 32 values |
+| 3 | `vmul` / `vsub` / `vadd` | fp32 partners combined (`mask<b32>`) |
+| 4 | `vcvt PART_EVEN` narrow | bf16 back into even lanes of 128×bf16 |
+| 5 | `vsts PK_B32` | dense 32 bf16 in UB |
+
+VMI collapses steps 1–2 into `vmi.load` + `vmi.extf`, steps 4–5 into
+`vmi.truncf` + `vmi.masked_store`.
+
 ---
 
 ### 5.2 bf16 INTERLEAVE — complex-multiply form in VMI
@@ -252,6 +466,33 @@ PK store. Correct, but the code looks like a shuffle kernel, not `y = x·cos +
 is closer to VMI structurally — but still uses `vbr`, `plt_b16`, and masked
 `vmul/vadd`.
 
+**Physical layout (bf16 INTERLEAVE, complex-multiply, one 64-element row):**
+
+```
+UB dense (64 bf16 interleaved):  x0 x1 x2 x3 ... x63
+        │ UNPK + PART_EVEN widen
+        ▼
+x (64×f32 logical, interleaved in one dense fp32 reg)
+        │ channel_split  ≡  vdintlv(x, x)
+        ├──────────────┬──────────────
+        ▼              ▼
+   x_even         x_odd        [x0,x2,...] [x1,x3,...]
+        │ negf         │
+        └──────┬───────┘
+               │ channel_merge(neg_odd, even)  ≡  vintlv
+               ▼
+   x_rot = [-x1,x0,-x3,x2,...]     cos, sin stay dense (no vdintlv)
+               │
+               └── mulf/addf:  y = x*cos + x_rot*sin
+                       │ truncf + PK
+                       ▼
+               dense bf16 interleaved out
+```
+
+Cartesian MI v1 instead runs `vdintlv` on cos/sin **and** x, performs eight
+masked ops on parity streams, then `vintlv(y_even, y_odd)` to rebuild interleaved
+output — see §3.5.
+
 ---
 
 ### 5.3 f16 HALF — moderate win
@@ -282,6 +523,20 @@ out2 = x2*cos + x1*sin
 VMI advantage here is **clarity, not algorithm**: masks and load/store dist
 modes disappear from the math block. Loop tiling (`rep`, `half_d_aligned`,
 dynamic tail) remains equally verbose in both.
+
+**Physical layout (f16 HALF):** partners are **two separate dense loads**, not a
+parity split. For D=64 with `halfD=32`:
+
+```
+x_lo reg (128×f16):  lanes 0..31 ← x[0..31]     (mask covers 32 lanes)
+x_hi reg (128×f16):  lanes 0..31 ← x[32..63]    (loaded from x + halfD_aligned)
+
+Six fp32-equivalent ops (native f16 here):
+  y_lo = cos_lo * x_lo - sin_lo * x_hi
+  y_hi = cos_hi * x_hi + sin_lo * x_lo
+```
+
+No `vdintlv`/`vintlv` — the NeoX layout already matches how HALF loads data.
 
 ---
 
@@ -316,6 +571,20 @@ vadd(htb, hta, htb, mask, MODE_ZEROING);
 Same story, different vocabulary: **merge(−odd, even)** vs **vintlv after
 negate**.
 
+**Index map for complex-multiply (8-element sketch, matches v2/CCE/VMI f16):**
+
+| Stage | Register | Logical contents |
+|-------|----------|------------------|
+| load | `x` | `[x0,x1,x2,x3,x4,x5,x6,x7]` |
+| `vdintlv` | `x_even` | `[x0,x2,x4,x6]` |
+| `vdintlv` | `x_odd` | `[x1,x3,x5,x7]` |
+| negate odd | `neg_x_odd` | `[-x1,-x3,-x5,-x7]` |
+| `vintlv` | `x_rot` | `[-x1,x0,-x3,x2,-x5,x4,-x7,x6]` |
+| `vmul` + `vadd` | `y` | `[y0,y1,…,y7]` interleaved |
+
+`cos` and `sin` remain **dense interleaved** throughout — unlike MI v1, which
+splits them with separate `vdintlv` calls.
+
 ---
 
 ### 5.5 f32 HALF — smallest win
@@ -342,6 +611,14 @@ pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
 VMI still helps (uniform `vmi.load`, one mask type, no `pge_b32`), but this is
 not where you save days of debugging UNPK/PK issues.
 
+**Physical layout (f32 HALF):** the easy baseline — **64×f32 fits one register**
+(256 B). Load, compute, store are all `NORM` with no UNPK, part, or PK:
+
+```
+x1: vreg<64×f32> ← x[0..31]     x2: vreg<64×f32> ← x[32..63]
+        └── native fp32 vmul/vsub/vadd (mask<b32> for tail only)
+```
+
 ---
 
 ### 5.6 f32 INTERLEAVE — Cartesian form; moderate win
@@ -366,6 +643,41 @@ Note: CCE f32 INTERLEAVE uses the **complex-multiply** path (like f16 v2), so
 VMI f32 interleave is **not** a line-for-line spelling match to CCE — it is an
 equivalent Cartesian organization chosen for clarity at the logical vector
 width.
+
+**Physical layout (f32 INTERLEAVE Cartesian):**
+
+```
+x (64×f32 dense interleaved)
+  │ channel_split  ≡  vdintlv
+  ├─────────┬─────────
+  ▼         ▼
+x_even   x_odd     (+ same for cos, sin in MI v1; VMI splits x/cos/sin logically)
+  │ 4 muls + 2 subs/adds on streams
+  ▼
+y_even, y_odd
+  │ channel_merge  ≡  vintlv
+  ▼
+y dense interleaved
+```
+
+CCE f32 would instead keep cos/sin dense and use one `vdintlv`/`vintlv` pair on
+`x` only (complex-multiply form, same as §5.4 index table).
+
+---
+
+### 5.7 End-to-end layout comparison (all six variants)
+
+| Variant | Loads | Compute reg layout | Shuffle ops | Stores |
+|---------|-------|-------------------|-------------|--------|
+| f32 HALF | 2× dense 64×f32 | native dense | none | 2× dense |
+| f16 HALF | 2× dense 128×f16 (32 active) | native dense | none | 2× dense |
+| bf16 HALF | 4× UNPK + PART_EVEN widen | 4× 64×f32 | none | 2× PART_EVEN + PK_B32 |
+| f16 INT v2 | 3× dense 128×f16 | dense + parity on `x` | `vdintlv`+`vintlv` on `x` | 1× dense |
+| f16 INT v1 | 3× dense + 3× `vdintlv` | 6 parity streams | 3× `vdintlv`, 1× `vintlv` | 1× dense |
+| bf16 INT | UNPK + fp32 body | fp32 dense + parity | same as f16 v2 + PK | PK_B32 |
+
+**VMI value correlates with shuffle + UNPK/PK column width**, not with RoPE
+formula complexity (which is identical everywhere).
 
 ---
 
@@ -404,10 +716,14 @@ width.
 **Suggested reading order for new algorithm engineers:**
 
 1. Section 1 of this doc (math)
-2. `rope_bf16.vmi.pto` HALF loop body — best VMI showcase
-3. `rope_bf16.mi.pto` same section — see what VMI removed
-4. `rope_cce_compute.h` `ComputeBf16` — ground truth with educational comments
-5. `rope_f16_v2.mi.pto` — CCE-faithful MI reference for f16
+2. **§3.2–§3.7** (physical register model — read before MI/CCE examples)
+3. `rope_bf16.vmi.pto` HALF loop body — best VMI showcase
+4. **§5.7** (variant layout comparison table)
+5. `rope_bf16.mi.pto` same section — see what VMI removed
+6. `rope_cce_compute.h` `ComputeBf16` — ground truth with educational comments
+7. `rope_f16_v2.mi.pto` — CCE-faithful MI reference for f16
+8. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` — full layout taxonomy
+9. `BLOCK_MX_QUANT_VMI_vs_MI.md` — same layout axes at 256-wide quant scale
 
 ---
 
@@ -420,6 +736,7 @@ width.
 | Closer to math? | **Yes** where VMI hides UNPK/PK/part and uses `channel_split/merge` for GPT-J |
 | Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling shell |
 | Still worth it if MI is v2-quality? | **Yes for bf16**; **marginal for f32 HALF** |
+| Why UNPK / vdintlv / vintlv? | Physical 256B regs + dense vs interleaved memory; see §3.3–§3.5 |
 
 VMI is not “RoPE in three lines.” It is **RoPE with the hardware contract moved
 into the compiler** — most valuable exactly where that contract is longest:
@@ -442,6 +759,7 @@ into the compiler** — most valuable exactly where that contract is longest:
 
 Related docs:
 
+- `BLOCK_MX_QUANT_VMI_vs_MI.md` — same three-layer pattern; deeper DINTLV/`vintlv` at 256-wide
 - `PTO-Gym-vmi/docs/PTO-vmi-design.en.md`
 - `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
 - `PTO-Gym-vmi/docs/PTO-micro-Instruction-SPEC.md`

--- a/docs/examples/vmi/ROPE_VMI_vs_MI.md
+++ b/docs/examples/vmi/ROPE_VMI_vs_MI.md
@@ -1,0 +1,447 @@
+# RoPE on PTO: Why VMI Helps Algorithm Engineers
+
+This note compares the RoPE example kernels in this directory across three
+expression layers:
+
+| Layer | Example files | Who it is for |
+|-------|---------------|---------------|
+| **CCE** | `rope_cce_compute.h` | Ground-truth intrinsics execution |
+| **MI** (`pto.mi`) | `rope_{f16,bf16,f32}.mi.pto`, `rope_f16_v2.mi.pto` | Hardware-faithful PTO micro-ops |
+| **VMI** (`pto.vmi`) | `rope_{f16,bf16,f32}.vmi.pto` | Logical-vector authoring |
+
+**Audience:** algorithm engineers who want the math to be visible in code and
+prefer not to manage SIMD register layout, mask families, or load/store
+distribution modes by hand.
+
+**Scope:** the six RoPE variants in the examples — `{f16, bf16, f32} × {HALF,
+INTERLEAVE}` — on the fixed demo tile `D=64`. All examples share the same outer
+kernel shell (GM→UB DMA, pipeline flags, UB→GM writeback).
+
+This document is intentionally honest: VMI is a real abstraction win in several
+places, but it is not magic, and it does not remove all low-level work.
+
+---
+
+## 1. RoPE math (what every variant implements)
+
+RoPE rotates pairs of dimensions by a position-dependent angle θ using
+precomputed `(cos θ, sin θ)`.
+
+### 1.1 HALF mode (NeoX / LLaMA-style layout)
+
+The head dimension `D` is split into two contiguous halves. For each index `d`
+in the low half:
+
+```
+y[d]       = x[d]       * cos[d]       - x[d + D/2] * sin[d]
+y[d+D/2]   = x[d+D/2]   * cos[d+D/2] + x[d]       * sin[d+D/2]
+```
+
+This is a **2×2 real rotation** applied independently to `(x_low, x_high)`
+pairs. No complex-number bookkeeping is required in code — just two fused
+half-vector updates.
+
+### 1.2 INTERLEAVE mode (GPT-J-style layout)
+
+Adjacent elements form pairs: `(x[2k], x[2k+1])`. Two algebraically equivalent
+spellings appear in the examples:
+
+**Complex-multiply form** (CCE, `rope_f16_v2.mi.pto`, f16/bf16 VMI interleave):
+
+```
+y = x * cos + (i*x) * sin
+```
+
+where `(i*x)` in interleaved real layout is `[-x1, x0, -x3, x2, ...]`.
+
+**Cartesian expansion form** (`rope_f16.mi.pto` v1, f32 VMI interleave):
+
+```
+y_even = x_even * cos_even - x_odd * sin_even
+y_odd  = x_odd  * cos_odd  + x_even * sin_odd
+```
+
+after deinterleaving even/odd streams from `[x0, x1, x2, x3, ...]`.
+
+Both are standard; they differ in **how** you schedule the SIMD ops, not in the
+RoPE result.
+
+### 1.3 bf16 numerics
+
+For bf16 paths, **x/y are bf16** but **cos/sin are fp16**, and the inner
+compute is done in **fp32** before narrowing back to bf16. This matches the CCE
+reference (`ComputeBf16`), not native bf16 arithmetic throughout.
+
+---
+
+## 2. What VMI actually is
+
+VMI (`pto.vmi`) sits between your algorithm and MI (`pto.mi`). You write
+**logical contiguous vectors** (`!pto.vmi.vreg<N×T>`) and **semantic ops**
+(`vmi.load`, `vmi.mulf`, `vmi.extf`, `channel_split`, …). The compiler
+(`pto.as`) lowers to MI instructions with the correct `dist`, `part`, `PK/UNPK`,
+and mask granularity.
+
+See `PTO-Gym-vmi/docs/PTO-vmi-design.en.md` for
+the full design.
+
+**VMI removes:** per-op mask plumbing, register layout choices, and
+type-conversion protocol details.
+
+**VMI does not remove:** loop nesting (`s → rep/blk → n`), stride/alignment
+math, DMA setup, or pipeline synchronization. Those remain visible in the
+examples.
+
+---
+
+## 3. Instruction map: math → MI → VMI
+
+The table below connects the math step to what you write at each layer.
+
+| Math intent | CCE intrinsic | MI (`pto.mi`) | VMI (`pto.vmi`) |
+|-------------|---------------|---------------|-----------------|
+| Load a logical vector from UB | `vlds` (`NORM` / `UNPK_B16`) | `pto.vlds` (+ optional `{dist = "UNPK_B16"}`) | `pto.vmi.load` |
+| Widen bf16/fp16 → fp32 | `vcvt` (`PART_EVEN`, `MODE_ZEROING`) | `pto.vcvt {part = "EVEN"}` | `pto.vmi.extf` |
+| Narrow fp32 → bf16/fp16 | `vcvt` (`ROUND_R`, `RS_DISABLE`, `PART_EVEN`, `MODE_ZEROING`) | `pto.vcvt {part = "EVEN", rnd, sat}` | `pto.vmi.truncf` |
+| Element-wise multiply / add / sub | `vmul` / `vadd` / `vsub` (`MODE_ZEROING` + mask) | same + **mask on every op** | `vmi.mulf` / `addf` / `subf` (no mask) |
+| Tail / partial vector mask | `plt_b16` / `plt_b32` (`POST_UPDATE`) | `pto.plt_b16` / `pge_b32 "PAT_VL32"` | `pto.vmi.create_mask %active` |
+| Split interleaved even/odd | `vdintlv` | `pto.vdintlv` | `pto.vmi.channel_split` |
+| Negate odd lane stream | `vbr` + `vmul` (`MODE_ZEROING`) | same | `pto.vmi.negf` |
+| Merge even/odd back | `vintlv` | `pto.vintlv` | `pto.vmi.channel_merge` |
+| Store with tail mask | `vsts` (`NORM_B16` / `NORM_B32` / `PK_B32` + mask) | `pto.vsts` (+ optional `{dist = "PK_B32"}`) + mask | `pto.vmi.masked_store` |
+
+### 3.1 MI details algorithm engineers should not have to memorize
+
+These are the hardware subtleties VMI is designed to hide:
+
+**UNPK_B16 load:** 64 dense b16 elements in memory expand into a 128-lane
+physical register with valid values only at **even** halfword positions; odd
+lanes are padding. If you later widen with the wrong `part`, you read zeros or
+garbage.
+
+**PART_EVEN vcvt:** selects the even-position lanes after an UNPK load. Required
+for bf16/fp16 widen paths in MI.
+
+**PK_B32 store:** packs bf16 values scattered at even register positions back
+into dense memory. Required after narrowing in MI bf16 paths.
+
+**Mask family mismatch:** f16 arithmetic uses `!pto.mask<b16>`; fp32 uses
+`!pto.mask<b32>`. A bf16 kernel typically needs **both** in the same loop body.
+
+**vdintlv / vintlv:** hardware deinterleave/interleave with a specific lane
+mapping. Correct for performance, opaque for reading.
+
+VMI replaces these with “load 64 bf16”, “extend to fp32”, “store bf16”, and
+“split/merge even/odd channels”.
+
+---
+
+## 4. Advantage by variant (ranked)
+
+Honest ranking of **VMI syntax / intuitiveness / math closeness** vs MI,
+from largest win to smallest:
+
+| Rank | Variant | VMI advantage | Why |
+|------|---------|---------------|-----|
+| 1 | **bf16 HALF** | **Very large** | MI exposes the full UNPK→EVEN→compute→EVEN→PK chain + dual mask families on every op |
+| 2 | **bf16 INTERLEAVE** | **Very large** | Same conversion chain, plus `channel_split/merge/negf` vs `vdintlv/vintlv/vbr` |
+| 3 | **f16 INTERLEAVE** | **Large** | `channel_split → negf → channel_merge` reads as “build i·x”; optional fp32 middle via `extf/truncf` |
+| 4 | **f32 INTERLEAVE** | **Moderate** | Cartesian expansion is already readable; VMI mainly removes per-op masks and names shuffles semantically |
+| 5 | **f16 HALF** | **Moderate** | Core 6-op math is identical; VMI drops mask args and uses logical `create_mask` |
+| 6 | **f32 HALF** | **Small** | MI f32 HALF is already close to the math; VMI mostly removes redundant mask parameters |
+
+**Takeaway:** the further you are from “native dense fp32 load/compute/store”, the
+more VMI pays off. **bf16 is the headline case.**
+
+If MI is written like `rope_f16_v2.mi.pto` (CCE-faithful loops and masks), VMI
+still wins on **bf16** and **mask-free arithmetic**, but the **algorithm
+structure** gap shrinks — you are mostly comparing syntax sugar vs hardware
+protocol.
+
+---
+
+## 5. Walkthroughs
+
+### 5.1 bf16 HALF — largest VMI win
+
+**Math (fp32 inner loop):**
+
+```
+y1 = x1 * cos - x2 * sin
+y2 = x2 * cos + x1 * sin
+```
+
+**MI** (`rope_bf16.mi.pto`) — one cos load/widen sequence:
+
+```mlir
+%cos_lo_16 = pto.vlds %cos_ub[%cs_off] {dist = "UNPK_B16"} : ... -> !pto.vreg<128xf16>
+%cos_lo = pto.vcvt %cos_lo_16, %mask16_all {part = "EVEN"} : ... -> !pto.vreg<64xf32>
+// ... repeat for sin, x halves ...
+%t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : ...
+%t1 = pto.vmul %sin_lo, %x_hi, %mask32_half : ...
+%y_lo_f32 = pto.vsub %t0, %t1, %mask32_half : ...
+%y_lo_16 = pto.vcvt %y_lo_f32, %mask32_half {part = "EVEN", rnd = "R", sat = "SAT"} : ...
+pto.vsts %y_lo_16, %y_ub[%y_off], %mask32_half {dist = "PK_B32"} : ...
+```
+
+Reading this as an algorithm engineer:
+
+- Four instruction **families** before the first multiply: UNPK load, EVEN
+  widen, masked fp32 op, EVEN narrow + PK store.
+- `%mask16_all` for loads/converts, `%mask32_half` for compute — easy to mix up.
+- `{part = "EVEN"}` is a correctness requirement, not an optimization knob.
+
+**VMI** (`rope_bf16.vmi.pto`) — same cos load/widen:
+
+```mlir
+%cos1_16 = pto.vmi.load %cos_ub[%cos1_off] : ... -> !pto.vmi.vreg<64xf16>
+%cos1 = pto.vmi.extf %cos1_16 : ... -> !pto.vmi.vreg<64xf32>
+// ...
+%x1_cos = pto.vmi.mulf %x1, %cos1 : ...
+%x2_sin = pto.vmi.mulf %x2, %sin1 : ...
+%out1_f32 = pto.vmi.subf %x1_cos, %x2_sin : ...
+%out1 = pto.vmi.truncf %out1_f32 : ... -> !pto.vmi.vreg<64xbf16>
+pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
+```
+
+This reads as the math plus dtype semantics: **load → widen → compute →
+truncate → store**. The compiler chooses UNPK/PART_EVEN/PK_B32 and mask
+families.
+
+**CCE** (`ComputeBf16` HALF) documents the same protocol explicitly in comments
+— excellent for verification, heavy for authoring.
+
+---
+
+### 5.2 bf16 INTERLEAVE — complex-multiply form in VMI
+
+**Math:**
+
+```
+y = x * cos + (i*x) * sin
+```
+
+**VMI** (`rope_bf16.vmi.pto`):
+
+```mlir
+%x = pto.vmi.extf %x16 : ... -> !pto.vmi.vreg<128xf32>
+%x_even, %x_odd = "pto.vmi.channel_split"(%x) : ... -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
+%neg_x_odd = pto.vmi.negf %x_odd : ...
+%rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even) : ... -> !pto.vmi.vreg<128xf32>
+%x_cos = pto.vmi.mulf %x, %cos : ...
+%rot_sin = pto.vmi.mulf %rot, %sin : ...
+%y_f32 = pto.vmi.addf %x_cos, %rot_sin : ...
+%y16 = pto.vmi.truncf %y_f32 : ... -> !pto.vmi.vreg<128xbf16>
+```
+
+Instruction meaning for algorithm engineers:
+
+- **`channel_split`:** `[e0,o0,e1,o1,…] → (even=[e0,e1,…], odd=[o0,o1,…])`.
+  Semantic name for MI `vdintlv`.
+- **`negf`:** negate the odd stream → `-odd`.
+- **`channel_merge`:** interleave `(-odd, even)` → `[-o0,e0,-o1,e1,…]`, which
+  is `(i*x)` in interleaved layout.
+- **`mulf` / `addf`:** the two-term complex multiply, mask-free.
+
+**MI v1** (`rope_bf16.mi.pto`) uses **Cartesian expansion** instead: deinterleave
+cos, sin, **and** x, then eight masked fp32 ops, then `vintlv`, then narrow +
+PK store. Correct, but the code looks like a shuffle kernel, not `y = x·cos +
+(i·x)·sin`.
+
+**MI v2 f16** (`rope_f16_v2.mi.pto`) matches the CCE complex-multiply path and
+is closer to VMI structurally — but still uses `vbr`, `plt_b16`, and masked
+`vmul/vadd`.
+
+---
+
+### 5.3 f16 HALF — moderate win
+
+The six-op HALF core is the same everywhere:
+
+```
+out1 = x1*cos - x2*sin
+out2 = x2*cos + x1*sin
+```
+
+**MI** (every op carries a mask):
+
+```mlir
+%t0 = pto.vmul %cos_lo, %x_lo, %mask16 : ...
+%t1 = pto.vmul %sin_lo, %x_hi, %mask16 : ...
+%y_lo = pto.vsub %t0, %t1, %mask16 : ...
+```
+
+**VMI:**
+
+```mlir
+%x1_cos = pto.vmi.mulf %x1_16, %cos1_16 : ...
+%x2_sin = pto.vmi.mulf %x2_16, %sin1_16 : ...
+%out1 = pto.vmi.subf %x1_cos, %x2_sin : ...
+```
+
+VMI advantage here is **clarity, not algorithm**: masks and load/store dist
+modes disappear from the math block. Loop tiling (`rep`, `half_d_aligned`,
+dynamic tail) remains equally verbose in both.
+
+---
+
+### 5.4 f16 INTERLEAVE — VMI matches CCE math spelling
+
+VMI f16 interleave uses the **complex-multiply form** with an fp32 middle
+(`extf` before shuffle, `truncf` before store). That is a **semantic** match to
+CCE/v2 MI, with a small **numeric** difference vs native f16 throughout (VMI
+chooses fp32 for the interleave body because `extf/truncf` are cheap at the
+logical level).
+
+Compare the fused body:
+
+**VMI:**
+
+```mlir
+%rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even) : ...
+%out_f32 = pto.vmi.addf (pto.vmi.mulf %x, %cos), (pto.vmi.mulf %rot, %sin) : ...
+```
+
+**CCE / MI v2:**
+
+```c
+vdintlv(heven, hodd, xr, xr);
+vmul(hnegodd, hodd, negOne, maskPair, MODE_ZEROING);
+vintlv(hxnew, hxnew_hi, hnegodd, heven);
+vmul(hta, xr, cosr, mask, MODE_ZEROING);
+vmul(htb, hxnew, sinr, mask, MODE_ZEROING);
+vadd(htb, hta, htb, mask, MODE_ZEROING);
+```
+
+Same story, different vocabulary: **merge(−odd, even)** vs **vintlv after
+negate**.
+
+---
+
+### 5.5 f32 HALF — smallest win
+
+f32 is the “easy” case: dense loads, native fp32 compute, dense stores. MI is
+already readable if you ignore the mask on every line.
+
+**MI:**
+
+```mlir
+%t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : ...
+%y_lo = pto.vsub %t0, %t1, %mask32_half : ...
+pto.vsts %y_lo, %y_ub[%y_off], %mask32_half : ...
+```
+
+**VMI:**
+
+```mlir
+%x1_cos = pto.vmi.mulf %x1, %cos1 : ...
+%out1 = pto.vmi.subf %x1_cos, %x2_sin : ...
+pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
+```
+
+VMI still helps (uniform `vmi.load`, one mask type, no `pge_b32`), but this is
+not where you save days of debugging UNPK/PK issues.
+
+---
+
+### 5.6 f32 INTERLEAVE — Cartesian form; moderate win
+
+The f32 VMI example intentionally uses **Cartesian expansion** (like MI v1),
+not the complex-multiply fused path used for f16/bf16 VMI interleave:
+
+```mlir
+%y_even = pto.vmi.subf (pto.vmi.mulf %x_even, %cos_even),
+                       (pto.vmi.mulf %x_odd, %sin_even) : ...
+%y_odd  = pto.vmi.addf (pto.vmi.mulf %x_odd, %cos_odd),
+                       (pto.vmi.mulf %x_even, %sin_odd) : ...
+%out = "pto.vmi.channel_merge"(%y_even, %y_odd) : ...
+```
+
+This is honest: the math **is** the Cartesian expansion, and VMI makes it
+readable via `channel_split/merge` instead of `vdintlv/vintlv`. The win over MI
+is real but incremental — you are mostly shedding eight mask parameters and
+getting semantic shuffle names.
+
+Note: CCE f32 INTERLEAVE uses the **complex-multiply** path (like f16 v2), so
+VMI f32 interleave is **not** a line-for-line spelling match to CCE — it is an
+equivalent Cartesian organization chosen for clarity at the logical vector
+width.
+
+---
+
+## 6. What VMI does not fix (honest limits)
+
+1. **Tiling and strides** — `half_d_aligned`, `rep`/`blk` loops, `x_s_step`, and
+   DMA byte rounding are identical in burden across MI and VMI examples.
+
+2. **Not all MI spellings match** — MI v1 interleave (Cartesian) vs MI v2/CCE
+   (complex-multiply) vs VMI f32 interleave (Cartesian) vs VMI f16 interleave
+   (complex-multiply). VMI simplifies each spelling, but authors still pick the
+   spelling.
+
+3. **Bit-exact parity** — VMI f16 interleave uses fp32 middle math; CCE f16
+   interleave is native f16. Expect small numeric differences, not algorithmic
+   ones.
+
+4. **Performance visibility** — hiding `dist/part/PK` means the compiler must
+   choose correctly. For peak tuning, engineers still inspect lowered MI (same
+   as inspecting assembly after CCE).
+
+5. **HALF vs INTERLEAVE layout** — VMI does not choose NeoX vs GPT-J for you;
+   `mode` still branches the kernel.
+
+---
+
+## 7. Practical guidance
+
+| If you are… | Prefer |
+|-------------|--------|
+| Writing or reviewing RoPE math, especially bf16 | **VMI** |
+| Verifying against CCE sim / intrinsics golden | **MI v2** or **CCE** |
+| Debugging wrong lanes / padding / PK artifacts | Lowered **MI** (VMI source may hide the bug location) |
+| f32 HALF only, team already knows MI masks | Either; VMI is nicer, not essential |
+
+**Suggested reading order for new algorithm engineers:**
+
+1. Section 1 of this doc (math)
+2. `rope_bf16.vmi.pto` HALF loop body — best VMI showcase
+3. `rope_bf16.mi.pto` same section — see what VMI removed
+4. `rope_cce_compute.h` `ComputeBf16` — ground truth with educational comments
+5. `rope_f16_v2.mi.pto` — CCE-faithful MI reference for f16
+
+---
+
+## 8. One-page summary
+
+| Question | Answer |
+|----------|--------|
+| Same RoPE semantics? | **Yes**, modulo bf16/fp32 inner precision choices and f32 interleave spelling variant |
+| Cleaner syntax? | **Yes**, strongest for bf16, moderate for f16 interleave, modest for f32 HALF |
+| Closer to math? | **Yes** where VMI hides UNPK/PK/part and uses `channel_split/merge` for GPT-J |
+| Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling shell |
+| Still worth it if MI is v2-quality? | **Yes for bf16**; **marginal for f32 HALF** |
+
+VMI is not “RoPE in three lines.” It is **RoPE with the hardware contract moved
+into the compiler** — most valuable exactly where that contract is longest:
+**mixed-precision loads, widened compute, and interleaved layouts.**
+
+---
+
+## Example file index
+
+| File | Layer | Dtype | Notes |
+|------|-------|-------|-------|
+| `rope_f16.vmi.pto` | VMI | f16 | HALF native f16; INTERLEAVE complex-multiply + fp32 middle |
+| `rope_bf16.vmi.pto` | VMI | bf16 | **Best VMI demo** — extf/truncf throughout |
+| `rope_f32.vmi.pto` | VMI | f32 | HALF simple; INTERLEAVE Cartesian expansion |
+| `rope_f16.mi.pto` | MI v1 | f16 | INTERLEAVE Cartesian expansion; simplified tiling |
+| `rope_f16_v2.mi.pto` | MI v2 | f16 | CCE-faithful; INTERLEAVE complex-multiply |
+| `rope_bf16.mi.pto` | MI | bf16 | Full UNPK/EVEN/PK exposure |
+| `rope_f32.mi.pto` | MI | f32 | Mask on every op |
+| `rope_cce_compute.h` | CCE | all | Intrinsics ground truth |
+
+Related docs:
+
+- `PTO-Gym-vmi/docs/PTO-vmi-design.en.md`
+- `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
+- `PTO-Gym-vmi/docs/PTO-micro-Instruction-SPEC.md`

--- a/docs/examples/vmi/ROPE_VMI_vs_MI.md
+++ b/docs/examples/vmi/ROPE_VMI_vs_MI.md
@@ -1,169 +1,135 @@
-# RoPE on PTO: Why VMI Helps Algorithm Engineers
+# RoPE on PTO: VMI vs MI vs CCE
 
-This note compares the RoPE example kernels in this directory across three
-expression layers:
+This walkthrough explains the RoPE examples in this directory from the point of
+view of an algorithm engineer: keep the rotation math visible, but understand
+where the hardware/register details still matter.
 
-| Layer | Example files | Who it is for |
-|-------|---------------|---------------|
-| **CCE** | `rope_cce_compute.h` | Ground-truth intrinsics execution |
+| Layer | Example files | Use it for |
+|-------|---------------|------------|
+| **CCE** | `rope_cce_compute.h` | Intrinsics ground truth and expected UB behavior |
 | **MI** (`pto.mi`) | `rope_{f16,bf16,f32}.mi.pto`, `rope_f16_v2.mi.pto` | Hardware-faithful PTO micro-ops |
 | **VMI** (`pto.vmi`) | `rope_{f16,bf16,f32}.vmi.pto` | Logical-vector authoring |
 
-**Audience:** algorithm engineers who want the math to be visible in code and
-prefer not to manage SIMD register layout, mask families, or load/store
-distribution modes by hand.
+**How to use this note:** read it as a bridge between the RoPE equations and the
+actual VMI/MI/CCE code. The goal is to make it clear what each VMI instruction
+means, what MI/CCE pattern it usually lowers to, and which low-level details are
+worth checking when lanes or stores look wrong.
 
-**Scope:** the six RoPE variants in the examples — `{f16, bf16, f32} × {HALF,
-INTERLEAVE}` — on the fixed demo tile `D=64`. All examples share the same outer
-kernel shell (GM→UB DMA, pipeline flags, UB→GM writeback).
-
-**Reader contract:** after reading this note, you should be able to connect the
-RoPE equations to the VMI source, predict the main MI/CCE lowering shape
-(`dist`, `part`, masks, packing), and recognize the common lane-layout bugs VMI
-is meant to prevent.
-
-**Concrete VF tile used by the simulator examples:** the correctness tests use
-`sCount=15`, `nCount=32`, `dLen=dAlign=64`; the per-head stride is
-`xNStep=yNStep=csSStep=64`, and the per-sequence stride is
-`xSStep=ySStep=nCount*64=2048` elements. Wall-time configs also exercise
+**Concrete tile in the VF simulator:** correctness tests use `sCount=15`,
+`nCount=32`, `dLen=dAlign=64`; `xNStep=yNStep=csSStep=64`, and
+`xSStep=ySStep=nCount*64=2048` elements. Wall-time sweeps also use
 `(s,n)=(1,2),(15,4),(15,8),(15,16),(15,32)`.
 
-This document is intentionally honest: VMI is a real abstraction win in several
-places, but it is not magic, and it does not remove all low-level work.
+VMI is not a shortcut around the hardware. It keeps layout bookkeeping out of
+the source you write; it does not remove loop structure, UB strides, DMA,
+pipeline flags, or the need to inspect lowered MI for peak tuning.
 
 ---
 
-## 1. RoPE math (what every variant implements)
+## 1. RoPE Math
 
-RoPE rotates pairs of dimensions by a position-dependent angle θ using
-precomputed `(cos θ, sin θ)`.
+RoPE rotates pairs of dimensions by a position-dependent angle using precomputed
+`cos` and `sin` tables.
 
-### 1.1 HALF mode (NeoX / LLaMA-style layout)
+### HALF Mode
 
-The head dimension `D` is split into two contiguous halves. For each index `d`
-in the low half:
+The head dimension `D` is split into two contiguous halves. For `d < D/2`:
 
-```
+```text
 y[d]       = x[d]       * cos[d]       - x[d + D/2] * sin[d]
 y[d+D/2]   = x[d+D/2]   * cos[d+D/2] + x[d]       * sin[d+D/2]
 ```
 
-This is a **2×2 real rotation** applied independently to `(x_low, x_high)`
-pairs. No complex-number bookkeeping is required in code — just two fused
-half-vector updates.
+In the demo tile, `D=64`, so each partner half has `32` elements.
 
-### 1.2 INTERLEAVE mode (GPT-J-style layout)
+### INTERLEAVE Mode
 
-Adjacent elements form pairs: `(x[2k], x[2k+1])`. Two algebraically equivalent
-spellings appear in the examples:
+Adjacent elements form rotation pairs: `(x[2k], x[2k+1])`.
 
-**Complex-multiply form** (CCE, `rope_f16_v2.mi.pto`, f16/bf16 VMI interleave):
+The CCE path, `rope_f16_v2.mi.pto`, and f16/bf16 VMI examples use the
+complex-multiply spelling:
 
-```
+```text
 y = x * cos + (i*x) * sin
 ```
 
-where `(i*x)` in interleaved real layout is `[-x1, x0, -x3, x2, ...]`.
+where `(i*x)` in real interleaved layout is:
 
-**Cartesian expansion form** (`rope_f16.mi.pto` v1, f32 VMI interleave):
-
+```text
+[-x1, x0, -x3, x2, -x5, x4, ...]
 ```
+
+Some examples use the equivalent Cartesian spelling:
+
+```text
 y_even = x_even * cos_even - x_odd * sin_even
 y_odd  = x_odd  * cos_odd  + x_even * sin_odd
 ```
 
-after deinterleaving even/odd streams from `[x0, x1, x2, x3, ...]`.
+Both spellings produce the same RoPE result. They differ in which layout
+operations are needed around the math.
 
-Both are standard; they differ in **how** you schedule the SIMD ops, not in the
-RoPE result.
+### bf16 Numerics
 
-### 1.3 bf16 numerics
-
-For bf16 paths, **x/y are bf16** but **cos/sin are fp16**, and the inner
-compute is done in **fp32** before narrowing back to bf16. This matches the CCE
-reference (`ComputeBf16`), not native bf16 arithmetic throughout.
+For bf16 RoPE, `x` and `y` are bf16, `cos` and `sin` are fp16, and the inner
+arithmetic is fp32 before narrowing back to bf16. This matches
+`ComputeBf16` in the CCE reference.
 
 ---
 
-## 2. What VMI actually is
+## 2. What VMI Changes
 
-VMI (`pto.vmi`) sits between your algorithm and MI (`pto.mi`). You write
-**logical contiguous vectors** (`!pto.vmi.vreg<N×T>`) and **semantic ops**
-(`vmi.load`, `vmi.mulf`, `vmi.extf`, `channel_split`, …). The compiler
-(`pto.as`) lowers to MI instructions with the correct `dist`, `part`, `PK/UNPK`,
-and mask granularity.
+VMI (`pto.vmi`) lets the author write logical vectors such as
+`!pto.vmi.vreg<64xbf16>` and semantic operations such as `vmi.load`,
+`vmi.extf`, `vmi.mulf`, `channel_split`, and `vmi.masked_store`.
 
-See `PTO-Gym-vmi/docs/PTO-vmi-design.en.md` for
-the full design.
+The compiler lowers that logical view to MI instructions with concrete:
 
-**VMI removes:** per-op mask plumbing, register layout choices, and
-type-conversion protocol details.
+- load/store distributions such as `UNPK_B16`, `PK_B32`, and `NORM`
+- conversion parts such as `PART_EVEN`
+- mask families such as `b16` and `b32`
+- shuffle operations such as `vdintlv` and `vintlv`
 
-**VMI does not remove:** loop nesting (`s → rep/blk → n`), stride/alignment
-math, DMA setup, or pipeline synchronization. Those remain visible in the
-examples.
+The conversion names intentionally mirror MLIR `arith` vocabulary:
 
-The VMI cast names intentionally follow MLIR `arith` vocabulary. `pto.vmi.extf`
-means “extend each logical lane to a wider floating type”, and
-`pto.vmi.truncf` means “narrow each logical lane to the destination floating
-type”. They are not claims about the number of hardware instructions. On bf16
-RoPE, one `extf` may lower through `vlds UNPK_B16` and `vcvt PART_EVEN`; one
-`truncf` plus `masked_store` may lower through `vcvt PART_EVEN` and `vsts
-PK_B32`. The abstraction is about preserving the algorithmic lane contract, not
-making the hardware layout disappear.
+- `pto.vmi.extf`: extend each logical lane to a wider floating type
+- `pto.vmi.truncf`: narrow each logical lane to the destination floating type
+
+These names describe lane-wise meaning; they are not one-instruction promises. For example, bf16
+`extf` often lowers to an unpacked load plus `vcvt PART_EVEN`; bf16 `truncf`
+plus `masked_store` lowers to a narrow plus `PK_B32` store.
 
 ---
 
-## 3. Instruction map: math → MI → VMI
+## 3. How to Read the Examples
 
-The table below connects the math step to what you write at each layer.
+Tag each instruction by role:
 
-| Math intent | CCE intrinsic | MI (`pto.mi`) | VMI (`pto.vmi`) |
-|-------------|---------------|---------------|-----------------|
-| Load a logical vector from UB | `vlds` (`NORM` / `UNPK_B16`) | `pto.vlds` (+ optional `{dist = "UNPK_B16"}`) | `pto.vmi.load` |
-| Widen bf16/fp16 → fp32 | `vcvt` (`PART_EVEN`, `MODE_ZEROING`) | `pto.vcvt {part = "EVEN"}` | `pto.vmi.extf` |
-| Narrow fp32 → bf16/fp16 | `vcvt` (`ROUND_R`, `RS_DISABLE`, `PART_EVEN`, `MODE_ZEROING`) | `pto.vcvt {part = "EVEN", rnd, sat}` | `pto.vmi.truncf` |
-| Element-wise multiply / add / sub | `vmul` / `vadd` / `vsub` (`MODE_ZEROING` + mask) | same + **mask on every op** | `vmi.mulf` / `addf` / `subf` (no mask) |
-| Tail / partial vector mask | `plt_b16` / `plt_b32` (`POST_UPDATE`) | `pto.plt_b16` / `pge_b32 "PAT_VL32"` | `pto.vmi.create_mask %active` |
-| Split interleaved even/odd | `vdintlv` | `pto.vdintlv` | `pto.vmi.channel_split` |
-| Negate odd lane stream | `vbr` + `vmul` (`MODE_ZEROING`) | same | `pto.vmi.negf` |
-| Merge even/odd back | `vintlv` | `pto.vintlv` | `pto.vmi.channel_merge` |
-| Store with tail mask | `vsts` (`NORM_B16` / `NORM_B32` / `PK_B32` + mask) | `pto.vsts` (+ optional `{dist = "PK_B32"}`) + mask | `pto.vmi.masked_store` |
+| Role | Question | RoPE examples |
+|------|----------|---------------|
+| **MATH** | Does it change the numeric value? | `mulf`, `addf`, `subf`, `negf` |
+| **TYPE** | Does it change dtype while preserving lane `i`? | `extf`, `truncf`, `vcvt` |
+| **LAYOUT** | Does it only move lanes or repair physical placement? | `UNPK_B16`, `PK_B32`, `PART_EVEN`, `vdintlv`, `vintlv` |
+| **MEMORY** | Does it cross the UB/register boundary? | `load`, `masked_store`, `vlds`, `vsts` |
 
-How to read the instruction map:
+VMI source mostly shows **MATH** and **TYPE**. MI/CCE show the **LAYOUT** and
+**MEMORY** work because the author is addressing physical vector registers.
 
-- `vmi.load` is a logical UB load. In f32 and dense f16 cases it lowers close to
-  `vlds NORM`. In bf16/f16 widen paths it may need `UNPK_B16` so that the next
-  MI `vcvt PART_EVEN` sees valid halfword lanes.
-- `vmi.mulf`, `vmi.addf`, and `vmi.subf` are element-wise arithmetic on logical
-  vectors. MI still needs `mask<b16>` or `mask<b32>` on every arithmetic op;
-  VMI carries the active-lane predicate at load/store or higher-level mask
-  creation points.
-- `channel_split` and `channel_merge` describe parity layout intent. They are
-  the VMI names for the same even/odd axis that MI exposes with `vdintlv` and
-  `vintlv`.
-- `masked_store` says “write active logical lanes”. MI still decides whether the
-  store is a plain `NORM_*` store or a packing store such as `PK_B32`.
+### Instruction Map
 
-### 3.1 How to use the side-by-side snippets
+| Math intent | CCE / MI shape | VMI shape |
+|-------------|----------------|-----------|
+| Load a logical vector | `vlds NORM` or `vlds UNPK_B16` | `pto.vmi.load` |
+| Widen bf16/f16 to fp32 | `vcvt {part=EVEN/ODD}` | `pto.vmi.extf` |
+| Narrow fp32 to bf16/f16 | `vcvt {rnd, sat, part}` | `pto.vmi.truncf` |
+| Multiply / add / subtract | `vmul` / `vadd` / `vsub` + concrete mask | `vmi.mulf` / `addf` / `subf` |
+| Split adjacent pairs | `vdintlv` | `pto.vmi.channel_split` |
+| Merge even/odd streams | `vintlv` | `pto.vmi.channel_merge` |
+| Store active lanes | `vsts NORM_*` or `PK_B32` + mask | `pto.vmi.masked_store` |
 
-When reading the walkthroughs below, separate each instruction into one of four
-roles:
+### Expected Lowering Shapes
 
-| Role | Question to ask | RoPE examples |
-|------|-----------------|---------------|
-| **MATH** | Does this change the value? | `mulf`, `addf`, `subf`, `negf` |
-| **TYPE** | Does this change dtype while preserving logical lane `i`? | `extf`, `truncf`, `vcvt` |
-| **LAYOUT** | Does this only move lanes around? | `UNPK_B16`, `PK_B32`, `PART_EVEN`, `vdintlv`, `vintlv` |
-| **MEMORY** | Does this cross the UB/register boundary? | `vmi.load`, `masked_store`, `vlds`, `vsts` |
-
-Most VMI lines are **MATH** or **TYPE**. Many MI/CCE lines are **LAYOUT** or
-**MEMORY** required by the 256-byte register contract.
-
-### 3.2 Expected lowering shapes for recurring VMI ops
-
-These are not formal lowering rules, but they are useful review expectations for
-the concrete examples in this directory.
+These are review expectations for the examples, not formal lowering rules.
 
 **bf16 load + widen in HALF mode:**
 
@@ -179,8 +145,8 @@ Expected MI/CCE shape:
 %x32 = pto.vcvt %x16_phys, %mask16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
 ```
 
-The `EVEN` part is not an optimization; it is required because `UNPK_B16` places
-dense bf16 memory values into even physical lanes.
+`PART_EVEN` is a correctness requirement because `UNPK_B16` places dense bf16
+memory values into even physical lanes.
 
 **bf16 narrow + store:**
 
@@ -197,12 +163,13 @@ pto.vsts %y16_phys, %y_ub[%off], %mask32 {dist = "PK_B32"} : ...
 ```
 
 `truncf` preserves logical lane order; `PK_B32` repairs the physical even-lane
-layout before values reach dense UB memory.
+layout before the values are written densely to UB.
 
 **INTERLEAVE rotation helper:**
 
 ```mlir
 %even, %odd = "pto.vmi.channel_split"(%x) : ...
+%neg_odd = pto.vmi.negf %odd : ...
 %rot = "pto.vmi.channel_merge"(%neg_odd, %even) : ...
 ```
 
@@ -210,311 +177,33 @@ Expected MI/CCE shape:
 
 ```mlir
 %even, %odd = pto.vdintlv %x, %x : ...
+%neg_odd = pto.vmul %odd, %minus_one, %mask : ...
 %rot, %rot_hi = pto.vintlv %neg_odd, %even : ...
 ```
 
-The argument order matters: `channel_merge(neg_odd, even)` builds
-`[-x1, x0, -x3, x2, ...]`, i.e. `(i*x)` in GPT-J interleaved layout.
-
-### 3.3 MI details algorithm engineers should not have to memorize
-
-These are the hardware subtleties VMI is designed to hide:
-
-**UNPK_B16 load:** 64 dense b16 elements in memory expand into a 128-lane
-physical register with valid values only at **even** halfword positions; odd
-lanes are padding. If you later widen with the wrong `part`, you read zeros or
-garbage.
-
-**PART_EVEN vcvt:** selects the even-position lanes after an UNPK load. Required
-for bf16/fp16 widen paths in MI.
-
-**PK_B32 store:** packs bf16 values scattered at even register positions back
-into dense memory. Required after narrowing in MI bf16 paths.
-
-**Mask family mismatch:** f16 arithmetic uses `!pto.mask<b16>`; fp32 uses
-`!pto.mask<b32>`. A bf16 kernel typically needs **both** in the same loop body.
-
-**vdintlv / vintlv:** hardware deinterleave/interleave with a specific lane
-mapping. Correct for performance, opaque for reading.
-
-VMI replaces these with “load 64 bf16”, “extend to fp32”, “store bf16”, and
-“split/merge even/odd channels”.
-
-### 3.4 Common bugs VMI helps avoid
-
-- **Wrong `part` after `UNPK_B16`:** using `PART_ODD` instead of `PART_EVEN`
-  reads padding lanes, not bf16 values.
-- **Wrong store distribution after bf16 narrow:** a dense `NORM_B16` store after
-  even-lane narrow leaks padded lane layout into UB; bf16 paths need `PK_B32`.
-- **Swapped interleave merge order:** `merge(even, neg_odd)` is not `(i*x)`;
-  the CCE/VMI complex-multiply spelling needs `merge(neg_odd, even)`.
-- **Mask-family drift:** bf16 paths mix `b16` load/convert masks with `b32`
-  arithmetic masks. VMI keeps one logical active-lane mask and lets lowering pick
-  the concrete predicate family.
-
-### 3.5 Physical register model (256-byte contract, D=64 demo)
-
-Every A5 vector register is **256 bytes**. The RoPE examples process one head row
-of **D=64** elements per inner tile. How those 64 elements map to physical
-registers depends on **dtype** and **layout mode**:
-
-| Case | Memory bytes (64 elems) | Typical physical reg | Load `dist` |
-|------|-------------------------|----------------------|-------------|
-| f16 / fp16 dense | 128 B | `vreg<128×f16>` (64 active lanes) | `NORM` |
-| bf16 dense | 128 B | `vreg<128×bf16>` after UNPK | `UNPK_B16` |
-| f32 dense | 256 B | `vreg<64×f32>` | `NORM` |
-| GPT-J interleaved (all dtypes) | same as above | one dense reg, then parity split | as above + `vdintlv` |
-
-**Logical view (VMI):** `!pto.vmi.vreg<64×T>` or `!pto.vmi.vreg<128×T>` means
-elements `0..N−1` in algorithm order. HALF mode treats indices `[0..D/2−1]` and
-`[D/2..D−1]` as **partner halves**. INTERLEAVE mode treats `(2k, 2k+1)` as
-**rotation pairs**.
-
-**Physical view (MI/CCE):** each register has **lane slots** with placement
-rules. UNPK, `part=EVEN/ODD`, `vdintlv`/`vintlv`, and `PK_B32` are not math —
-they maintain the mapping between lane slot and logical index.
-
-RoPE at D=64 is **smaller** than block MX quant (256-wide rows), so you rarely
-need `DINTLV_B16` split loads in these examples. The dominant layout axes here
-are **UNPK/PK** (bf16), **parity shuffle** (INTERLEAVE), and **mask family**
-(b16 vs b32).
-
-See also `BLOCK_MX_QUANT_VMI_vs_MI.md` §3.5–§3.9 for the same 256B contract
-applied to 256-element quant rows (where `DINTLV` + four `vintlv` steps appear).
-
-### 3.6 UNPK_B16 load and PK_B32 store (bf16 / fp16 dense paths)
-
-bf16 RoPE loads **64 dense halfwords** from UB, but a b16 register holds
-**128 lanes**. `UNPK_B16` expands each memory element into an **even physical
-lane**, leaving odd lanes as zero/padding:
-
-```
-Memory (32 dense bf16 in one HALF tile, D/2=32):
-  [b0, b1, b2, ..., b31]   ← 64 bytes
-
-After UNPK_B16 → vreg<128×bf16> (256 B):
-  phys lane:  0    1    2    3    4  ...  62   63   64  ... 127
-  holds:      b0   __   b1   __   b2  ...  b31  __   __  ...  __
-              ↑ even only; odd lanes are padding
-```
-
-**Widen:** `vcvt {part=EVEN}` reads lanes `0,2,4,…,126` → **64×f32** register
-with the 32 meaningful values in the active mask lanes. Using `part=ODD` would
-read the padding lanes and produce garbage — CCE documents this explicitly in
-`ComputeBf16`.
-
-**Narrow + store:** `vcvt {part=EVEN}` writes fp32 results back into even b16
-lanes, then `vsts {dist=PK_B32}` extracts even lanes and packs them into **dense
-memory**:
-
-```
-After PART_EVEN narrow → vreg<128×bf16>:
-  [y0, __, y1, __, y2, __, ...]
-
-PK_B32 store → memory:
-  [y0, y1, y2, ...]   ← dense again
-```
-
-**VMI:** `vmi.load` → `vreg<64×bf16>`, `vmi.extf` / `vmi.truncf`, `vmi.masked_store`.
-The UNPK → EVEN → PK chain is compiler lowering, not author code.
-
-### 3.7 HALF mode — contiguous halves (NeoX layout)
-
-HALF mode splits **D=64** into two partner blocks of **32 elements** each. No
-parity deinterleave is required — partners are already contiguous in memory:
-
-```
-Logical head row (D=64):
-  x[0..31]  = low half (x1)     partner with  x[32..63] = high half (x2)
-
-Memory layout (HALF):
-  ┌─────────────────┬─────────────────┐
-  │  x[0] … x[31]   │ x[32] … x[63]   │
-  └─────────────────┴─────────────────┘
-     load x_lo          load x_hi  (+halfD or +halfD_aligned offset)
-```
-
-**f16 / f32 HALF (dense):** each half fits in one register. MI loads
-`vreg<128×f16>` with a **32-lane tail mask** (`pge_b16 "PAT_VL32"` or dynamic
-`plt_b16` in v2). Only the low 32 physical lanes hold data; the register is
-128-wide because that is the native b16 vector width.
-
-**bf16 HALF:** each half uses UNPK (§3.6) + fp32 compute + PK store. MI needs
-**two mask families** in one loop body: `mask<b16>` for UNPK load and PART_EVEN
-widen of cos/sin, `mask<b32>` for fp32 `vmul`/`vsub`/`vadd`.
-
-**Physical register picture (bf16 HALF, one partner half):**
-
-```
-cos_lo_16  ──UNPK──► [c0,__,c1,__,…] ──PART_EVEN──► cos_lo (64×f32, 32 active)
-x_lo_16    ──UNPK──► [x0,__,x1,__,…] ──PART_EVEN──► x_lo  (64×f32, 32 active)
-                              │
-                              ├── vmul / vsub / vadd  (mask<b32>)
-                              ▼
-y_lo_f32 (64×f32) ──PART_EVEN narrow──► [y0,__,y1,__,…] ──PK_B32──► dense UB
-```
-
-VMI names the same math on logical `vreg<64×bf16>` / `vreg<64×f32>` without
- exposing the even-lane landing zone.
-
-### 3.8 INTERLEAVE mode — parity axis (GPT-J layout)
-
-GPT-J layout stores rotation pairs as **adjacent elements**:
-
-```
-Logical (D=64 interleaved):
-  [x0, x1,  x2, x3,  x4, x5, ... x62, x63]
-   └── pair 0 ──┘  └── pair 1 ──┘
-```
-
-Hardware `vdintlv` / `vintlv` implement the **parity axis** — the same axis
-used by `PART_EVEN`/`PART_ODD` on widen, but here applied to **already-widened
-or dense b16/f16 vectors** to separate even- and odd-indexed streams:
-
-```
-Dense reg x (128 lanes, 64 active interleaved):
-  [x0, x1, x2, x3, x4, x5, x6, x7, ...]
-
-vdintlv(x, x) →
-  x_even: [x0, x2, x4, x6, ...]     ← even logical indices
-  x_odd:  [x1, x3, x5, x7, ...]     ← odd logical indices
-```
-
-**Complex-multiply form** (CCE, `rope_f16_v2.mi.pto`, f16/bf16 VMI): build
-`(i·x)` in interleaved layout without splitting cos/sin:
-
-```
-x_even, x_odd = vdintlv(x)
-neg_x_odd     = x_odd * (-1)
-x_rot, _      = vintlv(neg_x_odd, x_even)   → [-x1, x0, -x3, x2, ...]
-
-y = x*cos + x_rot*sin                     ← 3 arithmetic ops on dense regs
-```
-
-Physical effect of `vintlv(neg_x_odd, x_even)` (8-element sketch):
-
-```
-neg_x_odd:  [-x1, -x3, -x5, -x7]
-x_even:     [ x0,  x2,  x4,  x6]
-
-x_rot:      [-x1, x0, -x3, x2, -x5, x4, -x7, x6]   ← interleaved (i·x)
-```
-
-**Cartesian expansion form** (MI v1, f32 VMI interleave): deinterleave **all**
-streams, compute even/odd updates separately, merge back:
-
-```
-cos_even, cos_odd = vdintlv(cos)
-sin_even, sin_odd = vdintlv(sin)
-x_even,   x_odd   = vdintlv(x)
-
-y_even = x_even*cos_even - x_odd*sin_even
-y_odd  = x_odd*cos_odd  + x_even*sin_odd
-
-y, _ = vintlv(y_even, y_odd)    ← re-pack to [y0,y1,y2,y3,...]
-```
-
-Same RoPE result; **more layout ops** in the Cartesian path (three `vdintlv` on
-tables + one `vintlv` repack vs one `vdintlv` + one `vintlv` on `x` only).
-
-**VMI mapping:**
-
-| MI/CCE | VMI | Physical meaning |
-|--------|-----|------------------|
-| `vdintlv` | `channel_split` | dense → even/odd parity streams |
-| `vintlv` | `channel_merge` | even/odd → dense interleaved |
-| `vmul` + `vbr(-1)` | `negf` | negate odd stream |
-
-### 3.9 Mask families and predicate width
-
-MI RoPE kernels often carry **two predicate granularities** in one loop:
-
-| Mask type | Used for | Example |
-|-----------|----------|---------|
-| `!pto.mask<b16>` | UNPK loads, b16 `vcvt`, dense f16 `vmul`, `plt_b16` tails | bf16 load/widen; f16 interleave |
-| `!pto.mask<b32>` | fp32 `vmul`/`vsub`/`vadd`, PART_EVEN narrow, `PK_B32` store | bf16 HALF compute body |
-
-A bf16 HALF loop typically creates **both** `%mask16_all` and `%mask32_half`.
-Using a b16 mask on a b32 op (or vice versa) is a silent wrong-lane bug.
-
-VMI uses one logical `!pto.vmi.mask<N×pred>` per tile; the compiler lowers to
-the correct `pset`/`plt`/`punpack` family.
-
-### 3.10 Variant → layout complexity (honest map)
-
-| Variant | Physical layout burden | Dominant MI ops beyond arithmetic |
-|---------|------------------------|-----------------------------------|
-| **f32 HALF** | Low | Tail mask only |
-| **f16 HALF** | Low | Tail mask; 128-wide reg, 32 active lanes |
-| **bf16 HALF** | **High** | UNPK, PART_EVEN ×2, PK_B32, dual masks |
-| **f16 INTERLEAVE v2** | Medium | `vdintlv`, `vbr`, `vintlv` on `x`; dense cos/sin |
-| **f16 INTERLEAVE v1** | **High** | `vdintlv` ×3, 8 arith, `vintlv` repack |
-| **bf16 INTERLEAVE** | **High** | UNPK/PK chain + parity shuffle in fp32 |
-| **f32 INTERLEAVE VMI** | Medium | Cartesian `channel_split/merge`; no UNPK |
+Argument order matters: `merge(neg_odd, even)` builds
+`[-x1, x0, -x3, x2, ...]`.
 
 ---
 
-## 4. Advantage by variant (ranked)
+## 4. Running Example: bf16 HALF
 
-Honest ranking of **VMI syntax / intuitiveness / math closeness** vs MI,
-from largest win to smallest:
+This is the best RoPE showcase because the algorithm is small while the MI
+layout protocol is long.
 
-| Rank | Variant | VMI advantage | Why |
-|------|---------|---------------|-----|
-| 1 | **bf16 HALF** | **Very large** | MI exposes the full UNPK→EVEN→compute→EVEN→PK chain + dual mask families on every op |
-| 2 | **bf16 INTERLEAVE** | **Very large** | Same conversion chain, plus `channel_split/merge/negf` vs `vdintlv/vintlv/vbr` |
-| 3 | **f16 INTERLEAVE** | **Large** | `channel_split → negf → channel_merge` reads as “build i·x”; optional fp32 middle via `extf/truncf` |
-| 4 | **f32 INTERLEAVE** | **Moderate** | Cartesian expansion is already readable; VMI mainly removes per-op masks and names shuffles semantically |
-| 5 | **f16 HALF** | **Moderate** | Core 6-op math is identical; VMI drops mask args and uses logical `create_mask` |
-| 6 | **f32 HALF** | **Small** | MI f32 HALF is already close to the math; VMI mostly removes redundant mask parameters |
+Math:
 
-**Takeaway:** the further you are from “native dense fp32 load/compute/store”, the
-more VMI pays off. **bf16 is the headline case.**
-
-If MI is written like `rope_f16_v2.mi.pto` (CCE-faithful loops and masks), VMI
-still wins on **bf16** and **mask-free arithmetic**, but the **algorithm
-structure** gap shrinks — you are mostly comparing syntax sugar vs hardware
-protocol.
-
----
-
-## 5. Walkthroughs
-
-### 5.1 bf16 HALF — largest VMI win
-
-**Math (fp32 inner loop):**
-
-```
-y1 = x1 * cos - x2 * sin
-y2 = x2 * cos + x1 * sin
+```text
+y1 = x1 * cos1 - x2 * sin1
+y2 = x2 * cos2 + x1 * sin2
 ```
 
-**MI** (`rope_bf16.mi.pto`) — one cos load/widen sequence:
-
-```mlir
-%cos_lo_16 = pto.vlds %cos_ub[%cs_off] {dist = "UNPK_B16"} : ... -> !pto.vreg<128xf16>
-%cos_lo = pto.vcvt %cos_lo_16, %mask16_all {part = "EVEN"} : ... -> !pto.vreg<64xf32>
-// ... repeat for sin, x halves ...
-%t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : ...
-%t1 = pto.vmul %sin_lo, %x_hi, %mask32_half : ...
-%y_lo_f32 = pto.vsub %t0, %t1, %mask32_half : ...
-%y_lo_16 = pto.vcvt %y_lo_f32, %mask32_half {part = "EVEN", rnd = "R", sat = "SAT"} : ...
-pto.vsts %y_lo_16, %y_ub[%y_off], %mask32_half {dist = "PK_B32"} : ...
-```
-
-Reading this as an algorithm engineer:
-
-- Four instruction **families** before the first multiply: UNPK load, EVEN
-  widen, masked fp32 op, EVEN narrow + PK store.
-- `%mask16_all` for loads/converts, `%mask32_half` for compute — easy to mix up.
-- `{part = "EVEN"}` is a correctness requirement, not an optimization knob.
-
-**VMI** (`rope_bf16.vmi.pto`) — same cos load/widen:
+VMI source shape:
 
 ```mlir
 %cos1_16 = pto.vmi.load %cos_ub[%cos1_off] : ... -> !pto.vmi.vreg<64xf16>
 %cos1 = pto.vmi.extf %cos1_16 : ... -> !pto.vmi.vreg<64xf32>
-// ...
+%x1 = pto.vmi.extf %x1_16 : ... -> !pto.vmi.vreg<64xf32>
 %x1_cos = pto.vmi.mulf %x1, %cos1 : ...
 %x2_sin = pto.vmi.mulf %x2, %sin1 : ...
 %out1_f32 = pto.vmi.subf %x1_cos, %x2_sin : ...
@@ -522,393 +211,193 @@ Reading this as an algorithm engineer:
 pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
 ```
 
-This reads as the math plus dtype semantics: **load → widen → compute →
-truncate → store**. The compiler chooses UNPK/PART_EVEN/PK_B32 and mask
-families.
+MI/CCE must expose:
 
-Instruction-by-instruction, that means:
+- `UNPK_B16` load for dense halfword data
+- `PART_EVEN` widen to fp32
+- `mask<b16>` for load/convert and `mask<b32>` for fp32 arithmetic
+- `PART_EVEN` narrow
+- `PK_B32` store back to dense bf16 UB
 
-- `%cos1_16 = pto.vmi.load ... -> vreg<64xf16>` reads the table as 64 logical
-  f16 lanes. The MI equivalent has to remember that a b16 physical register is
-  128 lanes and that `UNPK_B16` places useful values on even lanes.
-- `%cos1 = pto.vmi.extf %cos1_16` is the same semantic operation as
-  `arith.extf` lifted to a VMI vector register. The MI equivalent is `vcvt
-  PART_EVEN` because of the previous unpacked physical layout.
-- `%x1_cos = pto.vmi.mulf %x1, %cos1` is exactly the first term in
-  `x1*cos`. The MI equivalent is `vmul` plus `mask<b32>`.
-- `%out1_f32 = pto.vmi.subf %x1_cos, %x2_sin` is the low-half RoPE subtraction.
-  No hidden numerical trick is implied; it is the same fp32 subtract as MI/CCE.
-- `%out1 = pto.vmi.truncf %out1_f32` narrows each logical lane back to bf16.
-  MI must spell the rounding/saturation and destination part explicitly.
-- `pto.vmi.masked_store` writes the active logical lanes. MI/CCE use `vsts
-  PK_B32` here because the narrowed bf16 values live in even physical lanes.
+Physical pipeline for one 32-element partner half:
 
-**CCE** (`ComputeBf16` HALF) documents the same protocol explicitly in comments
-— excellent for verification, heavy for authoring.
+```text
+UB dense bf16
+  -> UNPK_B16:       [x0, __, x1, __, ...]
+  -> vcvt EVEN:      64xf32 logical values
+  -> vmul/sub/add:   fp32 RoPE math
+  -> vcvt EVEN:      [y0, __, y1, __, ...]
+  -> PK_B32 store:   UB dense bf16
+```
 
-**Physical layout (bf16 HALF, one 32-element partner half):**
-
-| Step | MI/CCE op | Register state (logical indices) |
-|------|-----------|----------------------------------|
-| 0 | UB memory | 32 dense bf16: `x[0..31]` or `x[32..63]` |
-| 1 | `vlds UNPK_B16` | 128×bf16 even lanes: phys `2k → x[k]` |
-| 2 | `vcvt PART_EVEN` | 64×f32: active lanes hold same 32 values |
-| 3 | `vmul` / `vsub` / `vadd` | fp32 partners combined (`mask<b32>`) |
-| 4 | `vcvt PART_EVEN` narrow | bf16 back into even lanes of 128×bf16 |
-| 5 | `vsts PK_B32` | dense 32 bf16 in UB |
-
-VMI collapses steps 1–2 into `vmi.load` + `vmi.extf`, steps 4–5 into
-`vmi.truncf` + `vmi.masked_store`.
+VMI collapses the layout protocol into `load`, `extf`, `truncf`, and
+`masked_store`, so the source reads as dtype-aware RoPE math.
 
 ---
 
-### 5.2 bf16 INTERLEAVE — complex-multiply form in VMI
+## 5. Running Example: INTERLEAVE
 
-**Math:**
+For GPT-J layout, the useful mental model is:
 
+```text
+x          = [x0, x1, x2, x3, ...]
+channel_split(x) -> even=[x0,x2,...], odd=[x1,x3,...]
+channel_merge(-odd, even) -> [-x1,x0,-x3,x2,...] = i*x
+y = x*cos + (i*x)*sin
 ```
-y = x * cos + (i*x) * sin
-```
 
-**VMI** (`rope_bf16.vmi.pto`):
+VMI complex-multiply shape:
 
 ```mlir
-%x = pto.vmi.extf %x16 : ... -> !pto.vmi.vreg<128xf32>
-%x_even, %x_odd = "pto.vmi.channel_split"(%x) : ... -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
+%x_even, %x_odd = "pto.vmi.channel_split"(%x) : ...
 %neg_x_odd = pto.vmi.negf %x_odd : ...
-%rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even) : ... -> !pto.vmi.vreg<128xf32>
+%rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even) : ...
 %x_cos = pto.vmi.mulf %x, %cos : ...
 %rot_sin = pto.vmi.mulf %rot, %sin : ...
-%y_f32 = pto.vmi.addf %x_cos, %rot_sin : ...
-%y16 = pto.vmi.truncf %y_f32 : ... -> !pto.vmi.vreg<128xbf16>
+%y = pto.vmi.addf %x_cos, %rot_sin : ...
 ```
 
-Instruction meaning for algorithm engineers:
+The CCE and `rope_f16_v2.mi.pto` spelling is structurally the same but uses
+`vdintlv`, `vbr(-1)`, `vmul`, and `vintlv`.
 
-- **`channel_split`:** `[e0,o0,e1,o1,…] → (even=[e0,e1,…], odd=[o0,o1,…])`.
-  Semantic name for MI `vdintlv`.
-- **`negf`:** negate the odd stream → `-odd`.
-- **`channel_merge`:** interleave `(-odd, even)` → `[-o0,e0,-o1,e1,…]`, which
-  is `(i*x)` in interleaved layout.
-- **`mulf` / `addf`:** the two-term complex multiply, mask-free.
-
-**MI v1** (`rope_bf16.mi.pto`) uses **Cartesian expansion** instead: deinterleave
-cos, sin, **and** x, then eight masked fp32 ops, then `vintlv`, then narrow +
-PK store. Correct, but the code looks like a shuffle kernel, not `y = x·cos +
-(i·x)·sin`.
-
-**MI v2 f16** (`rope_f16_v2.mi.pto`) matches the CCE complex-multiply path and
-is closer to VMI structurally — but still uses `vbr`, `plt_b16`, and masked
-`vmul/vadd`.
-
-**Physical layout (bf16 INTERLEAVE, complex-multiply, one 64-element row):**
-
-```
-UB dense (64 bf16 interleaved):  x0 x1 x2 x3 ... x63
-        │ UNPK + PART_EVEN widen
-        ▼
-x (64×f32 logical, interleaved in one dense fp32 reg)
-        │ channel_split  ≡  vdintlv(x, x)
-        ├──────────────┬──────────────
-        ▼              ▼
-   x_even         x_odd        [x0,x2,...] [x1,x3,...]
-        │ negf         │
-        └──────┬───────┘
-               │ channel_merge(neg_odd, even)  ≡  vintlv
-               ▼
-   x_rot = [-x1,x0,-x3,x2,...]     cos, sin stay dense (no vdintlv)
-               │
-               └── mulf/addf:  y = x*cos + x_rot*sin
-                       │ truncf + PK
-                       ▼
-               dense bf16 interleaved out
-```
-
-Cartesian MI v1 instead runs `vdintlv` on cos/sin **and** x, performs eight
-masked ops on parity streams, then `vintlv(y_even, y_odd)` to rebuild interleaved
-output — see §3.8.
+The Cartesian spelling splits `x`, `cos`, and `sin`, computes `y_even` and
+`y_odd`, and merges them back. It is equally valid, but it has more explicit
+shuffle and arithmetic lines. The f32 VMI interleave example uses this spelling,
+so it is not line-for-line identical to CCE even though the math is equivalent.
 
 ---
 
-### 5.3 f16 HALF — moderate win
+## 6. Variant Map
 
-The six-op HALF core is the same everywhere:
+| Variant | VMI advantage | Main hardware detail hidden |
+|---------|---------------|-----------------------------|
+| **bf16 HALF** | Very large | UNPK → EVEN → fp32 compute → EVEN → PK, plus dual masks |
+| **bf16 INTERLEAVE** | Very large | bf16 conversion chain plus parity split/merge |
+| **f16 INTERLEAVE** | Large | `vdintlv`/`vintlv` and explicit negate stream |
+| **f32 INTERLEAVE** | Moderate | semantic `channel_split/merge`, fewer mask arguments |
+| **f16 HALF** | Moderate | mask plumbing and 128-lane physical register width |
+| **f32 HALF** | Small | MI is already close to math; VMI mostly removes masks |
 
-```
-out1 = x1*cos - x2*sin
-out2 = x2*cos + x1*sin
-```
-
-**MI** (every op carries a mask):
-
-```mlir
-%t0 = pto.vmul %cos_lo, %x_lo, %mask16 : ...
-%t1 = pto.vmul %sin_lo, %x_hi, %mask16 : ...
-%y_lo = pto.vsub %t0, %t1, %mask16 : ...
-```
-
-**VMI:**
-
-```mlir
-%x1_cos = pto.vmi.mulf %x1_16, %cos1_16 : ...
-%x2_sin = pto.vmi.mulf %x2_16, %sin1_16 : ...
-%out1 = pto.vmi.subf %x1_cos, %x2_sin : ...
-```
-
-VMI advantage here is **clarity, not algorithm**: masks and load/store dist
-modes disappear from the math block. Loop tiling (`rep`, `half_d_aligned`,
-dynamic tail) remains equally verbose in both.
-
-**Physical layout (f16 HALF):** partners are **two separate dense loads**, not a
-parity split. For D=64 with `halfD=32`:
-
-```
-x_lo reg (128×f16):  lanes 0..31 ← x[0..31]     (mask covers 32 lanes)
-x_hi reg (128×f16):  lanes 0..31 ← x[32..63]    (loaded from x + halfD_aligned)
-
-Six fp32-equivalent ops (native f16 here):
-  y_lo = cos_lo * x_lo - sin_lo * x_hi
-  y_hi = cos_hi * x_hi + sin_lo * x_lo
-```
-
-No `vdintlv`/`vintlv` — the NeoX layout already matches how HALF loads data.
+Takeaway: VMI helps most when the value is far from “dense fp32 load, compute,
+store.” Mixed precision and interleaved layouts are the headline cases.
 
 ---
 
-### 5.4 f16 INTERLEAVE — VMI matches CCE math spelling
+## 7. Debug Appendix: Physical Rules
 
-VMI f16 interleave uses the **complex-multiply form** with an fp32 middle
-(`extf` before shuffle, `truncf` before store). That is a **semantic** match to
-CCE/v2 MI, with a small **numeric** difference vs native f16 throughout (VMI
-chooses fp32 for the interleave body because `extf/truncf` are cheap at the
-logical level).
+Use this section when reviewing lowered MI or comparing against CCE comments.
 
-Compare the fused body:
+### 256-Byte Register Model
 
-**VMI:**
+Every A5 vector register is 256 bytes:
 
-```mlir
-%rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even) : ...
-%out_f32 = pto.vmi.addf (pto.vmi.mulf %x, %cos), (pto.vmi.mulf %rot, %sin) : ...
+| Element type | Physical lanes per register |
+|--------------|-----------------------------|
+| f16 / bf16 / ui16 | 128 lanes |
+| f32 | 64 lanes |
+| ui8 / fp8 | 256 lanes |
+
+RoPE uses `D=64`, so f32 fits exactly in one register. f16/bf16 use only part of
+a 128-lane b16 register, and bf16 widening/narrowing introduces even-lane
+placement.
+
+### UNPK_B16 and PK_B32
+
+`UNPK_B16` expands dense halfword memory into even physical lanes:
+
+```text
+memory:       [b0, b1, b2, ...]
+physical reg: [b0, __, b1, __, b2, __, ...]
 ```
 
-**CCE / MI v2:**
+`vcvt PART_EVEN` reads those valid lanes into fp32. After fp32 compute,
+`vcvt PART_EVEN` writes bf16 results back into even lanes, and `PK_B32` stores
+them densely:
 
-```c
-vdintlv(heven, hodd, xr, xr);
-vmul(hnegodd, hodd, negOne, maskPair, MODE_ZEROING);
-vintlv(hxnew, hxnew_hi, hnegodd, heven);
-vmul(hta, xr, cosr, mask, MODE_ZEROING);
-vmul(htb, hxnew, sinr, mask, MODE_ZEROING);
-vadd(htb, hta, htb, mask, MODE_ZEROING);
+```text
+physical reg: [y0, __, y1, __, y2, __, ...]
+memory:       [y0, y1, y2, ...]
 ```
 
-Same story, different vocabulary: **merge(−odd, even)** vs **vintlv after
-negate**.
+### Parity Split and Merge
 
-**Index map for complex-multiply (8-element sketch, matches v2/CCE/VMI f16):**
+`vdintlv` and `vintlv` implement the parity axis:
 
-| Stage | Register | Logical contents |
-|-------|----------|------------------|
-| load | `x` | `[x0,x1,x2,x3,x4,x5,x6,x7]` |
-| `vdintlv` | `x_even` | `[x0,x2,x4,x6]` |
-| `vdintlv` | `x_odd` | `[x1,x3,x5,x7]` |
-| negate odd | `neg_x_odd` | `[-x1,-x3,-x5,-x7]` |
-| `vintlv` | `x_rot` | `[-x1,x0,-x3,x2,-x5,x4,-x7,x6]` |
-| `vmul` + `vadd` | `y` | `[y0,y1,…,y7]` interleaved |
+```text
+[x0,x1,x2,x3,...] --vdintlv--> even=[x0,x2,...], odd=[x1,x3,...]
+even/odd --vintlv--> [even0,odd0,even1,odd1,...]
+```
 
-`cos` and `sin` remain **dense interleaved** throughout — unlike MI v1, which
-splits them with separate `vdintlv` calls.
+VMI names these as `channel_split` and `channel_merge`.
+
+### Mask Families
+
+MI RoPE often carries both:
+
+- `!pto.mask<b16>` for b16 load/convert/f16 arithmetic
+- `!pto.mask<b32>` for fp32 arithmetic and bf16 narrow/store paths
+
+Using the wrong mask family is a wrong-lane bug. VMI uses a logical
+`!pto.vmi.mask<N×pred>` and lets lowering choose the concrete predicate family.
+
+### Common Bugs VMI Helps Avoid
+
+- using `PART_ODD` after `UNPK_B16`
+- using `NORM_B16` instead of `PK_B32` after bf16 narrow
+- swapping `channel_merge(neg_odd, even)` to `channel_merge(even, neg_odd)`
+- mixing b16 and b32 predicates in bf16 paths
 
 ---
 
-### 5.5 f32 HALF — smallest win
+## 8. Practical Guidance
 
-f32 is the “easy” case: dense loads, native fp32 compute, dense stores. MI is
-already readable if you ignore the mask on every line.
+| Task | Prefer |
+|------|--------|
+| Author or review RoPE math, especially bf16 | **VMI** |
+| Verify against intrinsics behavior | **CCE** or lowered **MI** |
+| Debug wrong lanes, padding, or stores | Lowered **MI** plus CCE comments |
+| Tune final schedules | Lowered **MI** / hardware traces |
 
-**MI:**
+Review checklist for VMI RoPE:
 
-```mlir
-%t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : ...
-%y_lo = pto.vsub %t0, %t1, %mask32_half : ...
-pto.vsts %y_lo, %y_ub[%y_off], %mask32_half : ...
-```
+1. Logical vector width matches the slice (`32` for HALF halves, `64` for D=64
+   interleaved rows).
+2. bf16 paths widen to fp32 and narrow back to bf16.
+3. INTERLEAVE complex multiply uses `channel_merge(neg_odd, even)`.
+4. Lowered MI contains the expected `UNPK_B16`/`PART_EVEN`/`PK_B32` sequence for
+   bf16 and `vdintlv`/`vintlv` for interleave.
+5. For CCE comparison, start with the `Expected UB effect` block and register
+   role comments in the matching `ComputeF16`, `ComputeBf16`, or `ComputeF32`
+   body.
 
-**VMI:**
+Suggested reading order:
 
-```mlir
-%x1_cos = pto.vmi.mulf %x1, %cos1 : ...
-%out1 = pto.vmi.subf %x1_cos, %x2_sin : ...
-pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
-```
-
-VMI still helps (uniform `vmi.load`, one mask type, no `pge_b32`), but this is
-not where you save days of debugging UNPK/PK issues.
-
-**Physical layout (f32 HALF):** the easy baseline — **64×f32 fits one register**
-(256 B). Load, compute, store are all `NORM` with no UNPK, part, or PK:
-
-```
-x1: vreg<64×f32> ← x[0..31]     x2: vreg<64×f32> ← x[32..63]
-        └── native fp32 vmul/vsub/vadd (mask<b32> for tail only)
-```
-
----
-
-### 5.6 f32 INTERLEAVE — Cartesian form; moderate win
-
-The f32 VMI example intentionally uses **Cartesian expansion** (like MI v1),
-not the complex-multiply fused path used for f16/bf16 VMI interleave:
-
-```mlir
-%y_even = pto.vmi.subf (pto.vmi.mulf %x_even, %cos_even),
-                       (pto.vmi.mulf %x_odd, %sin_even) : ...
-%y_odd  = pto.vmi.addf (pto.vmi.mulf %x_odd, %cos_odd),
-                       (pto.vmi.mulf %x_even, %sin_odd) : ...
-%out = "pto.vmi.channel_merge"(%y_even, %y_odd) : ...
-```
-
-This is honest: the math **is** the Cartesian expansion, and VMI makes it
-readable via `channel_split/merge` instead of `vdintlv/vintlv`. The win over MI
-is real but incremental — you are mostly shedding eight mask parameters and
-getting semantic shuffle names.
-
-Note: CCE f32 INTERLEAVE uses the **complex-multiply** path (like f16 v2), so
-VMI f32 interleave is **not** a line-for-line spelling match to CCE — it is an
-equivalent Cartesian organization chosen for clarity at the logical vector
-width.
-
-**Physical layout (f32 INTERLEAVE Cartesian):**
-
-```
-x (64×f32 dense interleaved)
-  │ channel_split  ≡  vdintlv
-  ├─────────┬─────────
-  ▼         ▼
-x_even   x_odd     (+ same for cos, sin in MI v1; VMI splits x/cos/sin logically)
-  │ 4 muls + 2 subs/adds on streams
-  ▼
-y_even, y_odd
-  │ channel_merge  ≡  vintlv
-  ▼
-y dense interleaved
-```
-
-CCE f32 would instead keep cos/sin dense and use one `vdintlv`/`vintlv` pair on
-`x` only (complex-multiply form, same as §5.4 index table).
+1. Section 1 of this doc for math.
+2. `rope_bf16.vmi.pto` HALF loop body.
+3. Section 4 here for the VMI/MI lowering shape.
+4. `rope_bf16.mi.pto` same loop body.
+5. `rope_cce_compute.h` `ComputeBf16`.
+6. Section 7 here when debugging physical lanes.
+7. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`.
 
 ---
 
-### 5.7 End-to-end layout comparison (all six variants)
+## Example File Index
 
-| Variant | Loads | Compute reg layout | Shuffle ops | Stores |
-|---------|-------|-------------------|-------------|--------|
-| f32 HALF | 2× dense 64×f32 | native dense | none | 2× dense |
-| f16 HALF | 2× dense 128×f16 (32 active) | native dense | none | 2× dense |
-| bf16 HALF | 4× UNPK + PART_EVEN widen | 4× 64×f32 | none | 2× PART_EVEN + PK_B32 |
-| f16 INT v2 | 3× dense 128×f16 | dense + parity on `x` | `vdintlv`+`vintlv` on `x` | 1× dense |
-| f16 INT v1 | 3× dense + 3× `vdintlv` | 6 parity streams | 3× `vdintlv`, 1× `vintlv` | 1× dense |
-| bf16 INT | UNPK + fp32 body | fp32 dense + parity | same as f16 v2 + PK | PK_B32 |
-
-**VMI value correlates with shuffle + UNPK/PK column width**, not with RoPE
-formula complexity (which is identical everywhere).
-
----
-
-## 6. What VMI does not fix (honest limits)
-
-1. **Tiling and strides** — `half_d_aligned`, `rep`/`blk` loops, `x_s_step`, and
-   DMA byte rounding are identical in burden across MI and VMI examples.
-
-2. **Not all MI spellings match** — MI v1 interleave (Cartesian) vs MI v2/CCE
-   (complex-multiply) vs VMI f32 interleave (Cartesian) vs VMI f16 interleave
-   (complex-multiply). VMI simplifies each spelling, but authors still pick the
-   spelling.
-
-3. **Bit-exact parity** — VMI f16 interleave uses fp32 middle math; CCE f16
-   interleave is native f16. Expect small numeric differences, not algorithmic
-   ones.
-
-4. **Performance visibility** — hiding `dist/part/PK` means the compiler must
-   choose correctly. For peak tuning, engineers still inspect lowered MI (same
-   as inspecting assembly after CCE).
-
-5. **HALF vs INTERLEAVE layout** — VMI does not choose NeoX vs GPT-J for you;
-   `mode` still branches the kernel.
-
----
-
-## 7. Practical guidance
-
-| If you are… | Prefer |
-|-------------|--------|
-| Writing or reviewing RoPE math, especially bf16 | **VMI** |
-| Verifying against CCE sim / intrinsics golden | **MI v2** or **CCE** |
-| Debugging wrong lanes / padding / PK artifacts | Lowered **MI** (VMI source may hide the bug location) |
-| f32 HALF only, team already knows MI masks | Either; VMI is nicer, not essential |
-
-**Review checklist for VMI RoPE code:**
-
-1. Confirm the logical vector width matches the RoPE slice (`32` for HALF halves,
-   `64` for the D=64 interleaved row in these examples).
-2. Confirm dtype transitions match the intended numerics: bf16 paths widen to
-   fp32 and narrow back; f16/f32 paths differ by variant.
-3. Confirm `channel_merge` argument order builds the expected rotation
-   (`neg_odd, even` for complex-multiply interleave).
-4. Inspect lowered MI for the expected `UNPK_B16`/`PART_EVEN`/`PK_B32` chain on
-   bf16 paths and `vdintlv`/`vintlv` on interleave paths.
-5. Compare against `rope_cce_compute.h` when debugging: start at the
-   `Expected UB effect` block, then the register-role comments inside the
-   matching `ComputeF16`, `ComputeBf16`, or `ComputeF32` body.
-
-**Suggested reading order for new algorithm engineers:**
-
-1. Section 1 of this doc (math)
-2. **§3.5–§3.10** (physical register model — read before MI/CCE examples)
-3. `rope_bf16.vmi.pto` HALF loop body — best VMI showcase
-4. **§5.7** (variant layout comparison table)
-5. `rope_bf16.mi.pto` same section — see what VMI removed
-6. `rope_cce_compute.h` `ComputeBf16` — ground truth with educational comments
-7. `rope_f16_v2.mi.pto` — CCE-faithful MI reference for f16
-8. `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md` — full layout taxonomy
-9. `BLOCK_MX_QUANT_VMI_vs_MI.md` — same layout axes at 256-wide quant scale
-
----
-
-## 8. One-page summary
-
-| Question | Answer |
-|----------|--------|
-| Same RoPE semantics? | **Yes**, modulo bf16/fp32 inner precision choices and f32 interleave spelling variant |
-| Cleaner syntax? | **Yes**, strongest for bf16, moderate for f16 interleave, modest for f32 HALF |
-| Closer to math? | **Yes** where VMI hides UNPK/PK/part and uses `channel_split/merge` for GPT-J |
-| Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling shell |
-| Still worth it if MI is v2-quality? | **Yes for bf16**; **marginal for f32 HALF** |
-| Why UNPK / vdintlv / vintlv? | Physical 256B regs + dense vs interleaved memory; see §3.6–§3.8 |
-
-VMI is not “RoPE in three lines.” It is **RoPE with the hardware contract moved
-into the compiler** — most valuable exactly where that contract is longest:
-**mixed-precision loads, widened compute, and interleaved layouts.**
-
----
-
-## Example file index
-
-| File | Layer | Dtype | Notes |
-|------|-------|-------|-------|
-| `rope_f16.vmi.pto` | VMI | f16 | HALF native f16; INTERLEAVE complex-multiply + fp32 middle |
-| `rope_bf16.vmi.pto` | VMI | bf16 | **Best VMI demo** — extf/truncf throughout |
-| `rope_f32.vmi.pto` | VMI | f32 | HALF simple; INTERLEAVE Cartesian expansion |
-| `rope_f16.mi.pto` | MI v1 | f16 | INTERLEAVE Cartesian expansion; simplified tiling |
-| `rope_f16_v2.mi.pto` | MI v2 | f16 | CCE-faithful; INTERLEAVE complex-multiply |
-| `rope_bf16.mi.pto` | MI | bf16 | Full UNPK/EVEN/PK exposure |
-| `rope_f32.mi.pto` | MI | f32 | Mask on every op |
-| `rope_cce_compute.h` | CCE | all | Intrinsics ground truth |
+| File | Layer | Notes |
+|------|-------|-------|
+| `rope_bf16.vmi.pto` | VMI | Best RoPE VMI demo: bf16 with fp32 inner math |
+| `rope_bf16.mi.pto` | MI | Full UNPK/EVEN/PK exposure |
+| `rope_f16.vmi.pto` | VMI | f16 HALF plus INTERLEAVE complex multiply |
+| `rope_f16.mi.pto` | MI | f16 Cartesian interleave variant |
+| `rope_f16_v2.mi.pto` | MI | CCE-faithful f16 complex-multiply variant |
+| `rope_f32.vmi.pto` | VMI | f32 HALF and Cartesian interleave |
+| `rope_f32.mi.pto` | MI | f32 masks and dense loads/stores |
+| `rope_cce_compute.h` | CCE | Intrinsics ground truth |
 
 Related docs:
 
-- `BLOCK_MX_QUANT_VMI_vs_MI.md` — same three-layer pattern; deeper DINTLV/`vintlv` at 256-wide
+- `BLOCK_MX_QUANT_VMI_vs_MI.md`
 - `PTO-Gym-vmi/docs/PTO-vmi-design.en.md`
 - `PTO-Gym-vmi/docs/PTO-micro-ISA-Pack-Unpack-Interleave-Part-Reference.md`
 - `PTO-Gym-vmi/docs/PTO-micro-Instruction-SPEC.md`

--- a/docs/examples/vmi/ROPE_VMI_vs_MI.md
+++ b/docs/examples/vmi/ROPE_VMI_vs_MI.md
@@ -92,6 +92,15 @@ type-conversion protocol details.
 math, DMA setup, or pipeline synchronization. Those remain visible in the
 examples.
 
+The VMI cast names intentionally follow MLIR `arith` vocabulary. `pto.vmi.extf`
+means “extend each logical lane to a wider floating type”, and
+`pto.vmi.truncf` means “narrow each logical lane to the destination floating
+type”. They are not claims about the number of hardware instructions. On bf16
+RoPE, one `extf` may lower through `vlds UNPK_B16` and `vcvt PART_EVEN`; one
+`truncf` plus `masked_store` may lower through `vcvt PART_EVEN` and `vsts
+PK_B32`. The abstraction is about preserving the algorithmic lane contract, not
+making the hardware layout disappear.
+
 ---
 
 ## 3. Instruction map: math → MI → VMI
@@ -109,6 +118,21 @@ The table below connects the math step to what you write at each layer.
 | Negate odd lane stream | `vbr` + `vmul` (`MODE_ZEROING`) | same | `pto.vmi.negf` |
 | Merge even/odd back | `vintlv` | `pto.vintlv` | `pto.vmi.channel_merge` |
 | Store with tail mask | `vsts` (`NORM_B16` / `NORM_B32` / `PK_B32` + mask) | `pto.vsts` (+ optional `{dist = "PK_B32"}`) + mask | `pto.vmi.masked_store` |
+
+How to read the instruction map:
+
+- `vmi.load` is a logical UB load. In f32 and dense f16 cases it lowers close to
+  `vlds NORM`. In bf16/f16 widen paths it may need `UNPK_B16` so that the next
+  MI `vcvt PART_EVEN` sees valid halfword lanes.
+- `vmi.mulf`, `vmi.addf`, and `vmi.subf` are element-wise arithmetic on logical
+  vectors. MI still needs `mask<b16>` or `mask<b32>` on every arithmetic op;
+  VMI carries the active-lane predicate at load/store or higher-level mask
+  creation points.
+- `channel_split` and `channel_merge` describe parity layout intent. They are
+  the VMI names for the same even/odd axis that MI exposes with `vdintlv` and
+  `vintlv`.
+- `masked_store` says “write active logical lanes”. MI still decides whether the
+  store is a plain `NORM_*` store or a packing store such as `PK_B32`.
 
 ### 3.1 MI details algorithm engineers should not have to memorize
 
@@ -407,6 +431,23 @@ pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask : ...
 This reads as the math plus dtype semantics: **load → widen → compute →
 truncate → store**. The compiler chooses UNPK/PART_EVEN/PK_B32 and mask
 families.
+
+Instruction-by-instruction, that means:
+
+- `%cos1_16 = pto.vmi.load ... -> vreg<64xf16>` reads the table as 64 logical
+  f16 lanes. The MI equivalent has to remember that a b16 physical register is
+  128 lanes and that `UNPK_B16` places useful values on even lanes.
+- `%cos1 = pto.vmi.extf %cos1_16` is the same semantic operation as
+  `arith.extf` lifted to a VMI vector register. The MI equivalent is `vcvt
+  PART_EVEN` because of the previous unpacked physical layout.
+- `%x1_cos = pto.vmi.mulf %x1, %cos1` is exactly the first term in
+  `x1*cos`. The MI equivalent is `vmul` plus `mask<b32>`.
+- `%out1_f32 = pto.vmi.subf %x1_cos, %x2_sin` is the low-half RoPE subtraction.
+  No hidden numerical trick is implied; it is the same fp32 subtract as MI/CCE.
+- `%out1 = pto.vmi.truncf %out1_f32` narrows each logical lane back to bf16.
+  MI must spell the rounding/saturation and destination part explicitly.
+- `pto.vmi.masked_store` writes the active logical lanes. MI/CCE use `vsts
+  PK_B32` here because the narrowed bf16 values live in even physical lanes.
 
 **CCE** (`ComputeBf16` HALF) documents the same protocol explicitly in comments
 — excellent for verification, heavy for authoring.

--- a/docs/examples/vmi/ROPE_VMI_vs_MI.md
+++ b/docs/examples/vmi/ROPE_VMI_vs_MI.md
@@ -17,6 +17,17 @@ distribution modes by hand.
 INTERLEAVE}` — on the fixed demo tile `D=64`. All examples share the same outer
 kernel shell (GM→UB DMA, pipeline flags, UB→GM writeback).
 
+**Reader contract:** after reading this note, you should be able to connect the
+RoPE equations to the VMI source, predict the main MI/CCE lowering shape
+(`dist`, `part`, masks, packing), and recognize the common lane-layout bugs VMI
+is meant to prevent.
+
+**Concrete VF tile used by the simulator examples:** the correctness tests use
+`sCount=15`, `nCount=32`, `dLen=dAlign=64`; the per-head stride is
+`xNStep=yNStep=csSStep=64`, and the per-sequence stride is
+`xSStep=ySStep=nCount*64=2048` elements. Wall-time configs also exercise
+`(s,n)=(1,2),(15,4),(15,8),(15,16),(15,32)`.
+
 This document is intentionally honest: VMI is a real abstraction win in several
 places, but it is not magic, and it does not remove all low-level work.
 
@@ -134,7 +145,78 @@ How to read the instruction map:
 - `masked_store` says “write active logical lanes”. MI still decides whether the
   store is a plain `NORM_*` store or a packing store such as `PK_B32`.
 
-### 3.1 MI details algorithm engineers should not have to memorize
+### 3.1 How to use the side-by-side snippets
+
+When reading the walkthroughs below, separate each instruction into one of four
+roles:
+
+| Role | Question to ask | RoPE examples |
+|------|-----------------|---------------|
+| **MATH** | Does this change the value? | `mulf`, `addf`, `subf`, `negf` |
+| **TYPE** | Does this change dtype while preserving logical lane `i`? | `extf`, `truncf`, `vcvt` |
+| **LAYOUT** | Does this only move lanes around? | `UNPK_B16`, `PK_B32`, `PART_EVEN`, `vdintlv`, `vintlv` |
+| **MEMORY** | Does this cross the UB/register boundary? | `vmi.load`, `masked_store`, `vlds`, `vsts` |
+
+Most VMI lines are **MATH** or **TYPE**. Many MI/CCE lines are **LAYOUT** or
+**MEMORY** required by the 256-byte register contract.
+
+### 3.2 Expected lowering shapes for recurring VMI ops
+
+These are not formal lowering rules, but they are useful review expectations for
+the concrete examples in this directory.
+
+**bf16 load + widen in HALF mode:**
+
+```mlir
+%x16 = pto.vmi.load %x_ub[%off] : ... -> !pto.vmi.vreg<64xbf16>
+%x32 = pto.vmi.extf %x16 : ... -> !pto.vmi.vreg<64xf32>
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%x16_phys = pto.vlds %x_ub[%off], %mask16 {dist = "UNPK_B16"} : ...
+%x32 = pto.vcvt %x16_phys, %mask16 {part = "EVEN"} : ... -> !pto.vreg<64xf32>
+```
+
+The `EVEN` part is not an optimization; it is required because `UNPK_B16` places
+dense bf16 memory values into even physical lanes.
+
+**bf16 narrow + store:**
+
+```mlir
+%y16 = pto.vmi.truncf %y32 : ... -> !pto.vmi.vreg<64xbf16>
+pto.vmi.masked_store %y16, %y_ub[%off], %mask : ...
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%y16_phys = pto.vcvt %y32, %mask32 {part = "EVEN", rnd = "R", sat = "SAT"} : ...
+pto.vsts %y16_phys, %y_ub[%off], %mask32 {dist = "PK_B32"} : ...
+```
+
+`truncf` preserves logical lane order; `PK_B32` repairs the physical even-lane
+layout before values reach dense UB memory.
+
+**INTERLEAVE rotation helper:**
+
+```mlir
+%even, %odd = "pto.vmi.channel_split"(%x) : ...
+%rot = "pto.vmi.channel_merge"(%neg_odd, %even) : ...
+```
+
+Expected MI/CCE shape:
+
+```mlir
+%even, %odd = pto.vdintlv %x, %x : ...
+%rot, %rot_hi = pto.vintlv %neg_odd, %even : ...
+```
+
+The argument order matters: `channel_merge(neg_odd, even)` builds
+`[-x1, x0, -x3, x2, ...]`, i.e. `(i*x)` in GPT-J interleaved layout.
+
+### 3.3 MI details algorithm engineers should not have to memorize
 
 These are the hardware subtleties VMI is designed to hide:
 
@@ -158,7 +240,19 @@ mapping. Correct for performance, opaque for reading.
 VMI replaces these with “load 64 bf16”, “extend to fp32”, “store bf16”, and
 “split/merge even/odd channels”.
 
-### 3.2 Physical register model (256-byte contract, D=64 demo)
+### 3.4 Common bugs VMI helps avoid
+
+- **Wrong `part` after `UNPK_B16`:** using `PART_ODD` instead of `PART_EVEN`
+  reads padding lanes, not bf16 values.
+- **Wrong store distribution after bf16 narrow:** a dense `NORM_B16` store after
+  even-lane narrow leaks padded lane layout into UB; bf16 paths need `PK_B32`.
+- **Swapped interleave merge order:** `merge(even, neg_odd)` is not `(i*x)`;
+  the CCE/VMI complex-multiply spelling needs `merge(neg_odd, even)`.
+- **Mask-family drift:** bf16 paths mix `b16` load/convert masks with `b32`
+  arithmetic masks. VMI keeps one logical active-lane mask and lets lowering pick
+  the concrete predicate family.
+
+### 3.5 Physical register model (256-byte contract, D=64 demo)
 
 Every A5 vector register is **256 bytes**. The RoPE examples process one head row
 of **D=64** elements per inner tile. How those 64 elements map to physical
@@ -185,10 +279,10 @@ need `DINTLV_B16` split loads in these examples. The dominant layout axes here
 are **UNPK/PK** (bf16), **parity shuffle** (INTERLEAVE), and **mask family**
 (b16 vs b32).
 
-See also `BLOCK_MX_QUANT_VMI_vs_MI.md` §3.2–§3.6 for the same 256B contract
+See also `BLOCK_MX_QUANT_VMI_vs_MI.md` §3.5–§3.9 for the same 256B contract
 applied to 256-element quant rows (where `DINTLV` + four `vintlv` steps appear).
 
-### 3.3 UNPK_B16 load and PK_B32 store (bf16 / fp16 dense paths)
+### 3.6 UNPK_B16 load and PK_B32 store (bf16 / fp16 dense paths)
 
 bf16 RoPE loads **64 dense halfwords** from UB, but a b16 register holds
 **128 lanes**. `UNPK_B16` expands each memory element into an **even physical
@@ -224,7 +318,7 @@ PK_B32 store → memory:
 **VMI:** `vmi.load` → `vreg<64×bf16>`, `vmi.extf` / `vmi.truncf`, `vmi.masked_store`.
 The UNPK → EVEN → PK chain is compiler lowering, not author code.
 
-### 3.4 HALF mode — contiguous halves (NeoX layout)
+### 3.7 HALF mode — contiguous halves (NeoX layout)
 
 HALF mode splits **D=64** into two partner blocks of **32 elements** each. No
 parity deinterleave is required — partners are already contiguous in memory:
@@ -245,7 +339,7 @@ Memory layout (HALF):
 `plt_b16` in v2). Only the low 32 physical lanes hold data; the register is
 128-wide because that is the native b16 vector width.
 
-**bf16 HALF:** each half uses UNPK (§3.3) + fp32 compute + PK store. MI needs
+**bf16 HALF:** each half uses UNPK (§3.6) + fp32 compute + PK store. MI needs
 **two mask families** in one loop body: `mask<b16>` for UNPK load and PART_EVEN
 widen of cos/sin, `mask<b32>` for fp32 `vmul`/`vsub`/`vadd`.
 
@@ -263,7 +357,7 @@ y_lo_f32 (64×f32) ──PART_EVEN narrow──► [y0,__,y1,__,…] ──PK_B3
 VMI names the same math on logical `vreg<64×bf16>` / `vreg<64×f32>` without
  exposing the even-lane landing zone.
 
-### 3.5 INTERLEAVE mode — parity axis (GPT-J layout)
+### 3.8 INTERLEAVE mode — parity axis (GPT-J layout)
 
 GPT-J layout stores rotation pairs as **adjacent elements**:
 
@@ -331,7 +425,7 @@ tables + one `vintlv` repack vs one `vdintlv` + one `vintlv` on `x` only).
 | `vintlv` | `channel_merge` | even/odd → dense interleaved |
 | `vmul` + `vbr(-1)` | `negf` | negate odd stream |
 
-### 3.6 Mask families and predicate width
+### 3.9 Mask families and predicate width
 
 MI RoPE kernels often carry **two predicate granularities** in one loop:
 
@@ -346,7 +440,7 @@ Using a b16 mask on a b32 op (or vice versa) is a silent wrong-lane bug.
 VMI uses one logical `!pto.vmi.mask<N×pred>` per tile; the compiler lowers to
 the correct `pset`/`plt`/`punpack` family.
 
-### 3.7 Variant → layout complexity (honest map)
+### 3.10 Variant → layout complexity (honest map)
 
 | Variant | Physical layout burden | Dominant MI ops beyond arithmetic |
 |---------|------------------------|-----------------------------------|
@@ -532,7 +626,7 @@ x (64×f32 logical, interleaved in one dense fp32 reg)
 
 Cartesian MI v1 instead runs `vdintlv` on cos/sin **and** x, performs eight
 masked ops on parity streams, then `vintlv(y_even, y_odd)` to rebuild interleaved
-output — see §3.5.
+output — see §3.8.
 
 ---
 
@@ -754,10 +848,24 @@ formula complexity (which is identical everywhere).
 | Debugging wrong lanes / padding / PK artifacts | Lowered **MI** (VMI source may hide the bug location) |
 | f32 HALF only, team already knows MI masks | Either; VMI is nicer, not essential |
 
+**Review checklist for VMI RoPE code:**
+
+1. Confirm the logical vector width matches the RoPE slice (`32` for HALF halves,
+   `64` for the D=64 interleaved row in these examples).
+2. Confirm dtype transitions match the intended numerics: bf16 paths widen to
+   fp32 and narrow back; f16/f32 paths differ by variant.
+3. Confirm `channel_merge` argument order builds the expected rotation
+   (`neg_odd, even` for complex-multiply interleave).
+4. Inspect lowered MI for the expected `UNPK_B16`/`PART_EVEN`/`PK_B32` chain on
+   bf16 paths and `vdintlv`/`vintlv` on interleave paths.
+5. Compare against `rope_cce_compute.h` when debugging: start at the
+   `Expected UB effect` block, then the register-role comments inside the
+   matching `ComputeF16`, `ComputeBf16`, or `ComputeF32` body.
+
 **Suggested reading order for new algorithm engineers:**
 
 1. Section 1 of this doc (math)
-2. **§3.2–§3.7** (physical register model — read before MI/CCE examples)
+2. **§3.5–§3.10** (physical register model — read before MI/CCE examples)
 3. `rope_bf16.vmi.pto` HALF loop body — best VMI showcase
 4. **§5.7** (variant layout comparison table)
 5. `rope_bf16.mi.pto` same section — see what VMI removed
@@ -777,7 +885,7 @@ formula complexity (which is identical everywhere).
 | Closer to math? | **Yes** where VMI hides UNPK/PK/part and uses `channel_split/merge` for GPT-J |
 | Easier than CCE? | **Yes for compute bodies**; **tie** for DMA/tiling shell |
 | Still worth it if MI is v2-quality? | **Yes for bf16**; **marginal for f32 HALF** |
-| Why UNPK / vdintlv / vintlv? | Physical 256B regs + dense vs interleaved memory; see §3.3–§3.5 |
+| Why UNPK / vdintlv / vintlv? | Physical 256B regs + dense vs interleaved memory; see §3.6–§3.8 |
 
 VMI is not “RoPE in three lines.” It is **RoPE with the hardware contract moved
 into the compiler** — most valuable exactly where that contract is longest:

--- a/docs/examples/vmi/mx_block_quant_scale_ocp_bf16.mi.pto
+++ b/docs/examples/vmi/mx_block_quant_scale_ocp_bf16.mi.pto
@@ -48,26 +48,68 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Input already in UB: xAddr contains bf16 block rows. The vector code
+        //   reads exponent bits only; it does not modify xAddr.
+        // - Outputs modified in UB:
+        //   * mxScale1Addr receives compact E8M0 scale bytes for each row/block group.
+        //   * mxScale2Addr receives the scale bytes in the row-interleaved layout
+        //     selected by gatherIndexAddr.
+        //   * mxScaleReciprocalAddr receives bf16 exponent-field reciprocal scales
+        //     used by the later quantization stage.
+        // - Mathematical purpose: compute the OCP MX shared scale from the maximum
+        //   bf16 exponent over the 32-row/32-column block, clamp against yMaxExp,
+        //   encode scale1 as E8M0, and compute reciprocal exponent bias - max_exp.
+        // - Special cases: Inf/NaN blocks produce E8M0 0xFF and bf16 NaN reciprocal;
+        //   all-zero blocks produce zero scale and zero reciprocal; invalid/subnormal
+        //   reciprocal cases are replaced with specialExp.
+        // Instruction reading guide for this MI file:
+        // - pto.vldsx2 "DINTLV_B16" is the first physical split: a 256-element
+        //   bf16 row cannot fit in one 256-byte register, so even logical indices
+        //   go to x0Bf16 and odd logical indices go to x1Bf16.
+        // - pto.vbitcast reinterprets bf16 bits as i16 without changing lanes;
+        //   pto.vand with 0x7F80 extracts the bf16 exponent field.
+        // - pto.vmax and pto.vcgmax implement running max and cross-lane max, but
+        //   each operation still names a concrete b16 predicate.
+        // - pto.vpack "LOWER", pto.vselr, and pto.vsts NORM_B8/NORM_B16 are
+        //   storage/layout instructions for scale bytes and reciprocal halfwords.
+        // VMI equivalents collapse the even/odd ownership into one logical
+        // vreg<256x...>, use group_reduce_maxi/group_broadcast for the reduction,
+        // and use trunci/store for typed narrowing and UB writes.
         // MI: 需要四种 mask - pset_b16(全量b16), pset_b8(全量b8), pge_b8(VL8), pge_b16(VL16)。
         // 不同操作需要不同粒度的 mask: vand/vcmp/vsel/vsub 用 b16, vsts NORM_B8 用 b8, 等等。
         // 对比 VMI: vmi.create_mask 统一为 vmi.mask<256xpred>。
 
+        // All 128 b16 lanes active: used by exponent bit ops, comparisons,
+        // selects, subtracts, shifts, and the cross-lane max.
         %pregAllB16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+        // All 256 b8 lanes active: used when writing the full scale2 byte vector.
         %pregAllB8 = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+        // First 8 b8 lanes active: scale1 has only 8 meaningful bytes per row.
         %pregReduceB8 = pto.pge_b8 "PAT_VL8" : !pto.mask<b8>
+        // First 16 b16 lanes active: reciprocal store writes the compact halfword set.
         %pregReduceB16 = pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
 
+        // 0x7F80 broadcast: bf16 exponent mask, preserving bits [14:7].
         %expMaskBF16 = pto.vbr %c32640_i16 : i16 -> !pto.vreg<128xi16>
         // MI: vbr 广播标量到 128-wide——因 DINTLV 拆分, 所有常量仅 128 宽。
         // 对比 VMI: vmi.broadcast 广播到 256-wide, 与数据宽度一致。
 
+        // Running max accumulator for even-index DINTLV half, initialized to exponent 0.
         %expMax1Dim2Init = pto.vbr %c0_i16 : i16 -> !pto.vreg<128xi16>
+        // Running max accumulator for odd-index DINTLV half, initialized to exponent 0.
         %expMax2Dim2Init = pto.vbr %c0_i16 : i16 -> !pto.vreg<128xi16>
+        // Target output maximum exponent in bf16 exponent-field position.
         %yMaxExpReg = pto.vbr %yMaxExp : i16 -> !pto.vreg<128xi16>
+        // E8M0 NaN byte value 0xFF, held in i16 lanes until vpack LOWER.
         %nanE8M0 = pto.vbr %c255_i16 : i16 -> !pto.vreg<128xi16>
+        // bf16 bias 127 encoded as exponent field 0x7F00.
         %biasE8M0 = pto.vbr %c32512_i16 : i16 -> !pto.vreg<128xi16>
+        // All-zero vector used for zero-block comparisons and selections.
         %zero = pto.vbr %c0_i16 : i16 -> !pto.vreg<128xi16>
+        // Custom bf16 NaN pattern used for reciprocal output on Inf/NaN blocks.
         %nanBF16 = pto.vbr %c32641_i16 : i16 -> !pto.vreg<128xi16>
+        // Special reciprocal threshold for invalid/subnormal reciprocal cases.
         %specialExp = pto.vbr %c64_i16 : i16 -> !pto.vreg<128xi16>
 
         %expMax1Dim2, %expMax2Dim2 = scf.for %i = %c0 to %row_count step %c1
@@ -83,17 +125,23 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // vand 需绑定 mask<b16>, 即使是对所有元素操作。
           // 对比 VMI: vmi.bitcast + vmi.andi (无 mask)。
 
+          // Reinterpret even-index bf16 values as i16 bit patterns; no numeric conversion.
           %x0Bits = pto.vbitcast %x0Bf16 : !pto.vreg<128xbf16> -> !pto.vreg<128xi16>
+          // Reinterpret odd-index bf16 values as i16 bit patterns.
           %x1Bits = pto.vbitcast %x1Bf16 : !pto.vreg<128xbf16> -> !pto.vreg<128xi16>
+          // Extract bf16 exponent field from even-index half: x0Bits & 0x7F80.
           %x0ExpBF16 = pto.vand %x0Bits, %expMaskBF16, %pregAllB16
             : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+          // Extract bf16 exponent field from odd-index half: x1Bits & 0x7F80.
           %x1ExpBF16 = pto.vand %x1Bits, %expMaskBF16, %pregAllB16
             : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
           // MI: vmax 逐元素取 max——需绑定 mask<b16>。x0/x1 两路分别归约。
           // 对比 VMI: cmpi + select 组合 (无 mask), 单路归约。
 
+          // Update running max for even-index lanes across rows.
           %nextAcc0 = pto.vmax %acc0, %x0ExpBF16, %pregAllB16
             : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+          // Update running max for odd-index lanes across rows.
           %nextAcc1 = pto.vmax %acc1, %x1ExpBF16, %pregAllB16
             : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
           scf.yield %nextAcc0, %nextAcc1 : !pto.vreg<128xi16>, !pto.vreg<128xi16>
@@ -105,8 +153,10 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // 对比 VMI: group_reduce_maxi(num_groups=1) + group_broadcast 显式两步。
         // ========================================================================
 
+        // Merge the even/odd DINTLV accumulators element-wise before global reduction.
         %expMaxDimPre = pto.vmax %expMax1Dim2, %expMax2Dim2, %pregAllB16
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Cross-lane max and broadcast: every lane receives the block max exponent.
         %expMaxDim0 = pto.vcgmax %expMaxDimPre, %pregAllB16
           : !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
 
@@ -116,30 +166,40 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // 对比 VMI: cmpi/select/subi/shrui 无 mask。
         // ========================================================================
 
+        // Predicate is true for non-Inf/NaN blocks because vcmp mode is "ne".
         %infMask = pto.vcmp %expMaxDim0, %expMaskBF16, %pregAllB16, "ne"
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.mask<b16>
+        // Predicate is true for non-zero blocks because vcmp mode is "ne".
         %zeroMask = pto.vcmp %expMaxDim0, %zero, %pregAllB16, "ne"
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.mask<b16>
+        // Predicate marks expMax <= yMaxExp, i.e. values too small for normal scale.
         %invalidDataMask = pto.vcmp %expMaxDim0, %yMaxExpReg, %pregAllB16, "le"
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.mask<b16>
+        // Clamp low/invalid exponent blocks up to yMaxExp before subtracting.
         %expMaxDim1 = pto.vsel %yMaxExpReg, %expMaxDim0, %invalidDataMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Compute exponent delta in bf16 exponent-field units: expMax - yMaxExp.
         %expMaxDim2 = pto.vsub %expMaxDim1, %yMaxExpReg, %pregAllB16
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Shift right by 7 to convert bf16 exponent-field placement into E8M0 byte value.
         %mxScaleB16_0 = pto.vshrs %expMaxDim2, %c7_i16, %pregAllB16
           : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // For Inf/NaN blocks, select 0xFF; otherwise keep computed scale.
         %mxScaleB16_1 = pto.vsel %mxScaleB16_0, %nanE8M0, %infMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // For zero blocks, select 0; otherwise keep the previous scale result.
         %mxScaleB16_2 = pto.vsel %mxScaleB16_1, %zero, %zeroMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
         // MI: vpack LOWER 将 bf16 的低字节提取为 scale1 字节。需指定 LOWER 半区。
         // 对比 VMI: vmi.trunci i32->ui8 语义截断。
 
+        // Pack low bytes of i16 scale lanes into a uint8 vector for scale1/scale2 storage.
         %mxScale1B8 = pto.vpack %mxScaleB16_2, "LOWER"
           : !pto.vreg<128xi16> -> !pto.vreg<256xui8>
 
         scf.for %i = %c0 to %row_count step %c1 {
           %scaleOff = arith.muli %i, %ub_block : index
+          // Store the compact scale1 bytes for this row; only first 8 b8 lanes are meaningful.
           pto.vsts %mxScale1B8, %mxScale1Addr[%scaleOff], %pregReduceB8 {dist = "NORM_B8"}
             : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
         }
@@ -147,10 +207,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // MI: vlds 加载 gatherIndex, 然后 vselr 按索引从 mxScale1 选取 scale2 字节。
         // 对比 VMI: 归约广播后所有 lane 值相同, 直接 store scale1Full 即可。
 
+        // Load gather indices that describe the scale2 interleaved output layout.
         %gatherIndex = pto.vlds %gatherIndexAddr[%c0] {dist = "NORM"}
           : !pto.ptr<ui8, ub> -> !pto.vreg<256xui8>
+        // Gather selected scale1 bytes into the scale2 row layout.
         %mxScale2B8 = pto.vselr %mxScale1B8, %gatherIndex
           : !pto.vreg<256xui8>, !pto.vreg<256xui8> -> !pto.vreg<256xui8>
+        // Store full scale2 byte vector.
         pto.vsts %mxScale2B8, %mxScale2Addr[%c0], %pregAllB8 {dist = "NORM_B8"}
           : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
 
@@ -159,20 +222,27 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // 对比 VMI: subi + select 链无 mask, trunci 自动处理类型转换。
         // ========================================================================
 
+        // Detect reciprocal edge case where exponent delta equals the bf16 bias field.
         %invalidRecipMask = pto.vcmp %expMaxDim2, %biasE8M0, %pregAllB16, "eq"
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.mask<b16>
+        // Reciprocal exponent field: bias - exponent_delta.
         %reversedShareExp0 = pto.vsub %biasE8M0, %expMaxDim2, %pregAllB16
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Inf/NaN blocks receive custom bf16 NaN reciprocal; others keep computed reciprocal.
         %reversedShareExp1 = pto.vsel %reversedShareExp0, %nanBF16, %infMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Zero blocks receive reciprocal 0.
         %reversedShareExp2 = pto.vsel %reversedShareExp1, %zero, %zeroMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Invalid reciprocal edge receives the special exponent threshold.
         %reversedShareExp3 = pto.vsel %specialExp, %reversedShareExp2, %invalidRecipMask
           : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+        // Reinterpret signed exponent-field lanes as unsigned halfwords for UB storage.
         %reversedShareExpU16 = pto.vbitcast %reversedShareExp3 : !pto.vreg<128xi16> -> !pto.vreg<128xui16>
         // MI: vsts + NORM_B16 按 halfword 写入, 绑定 mask<b16> (reduce 模式, 16个half/行)。
         // 对比 VMI: vmi.store。
 
+        // Store compact reciprocal halfwords; only the reduce-width b16 lanes are written.
         pto.vsts %reversedShareExpU16, %mxScaleReciprocalAddr[%c0], %pregReduceB16 {dist = "NORM_B16"}
           : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }

--- a/docs/examples/vmi/mx_block_quant_scale_ocp_bf16.vmi.pto
+++ b/docs/examples/vmi/mx_block_quant_scale_ocp_bf16.vmi.pto
@@ -52,22 +52,46 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Input already in UB: xAddr contains bf16 block rows as ui16 bit patterns.
+        //   The vector code reads exponent bits only; it does not modify xAddr.
+        // - Outputs modified in UB:
+        //   * mxScale1Addr receives compact E8M0 scale bytes for each row/block group.
+        //   * mxScale2Addr receives a full scale byte vector for the interleaved scale2
+        //     layout used by the surrounding MX quant pipeline.
+        //   * mxScaleReciprocalAddr receives compact ui16/bf16 exponent-field reciprocal
+        //     scales for the later f16/bf16 -> fp8/fp4 quant stage.
+        // - Mathematical purpose: compute the OCP MX shared scale from the maximum
+        //   bf16 exponent over the logical 256-lane block, clamp against yMaxExp,
+        //   encode scale1 as E8M0, and compute reciprocal exponent bias - max_exp.
+        // - Special cases match the MI/CCE path: Inf/NaN -> E8M0 0xFF and bf16 NaN
+        //   reciprocal; all-zero -> scale 0 and reciprocal 0; invalid reciprocal
+        //   edge -> specialExp.
         // VMI: create_mask 逻辑长度 256 创建统一 mask。
         // MI 对应: pset_b16 + pset_b8 + pge_b8 + pge_b16 四种 mask, 选错粒度即 bug。
 
+        // Create one logical all-lanes predicate for 256-element VMI operations.
         %mask256 = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
         // VMI: vmi.broadcast 广播标量到 256-wide 向量, 替代 MI 的 vbr(128-wide)。
         // MI 中这些常量(expMask/yMaxExp/bias/nan等) 均为 vreg<128xi16>,
         // 因 DINTLV_B16 拆出的两路各需要独立的常量寄存器。VMI 统一为 256 宽。
 
+        // All-zero constants for compare/select defaults in i16 and i32 domains.
         %zero16 = pto.vmi.broadcast %c0_i16 : i16 -> !pto.vmi.vreg<256xi16>
         %zero32 = pto.vmi.broadcast %c0_i32 : i32 -> !pto.vmi.vreg<256xi32>
+        // 0x7F80 keeps only the bf16 biased exponent bits [14:7].
         %expMaskBF16 = pto.vmi.broadcast %c32640_i16 : i16 -> !pto.vmi.vreg<256xi16>
+        // Target-format max exponent encoded in bf16 exponent-field position.
         %yMaxExpReg = pto.vmi.broadcast %yMaxExp : i16 -> !pto.vmi.vreg<256xi16>
+        // 0x7F00 is the bf16 exponent field for bias 127, used for reciprocal scale.
         %biasE8M0 = pto.vmi.broadcast %c32512_i16 : i16 -> !pto.vmi.vreg<256xi16>
+        // Subnormal/special reciprocal threshold used by the CCE OCP path.
         %specialExp = pto.vmi.broadcast %c64_i16 : i16 -> !pto.vmi.vreg<256xi16>
+        // Custom bf16 NaN payload used when the block exponent is Inf/NaN.
         %nanBF16 = pto.vmi.broadcast %c32641_i16 : i16 -> !pto.vmi.vreg<256xi16>
+        // E8M0 NaN encoding as i32 so it can be selected after the shift.
         %nanE8M0_32 = pto.vmi.broadcast %c255_i32 : i32 -> !pto.vmi.vreg<256xi32>
+        // Per-lane shift amount. VMI shrui uses a vector rhs; MI vshrs uses an immediate.
         %shift32 = pto.vmi.broadcast %c7_i32 : i32 -> !pto.vmi.vreg<256xi32>
 
         %expMaxRows16 = scf.for %i = %c0 to %row_count step %c1
@@ -76,13 +100,16 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // VMI: vmi.load 加载 256 个 bf16 (作为 ui16), 逻辑连续。
           // MI 对应: vldsx2 + DINTLV_B16 -> 两个 vreg<128xbf16>, 偶数/奇数索引分离。
 
+          // Load one logical 256-lane row of bf16 bits, represented as ui16.
           %xBitsU16 = pto.vmi.load %xAddr[%loadOffset]
             : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<256xui16>
           // VMI: bitcast + andi 提取指数位 (bf16 指数在位[14:7])。
           // MI 对应: vbitcast bf16->i16 + vand %mask<b16>——需要显式 mask。
 
+          // Reinterpret ui16 lanes as signed i16 bit patterns for integer masking.
           %xBits = pto.vmi.bitcast %xBitsU16
             : !pto.vmi.vreg<256xui16> -> !pto.vmi.vreg<256xi16>
+          // Extract bf16 exponent field with 0x7F80.
           %xExp = pto.vmi.andi %xBits, %expMaskBF16
             : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
             -> !pto.vmi.vreg<256xi16>
@@ -91,9 +118,11 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           //   注意 MI 用硬件 vmax 指令, VMI 用 cmpi+select 组合——语义等价, 但 MI 的 vmax
           //   仍然需要 mask 参数而 VMI 的 cmpi/select 不需要。
 
+          // Predicate lanes where the new row exponent exceeds the accumulator.
           %takeNew = pto.vmi.cmpi "slt", %acc, %xExp
             : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
             -> !pto.vmi.mask<256xpred>
+          // Select xExp for lanes with larger exponent, otherwise keep acc.
           %nextAcc = pto.vmi.select %takeNew, %xExp, %acc
             : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi16>,
               !pto.vmi.vreg<256xi16>
@@ -110,13 +139,22 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // MI 对应: vcgmax 隐式完成归约+广播——单条指令, 但归约结果和广播范围不可分离。
         // ========================================================================
 
+        // extsi mirrors MLIR arith.extsi on logical vector lanes: sign-extend
+        // each i16 exponent-field value to i32 so group_reduce_maxi has a wider
+        // integer domain. MI keeps this path in i16 and uses vcgmax directly.
         %expMaxRows32 = pto.vmi.extsi %expMaxRows16
           : !pto.vmi.vreg<256xi16> -> !pto.vmi.vreg<256xi32>
+        // group_reduce_maxi(num_groups=1): reduce all active lanes to one max.
+        // This separates "reduce" from "broadcast", unlike MI vcgmax which fuses them.
         %expMaxScalar32 = pto.vmi.group_reduce_maxi %expMaxRows32, %mask256 {num_groups = 1}
           : !pto.vmi.vreg<256xi32>, !pto.vmi.mask<256xpred>
           -> !pto.vmi.vreg<1xi32>
+        // Broadcast the single block exponent back to every logical lane so the
+        // following compare/select/sub/shift chain can remain element-wise.
         %expMaxDim32 = pto.vmi.group_broadcast %expMaxScalar32 {num_groups = 1}
           : !pto.vmi.vreg<1xi32> -> !pto.vmi.vreg<256xi32>
+        // trunci mirrors MLIR arith.trunci: keep the low 16 bits of each logical
+        // lane after reduction. It is a typed semantic cast, not a hardware vpack.
         %expMaxDim0 = pto.vmi.trunci %expMaxDim32
           : !pto.vmi.vreg<256xi32> -> !pto.vmi.vreg<256xi16>
 
@@ -130,32 +168,43 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // MI 对应: vcmp/vsel/vsub/vshrs——每条都需 mask<b16>。
         // ========================================================================
 
+        // Detect bf16 Inf/NaN exponent field (0x7F80).
         %isInfOrNan = pto.vmi.cmpi "eq", %expMaxDim0, %expMaskBF16
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.mask<256xpred>
+        // Detect all-zero exponent field.
         %isZero = pto.vmi.cmpi "eq", %expMaxDim0, %zero16
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.mask<256xpred>
+        // Detect expMax <= yMaxExp; written as yMaxExp >= expMax.
         %isLeYMax = pto.vmi.cmpi "ge", %yMaxExpReg, %expMaxDim0
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.mask<256xpred>
+        // Clamp too-small exponent blocks to yMaxExp.
         %expMaxDim1 = pto.vmi.select %isLeYMax, %yMaxExpReg, %expMaxDim0
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi16>,
             !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
+        // Compute exponent delta in bf16 exponent-field units.
         %expMaxDim2 = pto.vmi.subi %expMaxDim1, %yMaxExpReg
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
 
+        // Widen the exponent difference before logical right shift. Keeping this
+        // in i32 makes the subsequent trunci-to-ui8 explicit at the VMI level.
         %expMaxShift32 = pto.vmi.extsi %expMaxDim2
           : !pto.vmi.vreg<256xi16> -> !pto.vmi.vreg<256xi32>
+        // Shift bf16 exponent-field units down by 7 to obtain E8M0 byte values.
+        // MI spells this as vshrs with a scalar shift count and a b16 mask.
         %mxScaleI32_0 = pto.vmi.shrui %expMaxShift32, %shift32
           : !pto.vmi.vreg<256xi32>, !pto.vmi.vreg<256xi32>
           -> !pto.vmi.vreg<256xi32>
+        // Inf/NaN block: replace computed scale with E8M0 NaN (0xFF).
         %mxScaleI32_1 = pto.vmi.select %isInfOrNan, %nanE8M0_32, %mxScaleI32_0
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi32>,
             !pto.vmi.vreg<256xi32>
           -> !pto.vmi.vreg<256xi32>
+        // All-zero block: force scale byte to zero after the Inf/NaN override.
         %mxScaleI32_2 = pto.vmi.select %isZero, %zero32, %mxScaleI32_1
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi32>,
             !pto.vmi.vreg<256xi32>
@@ -164,6 +213,7 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // MI 对应: vpack %mxScaleB16_2, "LOWER" -> vreg<256xui8>。
         //   vpack 需要指定 LOWER/UPPER 半区, 开发者需理解 bf16 高低位关系。
 
+        // Narrow full scale vector to ui8 bytes for scale2-style storage.
         %mxScale1Full = pto.vmi.trunci %mxScaleI32_2
           : !pto.vmi.vreg<256xi32> -> !pto.vmi.vreg<256xui8>
 
@@ -171,9 +221,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // VMI: group_reduce_maxi(num_groups=64) 将 256 宽按 64 组归约 -> 64 个 scale1 字节。
         //     不同于前面的全规约(num_groups=1), 这里每 4 lane 归约出一个 scale1 字节。
 
+        // group_reduce_maxi(num_groups=64): reduce each 4-lane group to one value.
+        // This produces the 64 scale bytes used by the row-wise scale1 stores.
         %mxScale1Rows32 = pto.vmi.group_reduce_maxi %mxScaleI32_2, %mask256 {num_groups = 64}
           : !pto.vmi.vreg<256xi32>, !pto.vmi.mask<256xpred>
           -> !pto.vmi.vreg<64xi32>
+        // Typed narrowing to ui8 replaces MI vpack LOWER. The source is already
+        // an integer scale byte value in each logical lane.
         %mxScale1Rows = pto.vmi.trunci %mxScale1Rows32
           : !pto.vmi.vreg<64xi32> -> !pto.vmi.vreg<64xui8>
 
@@ -182,6 +236,7 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // VMI: vmi.store 直接写回——无 dist 模式, 无 mask 参数。
           // MI 对应: vsts + {dist="NORM_B8"} + mask<b8>。
 
+          // Store the compact 64-byte scale1 row.
           pto.vmi.store %mxScale1Rows, %mxScale1Addr[%scaleOff]
             : !pto.vmi.vreg<64xui8>, !pto.ptr<ui8, ub>
         }
@@ -190,6 +245,7 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         //   值相同, gatherIndex 不影响结果, 因此 VMI 直接用 scale1Full 写入。
         // MI 对应: vlds gatherIndex -> vselr(mxScale1, gatherIndex) -> vsts NORM_B8。
 
+        // Store the full 256-byte scale2 vector.
         pto.vmi.store %mxScale1Full, %mxScale2Addr[%c0]
           : !pto.vmi.vreg<256xui8>, !pto.ptr<ui8, ub>
 
@@ -199,35 +255,47 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
         // MI 对应: vsub + vsel 链——每条带 mask<b16>。
         // ========================================================================
 
+        // Detect reciprocal edge case where exponent delta equals bf16 bias.
         %invalidRecipMask = pto.vmi.cmpi "eq", %expMaxDim2, %biasE8M0
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.mask<256xpred>
+        // Compute reciprocal exponent field: bias - exponent_delta.
         %reversedShareExp0 = pto.vmi.subi %biasE8M0, %expMaxDim2
           : !pto.vmi.vreg<256xi16>, !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
+        // Override reciprocal with bf16 NaN for Inf/NaN blocks.
         %reversedShareExp1 = pto.vmi.select %isInfOrNan, %nanBF16, %reversedShareExp0
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi16>,
             !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
+        // Override reciprocal with zero for zero blocks.
         %reversedShareExp2 = pto.vmi.select %isZero, %zero16, %reversedShareExp1
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi16>,
             !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
+        // Override invalid reciprocal edge with special exponent threshold.
         %reversedShareExp3 = pto.vmi.select %invalidRecipMask, %specialExp, %reversedShareExp2
           : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xi16>,
             !pto.vmi.vreg<256xi16>
           -> !pto.vmi.vreg<256xi16>
 
+        // Reciprocal values are still bf16 exponent fields in i16 lanes. Widen
+        // before grouped reduction, then narrow to ui16 for the UB destination.
         %reversedShareExp32 = pto.vmi.extsi %reversedShareExp3
           : !pto.vmi.vreg<256xi16> -> !pto.vmi.vreg<256xi32>
+        // group_reduce_maxi(num_groups=16): choose the per-row reciprocal values
+        // that the MI path stores with a reduce-width b16 predicate.
         %reversedRows32 = pto.vmi.group_reduce_maxi %reversedShareExp32, %mask256 {num_groups = 16}
           : !pto.vmi.vreg<256xi32>, !pto.vmi.mask<256xpred>
           -> !pto.vmi.vreg<16xi32>
+        // trunci to ui16 is a semantic bit-width narrowing for storage. MI uses
+        // vbitcast i16->ui16 followed by vsts NORM_B16.
         %reversedRows = pto.vmi.trunci %reversedRows32
           : !pto.vmi.vreg<16xi32> -> !pto.vmi.vreg<16xui16>
         // VMI: group_reduce_maxi(num_groups=16) 归约到 16 个 bf16 reciprocal 值, 写入 UB。
         // MI 对应: vsts + {dist="NORM_B16"} + mask<b16> + vbitcast i16->ui16。
 
+        // Store compact reciprocal halfwords.
         pto.vmi.store %reversedRows, %mxScaleReciprocalAddr[%c0]
           : !pto.vmi.vreg<16xui16>, !pto.ptr<ui16, ub>
       }

--- a/docs/examples/vmi/mx_block_quant_y1_fp8_f16_e4m3.mi.pto
+++ b/docs/examples/vmi/mx_block_quant_y1_fp8_f16_e4m3.mi.pto
@@ -37,22 +37,57 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Inputs already in UB: xAddr contains f16 data rows; mxScale1ReciprocalAddr
+        //   contains bf16 reciprocal scale values produced by the OCP scale stage.
+        // - Output modified in UB: y1Addr is overwritten with packed FP8 E4M3 values.
+        // - Mathematical purpose per logical element i:
+        //     y1[i] = fp8_e4m3( f32(x[i]) * f32(reciprocal_scale[i]) )
+        //   using round-to-nearest-even and saturation in the f32->fp8 conversion.
+        // - The vector body processes each 256-element f16 row. DINTLV/EVEN/ODD/vintlv
+        //   only repair physical register layout so the final four PK4_B32 stores
+        //   produce dense 256-byte fp8 rows in y1Addr.
+        // xAddr and mxScale1ReciprocalAddr are read-only from the vector compute perspective.
+        // Instruction reading guide for this MI file:
+        // - pto.vldsx2 "DINTLV_B16" splits one 256-element f16 row into two
+        //   128-lane physical registers: even indices and odd indices.
+        // - pto.vcvt {part="EVEN"/"ODD"} is the second split caused by widening
+        //   f16 to f32. The four resulting 64xf32 streams each hold stride-4
+        //   logical indices until the vintlv repair steps run.
+        // - pto.vmul is the only numerical quant arithmetic: scaled = x * recip.
+        //   The surrounding vintlv instructions only restore logical order for
+        //   the fp8 packing path.
+        // - pto.vcvt {part="P0", rnd="R", sat="SAT"} narrows to fp8 E4M3 with
+        //   explicit rounding/saturation and byte-lane placement.
+        // - pto.vbitcast plus pto.vsts {dist="PK4_B32"} writes packed fp8 bytes.
+        // VMI expresses the same row as load -> extf -> mulf -> truncf ->
+        // masked_store on one logical vreg<256x...>.
         // MI: 需要三种 mask 粒度 - b16(load/vcvt), b32(vmul/vcvt/vsts)。
         // 每条 mask 指令创建的 mask 只能用于对应位宽的操作, 选错粒度 = 数据错误。
         // 对比 VMI: vmi.create_mask (统一 vmi.mask<256xpred>, 编译器管理粒度)。
 
+        // pset_b16 PAT_ALL creates an all-active predicate at 16-bit granularity.
+        // It is used by f16/bf16 conversion instructions whose source lanes are b16.
         %pregAllB16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+        // pset_b32 PAT_ALL creates an all-active predicate at 32-bit granularity.
+        // It gates f32 multiply, f32->fp8 conversion, and PK4_B32 stores.
         %pregAllB32 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 
         // MI: vlds + E2B_B16 加载 reciprocal scale。E2B 分布模式将 128 个 bf16
         // 按每 2 元素一组广播到 256 宽的寄存器中。后续需 vbitcast ui16->bf16 再 vcvt。
 
+        // vlds E2B_B16 loads reciprocal scale halfwords from UB and broadcasts
+        // them in the hardware-defined element-to-block layout used by MX quant.
         %scaleForMulBits = pto.vlds %mxScale1ReciprocalAddr[%c0] {dist = "E2B_B16"}
           : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         // MI: vbitcast 类型重解释 ui16->bf16, 然后 vcvt + PART_EVEN 取有效 bf16 转 f32。
         // 因为 E2B_B16 排布, 有效数据在 EVEN 半区, 选 ODD 读到 0。
 
+        // vbitcast reinterprets the loaded uint16 bit pattern as bf16 values;
+        // no lane movement or numeric conversion happens here.
         %scaleForMulBF16 = pto.vbitcast %scaleForMulBits : !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+        // vcvt PART_EVEN widens the valid bf16 lanes from the E2B_B16 layout to
+        // f32 reciprocal-scale values used by the later vmul instructions.
         %scaleForMulFP32 = pto.vcvt %scaleForMulBF16, %pregAllB16 {part = "EVEN"}
           : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 
@@ -83,41 +118,60 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           //     为什么又要拆? f16(16bit)->f32(32bit) 位宽翻倍, 128个f32需要两个物理寄存器。
           //     同理 x1F16(奇数索引,128xf16) 也拆 EVEN/ODD -> 共 4 路 f32。
 
+          // x0F16 owns even logical indices. PART_EVEN takes physical lanes
+          // 0,2,4,..., yielding logical indices [0,4,8,...,252].
           %x0Zero0 = pto.vcvt %x0F16, %pregAllB16 {part = "EVEN"}
             : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+          // PART_ODD takes physical lanes 1,3,5,... from x0F16, yielding
+          // logical indices [2,6,10,...,254].
           %x0One0 = pto.vcvt %x0F16, %pregAllB16 {part = "ODD"}
             : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
           // (3) MI: 4 条 vmul 分别乘 reciprocal scale - 每条必须绑定 mask<b32>。
           //     因为第(2)步已拆成 4 路 f32, 乘法也只能 4 路独立进行。
           //     对比 VMI: 1 条 vmi.mulf (无 mask 参数)。
 
+          // Scale the x0/PART_EVEN stream: res[0,4,8,...] = x * reciprocal.
           %x0Zero1 = pto.vmul %x0Zero0, %scaleForMulFP32, %pregAllB32
             : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+          // Scale the x0/PART_ODD stream: res[2,6,10,...] = x * reciprocal.
           %x0One1 = pto.vmul %x0One0, %scaleForMulFP32, %pregAllB32
             : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
           // (4) MI: vintlv 交织合并 - 将 x0Zero1 和 x0One1 交替穿插。
           //     目的是把同一路 x0 的 EVEN/ODD 子块合并回去, 为后续 P0~P3 打包做准备。
           //     同理 x1 路也做 vintlv。
 
+          // vintlv repairs the EVEN/ODD split inside the x0 half. After this,
+          // x0Zero2 starts the even logical stream [0,2,4,...] and x0One2 holds
+          // the upper companion chunk [128,130,...].
           %x0Zero2, %x0One2 = pto.vintlv %x0Zero1, %x0One1
             : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
+          // x1F16 owns odd logical indices. PART_EVEN yields [1,5,9,...,253].
           %x1Zero0 = pto.vcvt %x1F16, %pregAllB16 {part = "EVEN"}
             : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+          // PART_ODD on x1F16 yields [3,7,11,...,255].
           %x1One0 = pto.vcvt %x1F16, %pregAllB16 {part = "ODD"}
             : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+          // Scale the x1/PART_EVEN stream: res[1,5,9,...] = x * reciprocal.
           %x1Zero1 = pto.vmul %x1Zero0, %scaleForMulFP32, %pregAllB32
             : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+          // Scale the x1/PART_ODD stream: res[3,7,11,...] = x * reciprocal.
           %x1One1 = pto.vmul %x1One0, %scaleForMulFP32, %pregAllB32
             : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+          // vintlv repairs the EVEN/ODD split inside the x1 half, producing
+          // odd-index contiguous chunks [1,3,5,...] and [129,131,...].
           %x1Zero2, %x1One2 = pto.vintlv %x1Zero1, %x1One1
             : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
           // (5) MI: 跨路 vintlv - 将 x0 路和 x1 路的 zero 子块交替穿插, ones 同理。
           //     结果为 4 路 f32, 顺序满足 P0/P1/P2/P3 打包要求。
 
+          // Cross-interleave the repaired x0/x1 low chunks. This restores logical
+          // order for the first 128 scaled values, split across the two outputs.
           %x0Zero, %x1Zero = pto.vintlv %x0Zero2, %x1Zero2
             : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+          // Cross-interleave the repaired upper chunks. This restores logical
+          // order for the second 128 scaled values.
           %x0One, %x1One = pto.vintlv %x0One2, %x1One2
             : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
@@ -129,32 +183,51 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           //     256 个 fp8 需 8 个寄存器, 按 part 分组打包。rnd/sat 用错会产生数值误差。
           //     对比 VMI: 1 条 vmi.truncf (编译器自动填入 rnd/sat 并管理 part)。
 
+          // Convert the first packed-output chunk to fp8 E4M3. rnd="R" is
+          // round-to-nearest-even, sat="SAT" clamps overflows, and part="P0"
+          // places each 8-bit result in byte slot P0 of its 32-bit lane.
           %x0ZeroFP8 = pto.vcvt %x0Zero, %pregAllB32 {rnd = "R", sat = "SAT", part = "P0"}
             : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
+          // Reinterpret fp8 lanes as ui8 for the byte-oriented packed store.
           %x0ZeroU8 = pto.vbitcast %x0ZeroFP8 : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<256xui8>
           // (7) MI: vsts + PK4_B32 打包写回 - 每条 store 前需 vbitcast fp8->ui8。
           //     PK4_B32 指示硬件将 4 个 8-bit 元素打包为一个 32-bit 单元写出。
           //     4 条 vsts 分别写回 P0/P1/P2/P3 四个 64 字节块, 地址依次偏移 64/128/192。
           //     对比 VMI: 1 条 vmi.masked_store (编译器自动处理 bitcast+pack+地址计算)。
 
+          // Store chunk 0 at byte offset +0. PK4_B32 extracts the P0 byte from
+          // each 32-bit lane and packs four fp8 values per 32-bit memory word.
           pto.vsts %x0ZeroU8, %y1Addr[%blockBase], %pregAllB32 {dist = "PK4_B32"}
             : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
 
+          // Convert the second packed-output chunk. Note the source is %x1Zero,
+          // the companion result of the cross-interleave above; this ordering
+          // matches the CCE FP16 branch's four PK4_B32 stores.
           %x0OneFP8 = pto.vcvt %x1Zero, %pregAllB32 {rnd = "R", sat = "SAT", part = "P0"}
             : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
+          // Reinterpret the second fp8 chunk as ui8 for packed byte storage.
           %x0OneU8 = pto.vbitcast %x0OneFP8 : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<256xui8>
+          // Store chunk 1 at byte offset +64.
           pto.vsts %x0OneU8, %y1Addr[%yOff1], %pregAllB32 {dist = "PK4_B32"}
             : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
 
+          // Convert the third packed-output chunk from %x0One, covering the next
+          // 64 logical fp8 results after the low 128-value group.
           %x1ZeroFP8 = pto.vcvt %x0One, %pregAllB32 {rnd = "R", sat = "SAT", part = "P0"}
             : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
+          // Reinterpret the third fp8 chunk as ui8 for packed byte storage.
           %x1ZeroU8 = pto.vbitcast %x1ZeroFP8 : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<256xui8>
+          // Store chunk 2 at byte offset +128.
           pto.vsts %x1ZeroU8, %y1Addr[%yOff2], %pregAllB32 {dist = "PK4_B32"}
             : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
 
+          // Convert the fourth packed-output chunk from %x1One, completing the
+          // 256-element row.
           %x1OneFP8 = pto.vcvt %x1One, %pregAllB32 {rnd = "R", sat = "SAT", part = "P0"}
             : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
+          // Reinterpret the fourth fp8 chunk as ui8 for packed byte storage.
           %x1OneU8 = pto.vbitcast %x1OneFP8 : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<256xui8>
+          // Store chunk 3 at byte offset +192.
           pto.vsts %x1OneU8, %y1Addr[%yOff3], %pregAllB32 {dist = "PK4_B32"}
             : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
         }

--- a/docs/examples/vmi/mx_block_quant_y1_fp8_f16_e4m3.vmi.pto
+++ b/docs/examples/vmi/mx_block_quant_y1_fp8_f16_e4m3.vmi.pto
@@ -74,68 +74,94 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       // ========================================================================
 
     pto.vecscope {
+      // Expected UB effect of this vecscope:
+      // - Inputs already in UB: x_ub contains f16 data rows; scale_ub contains bf16
+      //   reciprocal scale values from the OCP scale stage.
+      // - Output modified in UB: y_ub is overwritten with packed FP8 E4M3 values.
+      // - Mathematical purpose per logical element i:
+      //     y[i] = fp8_e4m3( f32(x[i]) * f32(reciprocal_scale[i]) )
+      //   using target lowering's round/saturate behavior for f32 -> fp8.
+      // - VMI keeps the row as one logical 256-lane vector. Lowering still performs
+      //   the MI split/convert/pack work needed to write dense fp8 bytes.
+      // x_ub and scale_ub are read-only from the vector compute perspective.
         // VMI: create_mask 用逻辑长度创建统一 mask。
         // MI 对应: pset_b16 + pset_b32 + pset_b8 三种粒度分别维护。
 
+      // VMI: create_mask builds a logical predicate for the 256-element row.
+      // Lowering chooses the concrete b16/b32/b8 mask families needed by the
+      // MI load/convert/multiply/store sequence. Algorithm code carries one mask.
       %full_mask = pto.vmi.create_mask %col_count : index -> !pto.vmi.mask<256xpred>
-        // VMI: vmi.load 加载 256 个 bf16 scale 值，逻辑连续向量。
-        // MI 对应: vlds + E2B_B16 dist 模式 -> vbitcast ui16->bf16 -> vcvt PART_EVEN。
-        //   开发者需理解 E2B_B16 排布 + bitcast 类型重解释 + EVEN part 取数。
-        // VMI 中 load + extf 直接表达: 加载 bf16 并提升为 f32。
+
+      // VMI: vmi.load reads the reciprocal scale as a logical 256xbf16 vector.
+      // MI/CCE counterpart: vlds {dist="E2B_B16"} broadcasts block reciprocal
+      // scale values into a physical b16 layout, then vbitcast ui16->bf16 and
+      // vcvt {part="EVEN"} expose the values as f32. The VMI load names the
+      // logical data contract; the compiler owns the E2B_B16 placement.
 
       %scale_bf16 = pto.vmi.load %scale_ub[%c0]
         : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+      // extf mirrors MLIR arith.extf on an abstract vector register:
+      // for every logical lane i, produce f32(scale_bf16[i]). It is not a
+      // promise of one hardware vcvt; lowering may emit E2B/part-specific MI.
       %scale_fp32 = pto.vmi.extf %scale_bf16
         : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
 
       scf.for %row = %c0 to %row_count step %c1 {
+        // Row base in UB element units. The vector body below intentionally ignores
+        // GM copy details and describes only the __VEC_SCOPE__ compute path.
         %row_off = arith.muli %row, %col_count : index
-            // ========================================================================
-            // 逐行量化执行路径 - VMI 版本 (5 个语义动作)
-            // 每次处理一行 256 个 f16 元素: load -> extf -> mulf -> truncf -> store
-            //
-            // (1) VMI: vmi.load 加载逻辑连续向量 256xf16。
-            //     MI 对应: vldsx2 %xHalf[%blockBase], DINTLV_B16
-            //       -> low(128xf16)=偶数索引, high(128xf16)=奇数索引
-            //       数据从加载开始就以交错方式分散，开发者需追踪索引映射。
-            //     VMI 编译器自行决定物理排布，开发者只看到 256 个连续元素。
-            // ========================================================================
+        // ========================================================================
+        // 逐行量化执行路径 - VMI 版本 (5 个语义动作)
+        // 每次处理一行 256 个 f16 元素: load -> extf -> mulf -> truncf -> store
+        //
+        // (1) VMI: vmi.load 加载逻辑连续向量 256xf16。
+        //     MI 对应: vldsx2 %xHalf[%blockBase], DINTLV_B16
+        //       -> low(128xf16)=偶数索引, high(128xf16)=奇数索引
+        //       数据从加载开始就以交错方式分散，开发者需追踪索引映射。
+        //     VMI 编译器自行决定物理排布，开发者只看到 256 个连续元素。
+        // ========================================================================
 
         %x_f16 = pto.vmi.load %x_ub[%row_off]
           : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
-            // (2) VMI: extf 将 256 个 f16 语义提升为 256 个 f32 - 无需 part 选择。
-            //     MI 对应: 4 条 vcvt, low->EVEN/ODD, high->EVEN/ODD
-            //       -> 4 个 vreg<64xf32>, 原始索引步长变成 4
-            //       DINTLV_B16 拆出的 low/high 各需再拆 EVEN/ODD (f16->f32 位宽减半),
-            //       开发者必须理解嵌套的交错映射关系。
-            //     VMI 编译器追踪数据来源，自动选择正确的 part。
+        // (2) VMI: extf 将 256 个 f16 语义提升为 256 个 f32 - 无需 part 选择。
+        //     MI 对应: 4 条 vcvt, low->EVEN/ODD, high->EVEN/ODD
+        //       -> 4 个 vreg<64xf32>, 原始索引步长变成 4
+        //       DINTLV_B16 拆出的 low/high 各需再拆 EVEN/ODD (f16->f32 位宽减半),
+        //       开发者必须理解嵌套的交错映射关系。
+        //     VMI 编译器追踪数据来源，自动选择正确的 part。
+        //     Semantically this is arith.extf lifted from scalar/vector IR to
+        //     abstract vector registers: logical lane i stays lane i.
 
         %x_fp32 = pto.vmi.extf %x_f16
           : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xf32>
-            // (3) VMI: mulf 一条指令完成 256 个 f32 乘 scale - 无 mask 参数。
-            //     MI 对应: 4 条 vmul, 每条绑定 mask<b32>
-            //       %x0Zero1 = vmul %x0Zero0, %scaleForMulFP32, %pregAllB32
-            //       %x0One1  = vmul %x0One0,  %scaleForMulFP32, %pregAllB32
-            //       %x1Zero1 = vmul %x1Zero0, %scaleForMulFP32, %pregAllB32
-            //       %x1One1  = vmul %x1One0,  %scaleForMulFP32, %pregAllB32
-            //     4 条指令 + 4 个重复的 mask<b32> 参数。
+        // (3) VMI: mulf 一条指令完成 256 个 f32 乘 scale - 无 mask 参数。
+        //     MI 对应: 4 条 vmul, 每条绑定 mask<b32>
+        //       %x0Zero1 = vmul %x0Zero0, %scaleForMulFP32, %pregAllB32
+        //       %x0One1  = vmul %x0One0,  %scaleForMulFP32, %pregAllB32
+        //       %x1Zero1 = vmul %x1Zero0, %scaleForMulFP32, %pregAllB32
+        //       %x1One1  = vmul %x1One0,  %scaleForMulFP32, %pregAllB32
+        //     4 条指令 + 4 个重复的 mask<b32> 参数。
+        //     This is the only arithmetic operation in the quant stage:
+        //       scaled[i] = f32(x[i]) * f32(reciprocal_scale[i]).
 
         %res_fp32 = pto.vmi.mulf %x_fp32, %scale_fp32
           : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
          -> !pto.vmi.vreg<256xf32>
-            // (4) VMI: truncf 将 256 个 f32 语义截断为 256 个 fp8_e4m3 - 无需手写参数。
-            //     MI 对应: 4 条 vcvt, 每条都需显式指定 {rnd=R, sat=SAT, part=P0}
-            //       %x0ZeroFP8 = vcvt %x0Zero, %pregAllB32 {rnd=R, sat=SAT, part=P0}
-            //       ...共 4 条, 每条都需 rnd(舍入模式)/sat(饱和溢出)/part(P0~P3)。
-            //     MI 还需要 3 条 vor 把 P0~P3 合并 + vbitcast 类型重解释。
-            //     VMI 编译器根据目标类型自动填入正确的舍入/饱和参数, 并自动处理 part 打包。
+        // (4) VMI: truncf 将 256 个 f32 语义截断为 256 个 fp8_e4m3 - 无需手写参数。
+        //     MI 对应: 4 条 vcvt, 每条都需显式指定 {rnd=R, sat=SAT, part=P0}
+        //       %x0ZeroFP8 = vcvt %x0Zero, %pregAllB32 {rnd=R, sat=SAT, part=P0}
+        //       ...共 4 条, 每条都需 rnd(舍入模式)/sat(饱和溢出)/part(P0~P3)。
+        //     MI 还需要 bitcast 类型重解释和 PK4_B32 store 打包。
+        //     VMI 编译器根据目标类型自动填入正确的舍入/饱和参数, 并自动处理 part 打包。
+        //     Like MLIR arith.truncf, this is a semantic type narrowing; the
+        //     final hardware sequence is determined by the target fp8 storage layout.
 
         %res_fp8 = pto.vmi.truncf %res_fp32
           : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-            // (5) VMI: masked_store 统一掩码写回, 编译器自动处理打包策略。
-            //     MI 对应: 4 条 vsts, 每条绑定 mask<b32> + {dist=PK4_B32}
-            //       且 P0~P3 经 vor 合并后还需 vbitcast fp8->ui8 再 store。
-            //     VMI 编译器自动选择 PK 策略, 无需开发者关心打包和 bitcast。
+        // (5) VMI: masked_store 统一掩码写回, 编译器自动处理打包策略。
+        //     MI 对应: 4 条 vsts, 每条绑定 mask<b32> + {dist=PK4_B32}
+        //       且 store 前还需 vbitcast fp8->ui8。
+        //     VMI 编译器自动选择 PK 策略, 无需开发者关心打包和 bitcast。
 
         pto.vmi.masked_store %res_fp8, %y_ub[%row_off], %full_mask
           : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.vmi.mask<256xpred>

--- a/docs/examples/vmi/rope_bf16.mi.pto
+++ b/docs/examples/vmi/rope_bf16.mi.pto
@@ -83,6 +83,32 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Inputs already in UB: x_ub contains bf16 rows x[s,n,0..63];
+        //   cos_ub/sin_ub contain f16 RoPE tables for each s.
+        // - Output modified in UB: y_ub is overwritten with bf16 RoPE results.
+        // - Computation is performed in f32 after widening x/cos/sin, then narrowed
+        //   back to bf16 for storage.
+        // - mode == 0 (HALF/NeoX): for d in [0,32),
+        //     y[s,n,d]    = bf16(f32(x[d])    * f32(cos[d])
+        //                         - f32(x[d+32]) * f32(sin[d]))
+        //     y[s,n,d+32] = bf16(f32(x[d+32]) * f32(cos[d+32])
+        //                         + f32(x[d])    * f32(sin[d+32]))
+        // - mode != 0 (INTERLEAVE/GPT-J): computes the same pairwise rotation as
+        //   y_even/y_odd after deinterleaving adjacent pairs, then stores dense bf16.
+        // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
+        // Instruction reading guide for this MI file:
+        // - pto.vlds {dist="UNPK_B16"} expands dense bf16/f16 memory into even
+        //   halfword lanes of a 128-lane b16 register.
+        // - pto.vcvt {part="EVEN"} is therefore required for widening to f32;
+        //   PART_ODD would read padding lanes in these load paths.
+        // - pto.vcvt {part="EVEN", rnd="R", sat="SAT"} narrows f32 back to bf16
+        //   into even b16 lanes, and pto.vsts {dist="PK_B32"} packs those lanes
+        //   back to dense UB.
+        // - Arithmetic is ordinary fp32 vmul/vsub/vadd, but every op carries
+        //   !pto.mask<b32>; load/convert ops use !pto.mask<b16>.
+        // VMI equivalents are vmi.load, vmi.extf, mask-free vmi.mulf/subf/addf,
+        // vmi.truncf, and vmi.masked_store.
         //   UNPK_B16 load -> PART_EVEN widen -> fp32 compute ->
         //   PART_EVEN narrow -> PK_B32 store.
         // The loop shape is also intentionally the same: s -> rep/blk -> n.
@@ -91,7 +117,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // pge_b32 用于 f32 算术的 b32 操作。不同数据类型无法共用 mask。
           // VMI 对应: vmi.create_mask（统一 vmi.mask<Nxpred>）。
 
+          // All b16 lanes active for UNPK_B16 loads and b16->f32 vcvt.
           %mask16_all = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+          // First 32 f32 lanes active for one D/2 half of the RoPE row.
           %mask32_half = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
@@ -104,9 +132,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // 后续 vcvt {part = "EVEN"} 才能取出有效数据，选 ODD 读到 0。
             // VMI 对应: vmi.load（逻辑向量 64xf16，编译器自动处理排布）。
 
+            // Load low-half cosine and unpack valid f16 values to even b16 lanes.
             %cos_lo_16 = pto.vlds %cos_ub[%cs_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load low-half sine, also unpacked to even b16 lanes.
             %sin_lo_16 = pto.vlds %sin_ub[%cs_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load high-half cosine from +D/2.
             %cos_hi_16 = pto.vlds %cos_ub[%cs_hi_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load high-half sine from +D/2.
             %sin_hi_16 = pto.vlds %sin_ub[%cs_hi_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
             // only the EVEN halfword positions carry valid data
@@ -116,9 +148,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // 选错 part 意味着取到填充的 0（ODD）或错位数据。
             // VMI 对应: vmi.extf（编译器追踪数据来源，自动选对 part）。
 
+            // Widen low-half cosine from even b16 lanes to f32.
             %cos_lo = pto.vcvt %cos_lo_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+            // Widen low-half sine from even b16 lanes to f32.
             %sin_lo = pto.vcvt %sin_lo_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+            // Widen high-half cosine from even b16 lanes to f32.
             %cos_hi = pto.vcvt %cos_hi_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+            // Widen high-half sine from even b16 lanes to f32.
             %sin_hi = pto.vcvt %sin_hi_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 
             scf.for %n = %c0 to %n_count step %c1 {
@@ -132,9 +168,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // MI: bf16 load 同样用 UNPK_B16——64个 bf16 解包到 128xbf16 的 EVEN。
               // VMI 对应: vmi.load（64xbf16 逻辑向量）。
 
+              // Load low-half bf16 x and unpack to even b16 lanes.
               %x_lo_16 = pto.vlds %x_ub[%x_off] {dist = "UNPK_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+              // Load high-half bf16 x and unpack to even b16 lanes.
               %x_hi_16 = pto.vlds %x_ub[%x_hi_off] {dist = "UNPK_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+              // Widen low-half x to f32 from even lanes.
               %x_lo = pto.vcvt %x_lo_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+              // Widen high-half x to f32 from even lanes.
               %x_hi = pto.vcvt %x_hi_16, %mask16_all {part = "EVEN"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 
               // Half layout: two independent 32-element halves are rotated against each other.
@@ -148,37 +188,53 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: vmi.mulf/subf/addf（无 mask 参数）。
               // ========================================================================
 
+              // t0 = cos_lo * x_lo in fp32.
               %t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // t1 = sin_lo * x_hi in fp32.
               %t1 = pto.vmul %sin_lo, %x_hi, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_lo_f32 = cos_lo*x_lo - sin_lo*x_hi.
               %y_lo_f32 = pto.vsub %t0, %t1, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
+              // t2 = cos_hi * x_hi in fp32.
               %t2 = pto.vmul %cos_hi, %x_hi, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // t3 = sin_hi * x_lo in fp32.
               %t3 = pto.vmul %sin_hi, %x_lo, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_hi_f32 = cos_hi*x_hi + sin_hi*x_lo.
               %y_hi_f32 = pto.vadd %t2, %t3, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
               // Narrow back to bf16 in EVEN slots, then PACK_B32 back to dense UB layout.
+              // Narrow low-half fp32 result to bf16 in even lanes with round/saturate.
               %y_lo_16 = pto.vcvt %y_lo_f32, %mask32_half {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>
+              // Narrow high-half fp32 result to bf16 in even lanes with round/saturate.
               %y_hi_16 = pto.vcvt %y_hi_f32, %mask32_half {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>
 
               // MI: vsts + PK_B32 打包写回——EVEN 位置的有效 bf16 需要硬件
               // 打包成内存中连续的 32 个元素。错误使用普通 store 会混入 ODD 的无效数据。
               // VMI 对应: vmi.masked_store（编译器自动选择打包策略）。
 
+              // Pack even-lane bf16 low result back to dense UB.
               pto.vsts %y_lo_16, %y_ub[%y_off], %mask32_half {dist = "PK_B32"} : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b32>
+              // Pack even-lane bf16 high result back to dense UB.
               pto.vsts %y_hi_16, %y_ub[%y_hi_off], %mask32_half {dist = "PK_B32"} : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b32>
             }
           }
         } else {
+          // All b16 lanes active for UNPK_B16 loads and b16->f32 conversions.
           %mask16_all = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+          // All f32 lanes active for interleave arithmetic and final narrow/store.
           %mask32_all = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
             %cs_off = arith.muli %s, %cs_s_step : index
             %y_s_off = arith.muli %s, %y_s_step : index
 
+            // Load dense interleaved f16 cosine table with UNPK_B16.
             %cos16 = pto.vlds %cos_ub[%cs_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load dense interleaved f16 sine table with UNPK_B16.
             %sin16 = pto.vlds %sin_ub[%cs_off] {dist = "UNPK_B16"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Widen cosine table from even b16 lanes to f32.
             %cos = pto.vcvt %cos16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+            // Widen sine table from even b16 lanes to f32.
             %sin = pto.vcvt %sin16, %mask16_all {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
             // deinterleave -> build rotated partner -> y = x*cos + rot(x)*sin.
             // This PTO spelling keeps the same pairwise result while showing
@@ -187,7 +243,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // 输入两个相同寄存器（cos, cos），输出 even/odd 两个半宽寄存器。
             // VMI 对应: channel_split。
 
+            // Split cosine into even and odd RoPE pair channels.
             %cos_even, %cos_odd = pto.vdintlv %cos, %cos : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+            // Split sine into even and odd RoPE pair channels.
             %sin_even, %sin_odd = pto.vdintlv %sin, %sin : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
             scf.for %n = %c0 to %n_count step %c1 {
@@ -196,11 +254,14 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %x_off = arith.addi %x_s_off, %x_n_off : index
               %y_off = arith.addi %y_s_off, %y_n_off : index
 
+              // Load dense interleaved bf16 x with UNPK_B16.
               %x16 = pto.vlds %x_ub[%x_off] {dist = "UNPK_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+              // Widen x from even b16 lanes to f32.
               %x = pto.vcvt %x16, %mask16_all {part = "EVEN"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
               // MI: vdintlv 解交织 x，拆出 even/odd。
               // VMI 对应: channel_split。
 
+              // Split x into even and odd pair channels.
               %x_even, %x_odd = pto.vdintlv %x, %x : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
               // Explicit even/odd RoPE equations:
@@ -212,23 +273,32 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: 6条 vmi.mulf/subf/addf（无 mask）。
               // ========================================================================
 
+              // x_even_cos = x_even * cos_even.
               %x_even_cos = pto.vmul %x_even, %cos_even, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // x_odd_sin = x_odd * sin_even.
               %x_odd_sin = pto.vmul %x_odd, %sin_even, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_even = x_even*cos_even - x_odd*sin_even.
               %y_even = pto.vsub %x_even_cos, %x_odd_sin, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
+              // x_odd_cos = x_odd * cos_odd.
               %x_odd_cos = pto.vmul %x_odd, %cos_odd, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // x_even_sin = x_even * sin_odd.
               %x_even_sin = pto.vmul %x_even, %sin_odd, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_odd = x_odd*cos_odd + x_even*sin_odd.
               %y_odd = pto.vadd %x_odd_cos, %x_even_sin, %mask32_all : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
               // MI: vintlv 硬件交织 even/odd 回交织格式。
               // 产出两个寄存器，y_pack 存低半、y_pack_hi 存高半。
               // VMI 对应: channel_merge（单个 vreg<128> 输出）。
 
+              // Interleave even/odd f32 results back to dense RoPE order.
               %y_pack, %y_pack_hi = pto.vintlv %y_even, %y_odd : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+              // Narrow the packed f32 result to bf16 in even lanes.
               %y_pack_16 = pto.vcvt %y_pack, %mask32_all {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>
               // MI: vsts + PK_B32 打包写回。
               // VMI 对应: vmi.masked_store。
 
+              // Pack even-lane bf16 result back to dense UB.
               pto.vsts %y_pack_16, %y_ub[%y_off], %mask32_all {dist = "PK_B32"} : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b32>
             }
           }

--- a/docs/examples/vmi/rope_bf16.vmi.pto
+++ b/docs/examples/vmi/rope_bf16.vmi.pto
@@ -87,6 +87,20 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %is_half_mode = arith.cmpi eq, %mode, %c0_i32 : i32
 
     pto.vecscope {
+      // Expected UB effect of this vecscope:
+      // - Inputs already in UB: x_ub contains bf16 rows x[s,n,0..63];
+      //   cos_ub/sin_ub contain f16 RoPE tables for each s.
+      // - Output modified in UB: y_ub is overwritten with bf16 RoPE results.
+      // - Computation is performed in f32 after VMI extf, then narrowed to bf16
+      //   with VMI truncf before masked_store.
+      // - mode == 0 (HALF/NeoX): for d in [0,32),
+      //     y[s,n,d]    = bf16(f32(x[d])    * f32(cos[d])
+      //                         - f32(x[d+32]) * f32(sin[d]))
+      //     y[s,n,d+32] = bf16(f32(x[d+32]) * f32(cos[d+32])
+      //                         + f32(x[d])    * f32(sin[d+32]))
+      // - mode != 0 (INTERLEAVE/GPT-J): constructs rot(x)=[-x1,x0,-x3,x2,...]
+      //   and computes y = bf16(f32(x)*f32(cos) + rot(x)*f32(sin)).
+      // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
       // ========================================================================
       // VMI vs MI — RoPE bf16 向量计算路径对比概览
       // ========================================================================
@@ -135,6 +149,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // MI 对应: pset_b16 "PAT_ALL" → !pto.mask<b16> (load 用)
             //          pge_b32 "PAT_VL32" → !pto.mask<b32> (compute 用)
             //   不同数据类型需要不同粒度的 mask——VMI 统一为一种。
+            // Create a logical tail predicate for this bf16/f32 half tile.
             %mask = pto.vmi.create_mask %active : index -> !pto.vmi.mask<64xpred>
 
             %cos1_off = arith.addi %cs_off, %elem_off : index
@@ -150,25 +165,36 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             //   UNPK_B16 把 64 个 f16 解包到 128xf16 的 EVEN 位置（ODD 填 0），
             //   后续 vcvt {part = "EVEN"} 才能取到有效数据。
             // VMI 屏蔽了这个隐含协议：load → extf 直接表达"加载并提升精度"。
+            // Load low-half f16 cosine table.
             %cos1_16 = pto.vmi.load %cos_ub[%cos1_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
+            // Load high-half f16 cosine table.
             %cos2_16 = pto.vmi.load %cos_ub[%cos2_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
+            // Load low-half f16 sine table.
             %sin1_16 = pto.vmi.load %sin_ub[%sin1_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
+            // Load high-half f16 sine table.
             %sin2_16 = pto.vmi.load %sin_ub[%sin2_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
 
             // VMI: extf 将 f16/bf16 语义提升为 f32——无需 part 选择。
+            // Like MLIR arith.extf, this is a semantic per-lane conversion on
+            // the abstract vector register. Lowering may still emit MI vcvt with
+            // PART_EVEN after UNPK_B16; VMI keeps logical lane i as lane i.
             // MI 对应: pto.vcvt %cos_lo_16, %mask16_all {part = "EVEN"}
             //   → 开发者必须知道 UNPK_B16 后数据在 EVEN，选 ODD 读到填充 0。
             // VMI 编译器追踪数据来源，自动选择正确的转换 part。
+            // Widen low-half cosine to f32.
             %cos1 = pto.vmi.extf %cos1_16
                 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+            // Widen high-half cosine to f32.
             %cos2 = pto.vmi.extf %cos2_16
                 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+            // Widen low-half sine to f32.
             %sin1 = pto.vmi.extf %sin1_16
                 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+            // Widen high-half sine to f32.
             %sin2 = pto.vmi.extf %sin2_16
                 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
 
@@ -188,16 +214,22 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               // VMI: vmi.load 语义——加载 bf16 逻辑向量，自动处理物理排布。
               // MI 对应: pto.vlds %x[%off] {dist = "UNPK_B16"}
               //   → !pto.vreg<128xbf16>，64 个 bf16 解包到 128 宽的 EVEN 位置。
+              // Load low-half bf16 x.
               %x1_16 = pto.vmi.load %x_ub[%x1_off]
                   : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<64xbf16>
+              // Load high-half bf16 x.
               %x2_16 = pto.vmi.load %x_ub[%x2_off]
                   : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<64xbf16>
 
               // VMI: extf 语义提升 bf16 → f32，无需 part。
+              // This deliberately mirrors arith.extf naming: it describes value
+              // conversion, not a specific physical PART_EVEN/PART_ODD instruction.
               // MI 对应: pto.vcvt %x_lo_16, %mask16_all {part = "EVEN"}
               //   → !pto.vreg<64xf32>，必须指定 EVEN part。
+              // Widen low-half x to f32.
               %x1 = pto.vmi.extf %x1_16
                   : !pto.vmi.vreg<64xbf16> -> !pto.vmi.vreg<64xf32>
+              // Widen high-half x to f32.
               %x2 = pto.vmi.extf %x2_16
                   : !pto.vmi.vreg<64xbf16> -> !pto.vmi.vreg<64xf32>
 
@@ -213,29 +245,40 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //   每条指令都需要显式 mask<b32>，VMI 消除这一负担。
               // ========================================================================
               // y1 = x1 * cos - x2 * sin
+              // x1_cos = x1 * cos_low.
               %x1_cos = pto.vmi.mulf %x1, %cos1
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // x2_sin = x2 * sin_low.
               %x2_sin = pto.vmi.mulf %x2, %sin1
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // out1_f32 = x1*cos_low - x2*sin_low.
               %out1_f32 = pto.vmi.subf %x1_cos, %x2_sin
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
               // y2 = x2 * cos + x1 * sin
+              // x2_cos = x2 * cos_high.
               %x2_cos = pto.vmi.mulf %x2, %cos2
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // x1_sin = x1 * sin_high.
               %x1_sin = pto.vmi.mulf %x1, %sin2
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // out2_f32 = x2*cos_high + x1*sin_high.
               %out2_f32 = pto.vmi.addf %x2_cos, %x1_sin
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
               // VMI: truncf 语义截断 f32 → bf16，无需 rnd/sat 参数。
+              // Like MLIR arith.truncf, the op names the target element type and
+              // preserves logical index order; target lowering supplies vcvt round,
+              // saturation, part selection, and any required PK_B32 store layout.
               // MI 对应: pto.vcvt %y_lo_f32, %mask32_half
               //            {part = "EVEN", rnd = "R", sat = "SAT"}
               //   → !pto.vreg<128xbf16>，然后还需 PK_B32 store 打包写回。
               // VMI 中 truncf + masked_store 直接表达"截断并写回"，
               // 编译器自动填入 rnd/sat 并处理 pack。
+              // Narrow low-half fp32 result back to bf16.
               %out1 = pto.vmi.truncf %out1_f32
                   : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
+              // Narrow high-half fp32 result back to bf16.
               %out2 = pto.vmi.truncf %out2_f32
                   : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
 
@@ -245,8 +288,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //   PK_B32 告诉硬件把散在 EVEN 位置的有效 bf16 打包成内存中
               //   连续的 32 个元素——开发者需要理解何时用 PK、何时不用。
               // VMI 编译器根据数据布局自动选择打包策略。
+              // Store low-half bf16 output.
               pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask
                   : !pto.vmi.vreg<64xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<64xpred>
+              // Store high-half bf16 output.
               pto.vmi.masked_store %out2, %y_ub[%y2_off], %mask
                   : !pto.vmi.vreg<64xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<64xpred>
             }
@@ -267,17 +312,25 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
           //   这条"硬件解交织→手工negate→硬件交织"的链路被 VMI 的
           //   channel_split → negf → channel_merge 取代为更直观的语义表达。
           // ========================================================================
+          // Create a logical predicate for the full D=64 interleaved row.
           %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<128xpred>
           // VMI: 加载 f16 cos/sin，extf 提升到 f32。
+          // extf is the vector-register analogue of MLIR arith.extf: the source
+          // and result have the same logical indices even if lowering uses UNPK
+          // and PART_EVEN internally.
           // MI 对应: vlds + UNPK_B16 → vcvt + PART_EVEN（隐式协议），
           //   VMI 中 load + extf 直接表达"加载并提升"。
+          // Load dense interleaved f16 cosine table.
           %cos16 = pto.vmi.load %cos_ub[%cs_off]
               : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+          // Load dense interleaved f16 sine table.
           %sin16 = pto.vmi.load %sin_ub[%cs_off]
               : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
 
+          // Widen cosine table to f32.
           %cos = pto.vmi.extf %cos16
               : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
+          // Widen sine table to f32.
           %sin = pto.vmi.extf %sin16
               : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
 
@@ -288,8 +341,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             %x_off = arith.addi %x_s_off, %x_n_off : index
             %y_off = arith.addi %y_s_off, %y_n_off : index
 
+            // Load dense interleaved bf16 x.
             %x16 = pto.vmi.load %x_ub[%x_off]
                 : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<128xbf16>
+            // Widen x to f32.
             %x = pto.vmi.extf %x16
                 : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<128xf32>
 
@@ -314,22 +369,32 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // 5. truncf 自动处理 rnd/sat
             // 6. masked_store 自动处理 PK 策略
             // ========================================================================
+            // Split x into even and odd pair channels.
             %x_even, %x_odd = "pto.vmi.channel_split"(%x)
                 : (!pto.vmi.vreg<128xf32>) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
+            // Negate odd channel for rot(x).
             %neg_x_odd = pto.vmi.negf %x_odd
                 : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+            // Merge [-odd, even] to build dense rot(x).
             %rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even)
                 : (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<128xf32>
 
+            // x_cos = x * cos.
             %x_cos = pto.vmi.mulf %x, %cos
                 : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
+            // rot_sin = rot(x) * sin.
             %rot_sin = pto.vmi.mulf %rot, %sin
                 : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
+            // y_f32 = x*cos + rot(x)*sin.
             %y_f32 = pto.vmi.addf %x_cos, %rot_sin
                 : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
+            // truncf narrows f32 back to bf16 by type. MI must spell the same
+            // operation as vcvt {part="EVEN", rnd="R", sat="SAT"} plus PK_B32 store.
+            // Narrow f32 result back to bf16.
             %y16 = pto.vmi.truncf %y_f32
                 : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xbf16>
 
+            // Store dense interleaved bf16 output.
             pto.vmi.masked_store %y16, %y_ub[%y_off], %mask
                 : !pto.vmi.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<128xpred>
           }

--- a/docs/examples/vmi/rope_f16.mi.pto
+++ b/docs/examples/vmi/rope_f16.mi.pto
@@ -80,12 +80,34 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Inputs already in UB: x_ub contains f16 rows x[s,n,0..63];
+        //   cos_ub/sin_ub contain f16 RoPE tables for each s.
+        // - Output modified in UB: y_ub is overwritten with the RoPE-rotated f16 row.
+        // - mode == 0 (HALF/NeoX): for d in [0,32),
+        //     y[s,n,d]    = x[s,n,d]    * cos[s,d]    - x[s,n,d+32] * sin[s,d]
+        //     y[s,n,d+32] = x[s,n,d+32] * cos[s,d+32] + x[s,n,d]    * sin[s,d+32]
+        // - mode != 0 (INTERLEAVE/GPT-J): for pairs (2k,2k+1),
+        //     y_even = x_even*cos_even - x_odd*sin_even
+        //     y_odd  = x_odd *cos_odd  + x_even*sin_odd
+        // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
+        // Instruction reading guide for this MI file:
+        // - pto.vlds/pto.vsts are direct UB <-> vector-register moves. In f16
+        //   NORM mode there is no UNPK/PK conversion, but the 256-byte physical
+        //   register is still 128 f16 lanes and the mask decides which lanes count.
+        // - pto.vmul/pto.vsub/pto.vadd are native f16 element-wise arithmetic;
+        //   each instruction explicitly consumes !pto.mask<b16>.
+        // - pto.vdintlv/pto.vintlv are layout instructions, not RoPE math:
+        //   they split and rebuild the even/odd interleaved pair structure.
+        // VMI equivalents are vmi.load, mask-free vmi.mulf/subf/addf, and
+        // channel_split/channel_merge on logical vectors.
         //   s loop -> hoisted cos/sin load -> per-head x load -> SIMD RoPE math -> store.
         scf.if %is_half_mode {
           // MI: pge_b16 创建 b16 粒度的 mask（f16 操作专用）。
           // 开发者需为不同数据类型选择不同 mask 种类（b16/b32/b8），选错即 bug。
           // VMI 对应: vmi.create_mask（统一 vmi.mask<Nxpred>，编译器管理粒度）。
 
+          // Activate the first 32 f16 lanes for the low/high D/2 half tiles.
           %mask16_half = pto.pge_b16 "PAT_VL32" : !pto.mask<b16>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
@@ -98,9 +120,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // lo(0:31) 和 hi(32:63) 分别存放。
             // VMI 对应: vmi.load（逻辑向量 vreg<128xf16>，编译器管理物理布局）。
 
+            // Load low-half cosine table.
             %cos_lo = pto.vlds %cos_ub[%cs_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load high-half cosine table from +D/2.
             %cos_hi = pto.vlds %cos_ub[%cs_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load low-half sine table.
             %sin_lo = pto.vlds %sin_ub[%cs_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load high-half sine table from +D/2.
             %sin_hi = pto.vlds %sin_ub[%cs_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
             // HALF layout: low 32 and high 32 elements are rotated as two partner halves.
@@ -112,7 +138,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %x_hi_off = arith.addi %x_off, %c32 : index
               %y_hi_off = arith.addi %y_off, %c32 : index
 
+              // Load low-half x for this head row.
               %x_lo = pto.vlds %x_ub[%x_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              // Load high-half x, paired with x_lo in HALF-mode RoPE.
               %x_hi = pto.vlds %x_ub[%x_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
               // ========================================================================
@@ -125,18 +153,26 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: vmi.mulf/subf/addf（无 mask 参数，编译器自动生成）。
               // ========================================================================
 
+              // t0 = cos_lo * x_lo.
               %t0 = pto.vmul %cos_lo, %x_lo, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // t1 = sin_lo * x_hi.
               %t1 = pto.vmul %sin_lo, %x_hi, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // y_lo = cos_lo*x_lo - sin_lo*x_hi.
               %y_lo = pto.vsub %t0, %t1, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
+              // t2 = cos_hi * x_hi.
               %t2 = pto.vmul %cos_hi, %x_hi, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // t3 = sin_hi * x_lo.
               %t3 = pto.vmul %sin_hi, %x_lo, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // y_hi = cos_hi*x_hi + sin_hi*x_lo.
               %y_hi = pto.vadd %t2, %t3, %mask16_half : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
               // MI: vsts 写回，绑定 mask<b16> 控制写入的活跃 lane。
               // VMI 对应: vmi.masked_store（统一 vmi.mask<Nxpred> 类型）。
 
+              // Store low-half output.
               pto.vsts %y_lo, %y_ub[%y_off], %mask16_half : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+              // Store high-half output.
               pto.vsts %y_hi, %y_ub[%y_hi_off], %mask16_half : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
             }
           }
@@ -150,14 +186,18 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // 解交织/交织使用 vdintlv/vintlv 硬件指令——开发者需理解 lane 映射。
           // ========================================================================
 
+          // Pair mask covers 32 even/odd pairs after deinterleave.
           %mask16_pair = pto.pge_b16 "PAT_VL32" : !pto.mask<b16>
+          // Full mask covers the 64-lane dense interleaved store.
           %mask16_full = pto.pge_b16 "PAT_VL64" : !pto.mask<b16>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
             %cs_off = arith.muli %s, %cs_s_step : index
             %y_s_off = arith.muli %s, %y_s_step : index
 
+            // Load dense interleaved cosine table [c0,c1,c2,c3,...].
             %cos = pto.vlds %cos_ub[%cs_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+            // Load dense interleaved sine table [s0,s1,s2,s3,...].
             %sin = pto.vlds %sin_ub[%cs_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
             // building the rotated partner [-x1, x0, -x3, x2, ...] and then
             // evaluating y = x * cos + rotated(x) * sin.
@@ -168,7 +208,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // 输出两个 vreg<128xf16>（各只有半宽有效），需要知道 lane 映射关系。
             // VMI 对应: channel_split（语义化奇偶分解，直接产出 vreg<64>）。
 
+            // Split cosine into even and odd pair streams.
             %cos_even, %cos_odd = pto.vdintlv %cos, %cos : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
+            // Split sine into even and odd pair streams.
             %sin_even, %sin_odd = pto.vdintlv %sin, %sin : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
 
             scf.for %n = %c0 to %n_count step %c1 {
@@ -177,10 +219,12 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %x_off = arith.addi %x_s_off, %x_n_off : index
               %y_off = arith.addi %y_s_off, %y_n_off : index
 
+              // Load dense interleaved input x.
               %x = pto.vlds %x_ub[%x_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
               // MI: vdintlv 解交织 x，拆出 even/odd 两个半宽寄存器。
               // VMI 对应: channel_split。
 
+              // Split x into even and odd pair streams.
               %x_even, %x_odd = pto.vdintlv %x, %x : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
 
               // Explicit even/odd RoPE equations for the interleaved layout.
@@ -190,12 +234,18 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: 6条 vmi.mulf/subf/addf（无 mask 参数）。
               // ========================================================================
 
+              // x_even_cos = x_even * cos_even.
               %x_even_cos = pto.vmul %x_even, %cos_even, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // x_odd_sin = x_odd * sin_even.
               %x_odd_sin = pto.vmul %x_odd, %sin_even, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // y_even = x_even*cos_even - x_odd*sin_even.
               %y_even = pto.vsub %x_even_cos, %x_odd_sin, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
+              // x_odd_cos = x_odd * cos_odd.
               %x_odd_cos = pto.vmul %x_odd, %cos_odd, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // x_even_sin = x_even * sin_odd.
               %x_even_sin = pto.vmul %x_even, %sin_odd, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+              // y_odd = x_odd*cos_odd + x_even*sin_odd.
               %y_odd = pto.vadd %x_odd_cos, %x_even_sin, %mask16_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
               // MI: vintlv 硬件交织——将独立的 even/odd 寄存器合并回
@@ -203,11 +253,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // 需要分别 store 或只 store 低半（取决于数据量）。
               // VMI 对应: channel_merge（产出单个 vreg<128>，逻辑更简洁）。
 
+              // Merge even/odd outputs back to dense interleaved order.
               %y_pack, %y_pack_hi = pto.vintlv %y_even, %y_odd : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
               // MI: vsts 写回，绑定 mask<b16> full mask（64宽）。
               // vintlv 产出的 y_pack_hi 在当前数据量（64元素）下不需要 store。
               // VMI 对应: vmi.masked_store（单个 128xf16 向量一次写回）。
 
+              // Store dense interleaved output; y_pack_hi is unused for D=64.
               pto.vsts %y_pack, %y_ub[%y_off], %mask16_full : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
             }
           }

--- a/docs/examples/vmi/rope_f16.vmi.pto
+++ b/docs/examples/vmi/rope_f16.vmi.pto
@@ -88,6 +88,17 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %is_half_mode = arith.cmpi eq, %mode, %c0_i32 : i32
 
     pto.vecscope {
+      // Expected UB effect of this vecscope:
+      // - Inputs already in UB: x_ub contains f16 rows x[s,n,0..63];
+      //   cos_ub/sin_ub contain f16 RoPE tables for each s.
+      // - Output modified in UB: y_ub is overwritten with the RoPE-rotated f16 row.
+      // - mode == 0 (HALF/NeoX): for d in [0,32),
+      //     y[s,n,d]    = x[s,n,d]    * cos[s,d]    - x[s,n,d+32] * sin[s,d]
+      //     y[s,n,d+32] = x[s,n,d+32] * cos[s,d+32] + x[s,n,d]    * sin[s,d+32]
+      // - mode != 0 (INTERLEAVE/GPT-J): constructs rot(x)=[-x1,x0,-x3,x2,...]
+      //   in logical vector form and computes y = x*cos + rot(x)*sin. This VMI
+      //   spelling widens to f32 for the interleave body, then narrows to f16.
+      // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
       // ========================================================================
       // VMI vs MI — RoPE f16 向量计算路径对比概览
       // ========================================================================
@@ -136,6 +147,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // VMI: create_mask 用逻辑长度直接创建，统一 vmi.mask<Nxpred>。
             // MI 对应: pge_b16 "PAT_VL32" → !pto.mask<b16>，
             //   不同数据类型需要不同粒度的 mask（b16/b32/b8），VMI 统一为一种。
+            // Create a logical tail predicate for this f16 half tile.
             %mask = pto.vmi.create_mask %active : index -> !pto.vmi.mask<128xpred>
 
             %cos1_off = arith.addi %cs_off, %elem_off : index
@@ -150,12 +162,16 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             //   → !pto.vreg<128xf16>，需要开发者指定 UNPK_B16 解包模式，
             //   且明白有效数据只占 EVEN 位置，ODD 是填充 0。
             // VMI 消除了 dist 模式选择——编译器根据上下文自动决定物理排布。
+            // Load low-half cosine as a logical f16 vector.
             %cos1_16 = pto.vmi.load %cos_ub[%cos1_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+            // Load high-half cosine from the aligned half-D base.
             %cos2_16 = pto.vmi.load %cos_ub[%cos2_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+            // Load low-half sine.
             %sin1_16 = pto.vmi.load %sin_ub[%sin1_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+            // Load high-half sine.
             %sin2_16 = pto.vmi.load %sin_ub[%sin2_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
 
@@ -172,8 +188,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               %y2_base = arith.addi %y_off, %half_d_aligned : index
               %y2_off = arith.addi %y2_base, %elem_off : index
 
+              // Load low-half x for this head row.
               %x1_16 = pto.vmi.load %x_ub[%x1_off]
                   : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+              // Load high-half x, paired with x1_16.
               %x2_16 = pto.vmi.load %x_ub[%x2_off]
                   : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
 
@@ -191,17 +209,23 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //   每条算术指令都需要显式携带 mask（b16 for f16），
               //   VMI 消除了这个负担——编译器自动管理 mask。
               // ========================================================================
+              // x1_cos = x1 * cos_low.
               %x1_cos = pto.vmi.mulf %x1_16, %cos1_16
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
+              // x2_sin = x2 * sin_low.
               %x2_sin = pto.vmi.mulf %x2_16, %sin1_16
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
+              // out1 = x1*cos_low - x2*sin_low.
               %out1 = pto.vmi.subf %x1_cos, %x2_sin
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
 
+              // x2_cos = x2 * cos_high.
               %x2_cos = pto.vmi.mulf %x2_16, %cos2_16
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
+              // x1_sin = x1 * sin_high.
               %x1_sin = pto.vmi.mulf %x1_16, %sin2_16
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
+              // out2 = x2*cos_high + x1*sin_high.
               %out2 = pto.vmi.addf %x2_cos, %x1_sin
                   : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf16>
 
@@ -211,8 +235,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //   且 f16 store 在 MI 中可能需要 {pk = "PK_B32"} 打包模式
               //   （当数据从 f32 narrowing 后分散在 EVEN 位置时），
               //   VMI 无需关心 pack 策略。
+              // Store low-half output under the logical tail mask.
               pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask
                   : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
+              // Store high-half output under the same mask.
               pto.vmi.masked_store %out2, %y_ub[%y2_off], %mask
                   : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
             }
@@ -240,21 +266,29 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // VMI 版本选择 f16→f32 扩展精度后再截断——因为 VMI 不需要开发者关心
             //   vcvt 的 part/EVEN 细节，提升精度几乎无成本。
             // ========================================================================
+            // Create a logical predicate for the active interleaved lanes.
             %mask = pto.vmi.create_mask %active : index -> !pto.vmi.mask<128xpred>
 
             %cs_elem_off = arith.addi %cs_off, %elem_off : index
+            // Load dense interleaved f16 cosine table.
             %cos16 = pto.vmi.load %cos_ub[%cs_elem_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+            // Load dense interleaved f16 sine table.
             %sin16 = pto.vmi.load %sin_ub[%cs_elem_off]
                 : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
 
             // VMI: extf 将 f16 语义扩展为 f32——无需指定 part。
+            // This deliberately mirrors MLIR arith.extf, but the value lives in an
+            // abstract vector register. It preserves logical element order while the
+            // lowering pass chooses any required MI vcvt part/layout sequence.
             // MI 对应: pto.vcvt %cos, %mask_b16 {part = "EVEN"}
             //   → 开发者必须知道 UNPK_B16 load 后有效数据在 EVEN 位置，
             //   选错 part（EVEN vs ODD）会导致读到填充的 0 或错位数据。
             // VMI 的 extf 屏蔽了这个陷阱：编译器自己知道数据在哪。
+            // Widen cosine table to f32 logical lanes.
             %cos = pto.vmi.extf %cos16
                 : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
+            // Widen sine table to f32 logical lanes.
             %sin = pto.vmi.extf %sin16
                 : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
 
@@ -267,9 +301,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               %x_elem_off = arith.addi %x_off, %elem_off : index
               %y_elem_off = arith.addi %y_off, %elem_off : index
 
+              // Load dense interleaved f16 input x.
               %x16 = pto.vmi.load %x_ub[%x_elem_off]
                   : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
 
+              // Widen x to f32 before constructing rot(x).
               %x = pto.vmi.extf %x16
                   : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
 
@@ -290,32 +326,43 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //    编排 negate + 重排更直观
               // 3. 所有 mulf/addf 无需 mask 参数——编译器自动管理
               // ========================================================================
+              // Split x into even and odd pair channels.
               %x_even, %x_odd = "pto.vmi.channel_split"(%x)
                   : (!pto.vmi.vreg<128xf32>) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
+              // Negate odd channel to form the first half of rot(x).
               %neg_x_odd = pto.vmi.negf %x_odd
                   : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // Merge [-odd, even] back into dense interleaved rot(x).
               %rot = "pto.vmi.channel_merge"(%neg_x_odd, %x_even)
                   : (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<128xf32>
 
               // VMI: mulf / addf 直接表达 f32 向量乘加，无需 mask 参数。
               // MI 对应: 每条 vmul/vadd 都需要显式 mask<b32>。
+              // x_cos = x * cos.
               %x_cos = pto.vmi.mulf %x, %cos
                   : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
+              // rot_sin = rot(x) * sin.
               %rot_sin = pto.vmi.mulf %rot, %sin
                   : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
+              // out_f32 = x*cos + rot(x)*sin.
               %out_f32 = pto.vmi.addf %x_cos, %rot_sin
                   : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
               // VMI: truncf 将 f32 截断回 f16——无需 rnd/sat 参数。
+              // Like MLIR arith.truncf, this is a typed semantic narrowing on
+              // logical lanes; target lowering supplies the MI rounding/saturation
+              // and any pack/store protocol required by the chosen layout.
               // MI 对应: pto.vcvt %out_f32, %mask_b32 {part = "EVEN", rnd = "R", sat = "SAT"}
               //   → 开发者必须指定舍入模式 (rnd="R"=round nearest even)
               //   和饱和模式 (sat="SAT")，用错会产生数值误差。
               // VMI 编译器根据目标类型自动填入正确的舍入/饱和参数。
+              // Narrow f32 result back to f16 logical lanes.
               %out = pto.vmi.truncf %out_f32
                   : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
 
               // VMI: masked_store 用统一的 vmi.mask<128xpred> 掩码写回。
               // MI 对应: pto.vsts %y_pack, %y_ub[%y_off], %mask16_full
               //   → 需要 !pto.mask<b16> + 可能需要 pk 模式。
+              // Store dense interleaved f16 output.
               pto.vmi.masked_store %out, %y_ub[%y_elem_off], %mask
                   : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
             }

--- a/docs/examples/vmi/rope_f16_v2.mi.pto
+++ b/docs/examples/vmi/rope_f16_v2.mi.pto
@@ -110,6 +110,16 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       %is_half_mode = arith.cmpi eq, %mode, %c0_i32 : i32
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Inputs already in UB: x_ub contains f16 rows x[s,n,0..63];
+        //   cos_ub/sin_ub contain f16 RoPE tables for each s.
+        // - Output modified in UB: y_ub is overwritten with the RoPE-rotated f16 row.
+        // - mode == 0 (HALF/NeoX): for d in [0,32),
+        //     y[s,n,d]    = x[s,n,d]    * cos[s,d]    - x[s,n,d+32] * sin[s,d]
+        //     y[s,n,d+32] = x[s,n,d+32] * cos[s,d+32] + x[s,n,d]    * sin[s,d+32]
+        // - mode != 0 (INTERLEAVE/GPT-J): builds rot(x)=[-x1,x0,-x3,x2,...]
+        //   with vdintlv/vintlv and computes y = x*cos + rot(x)*sin in f16.
+        // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
         // Compute body aligned to rope_cce_compute.h ComputeF16.
         // Contrast with rope_f16.mi.pto: see summary block above vecscope.
         scf.if %is_half_mode {
@@ -140,9 +150,17 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %sin_hi_base = arith.addi %cs_off, %half_d_aligned : index
               %sin_hi_off = arith.addi %sin_hi_base, %elem_off : index
 
+              // MI/CCE: vlds NORM_B16 loads one 256-byte f16 register from UB.
+              // The active lane count is not encoded in the load; it is carried by
+              // %mask16 on the later arithmetic/store ops. These four table loads
+              // are hoisted outside the head loop because cos/sin depend on s and d,
+              // not on n. VMI equivalent: four pto.vmi.load ops on logical vectors.
               %cos_lo = pto.vlds %cos_ub[%cos_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              // High-half cosine starts at half_d_aligned, matching CCE calign(halfD, 16).
               %cos_hi = pto.vlds %cos_ub[%cos_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              // Low-half sine partners x_hi in y_lo = cos_lo*x_lo - sin_lo*x_hi.
               %sin_lo = pto.vlds %sin_ub[%sin_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              // High-half sine partners x_lo in y_hi = cos_hi*x_hi + sin_hi*x_lo.
               %sin_hi = pto.vlds %sin_ub[%sin_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
               scf.for %n = %c0 to %n_count step %c1 {
@@ -157,19 +175,30 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
                 %y_hi_base = arith.addi %y_base, %half_d_aligned : index
                 %y_hi_off = arith.addi %y_hi_base, %elem_off : index
 
+                // Per-head input loads: x_lo is x[s,n,d], x_hi is x[s,n,d+halfD].
+                // Both are dense f16 loads; only %mask16 determines how many lanes are valid.
                 %x_lo = pto.vlds %x_ub[%x_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
                 %x_hi = pto.vlds %x_ub[%x_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
                 // RoPE half math is the same 6-op sequence in both files;
                 // only the mask source and UB offsets differ (see comments above).
+                // t0 = cos_lo * x_lo. pto.vmul is element-wise f16 multiply and
+                // requires a b16 predicate even when the mask is the same for all math ops.
                 %t0 = pto.vmul %cos_lo, %x_lo, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // t1 = sin_lo * x_hi, the cross term subtracted from the low output half.
                 %t1 = pto.vmul %sin_lo, %x_hi, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // y_lo = t0 - t1 = x_lo*cos_lo - x_hi*sin_lo.
                 %y_lo = pto.vsub %t0, %t1, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
+                // t2 = cos_hi * x_hi, the direct high-half term.
                 %t2 = pto.vmul %cos_hi, %x_hi, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // t3 = sin_hi * x_lo, the cross term added into the high output half.
                 %t3 = pto.vmul %sin_hi, %x_lo, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // y_hi = t2 + t3 = x_hi*cos_hi + x_lo*sin_hi.
                 %y_hi = pto.vadd %t2, %t3, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
+                // Store low and high partner halves back to dense UB. There is no PK mode
+                // in native f16 half mode; the same b16 predicate gates active lanes.
                 pto.vsts %y_lo, %y_ub[%y_lo_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
                 pto.vsts %y_hi, %y_ub[%y_hi_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
               }
@@ -209,11 +238,16 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %pair_cnt_plus = arith.addi %cnt_i32, %c1_i32 : i32
               %pair_cnt_i32 = arith.divui %pair_cnt_plus, %c2_i32 : i32
 
+              // Full-block predicate: active f16 lanes for dense x/cos/sin/y operations.
               %mask16, %mask16_next = pto.plt_b16 %cnt_i32 : i32 -> !pto.mask<b16>, i32
+              // Pair predicate: active even/odd pair lanes after vdintlv. It has half
+              // the logical length because one lane in each split stream represents one pair.
               %mask_pair, %mask_pair_next = pto.plt_b16 %pair_cnt_i32 : i32 -> !pto.mask<b16>, i32
 
               %cs_elem_off = arith.addi %cs_off, %off : index
               // rope_f16.mi.pto deinterleaves cos/sin here; v2 keeps tables dense.
+              // Dense cos/sin loads. In the complex-multiply spelling the tables are
+              // not deinterleaved; the rotated x vector is built instead.
               %cos = pto.vlds %cos_ub[%cs_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
               %sin = pto.vlds %sin_ub[%cs_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
@@ -225,20 +259,31 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
                 %x_elem_off = arith.addi %x_off, %off : index
                 %y_elem_off = arith.addi %y_off, %off : index
 
+                // Dense interleaved input: [x0,x1,x2,x3,...]. vdintlv below splits parity.
                 %x = pto.vlds %x_ub[%x_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
 
                 // Build (i*x) for complex-multiply form — v1 builds i*x implicitly
                 // via separate y_even/y_odd updates on deinterleaved streams.
+                // vdintlv(x,x): even=[x0,x2,...], odd=[x1,x3,...]. This is the
+                // hardware equivalent of VMI channel_split.
                 %x_even, %x_odd = pto.vdintlv %x, %x : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
+                // Negate odd stream to form the real-layout action of multiplying by i.
                 %x_neg_odd = pto.vmul %x_odd, %neg_one, %mask_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // vintlv(-odd, even): rebuild [-x1,x0,-x3,x2,...]. x_rot_hi is
+                // produced by the hardware interleave but unused for this 64-element block.
                 %x_rot, %x_rot_hi = pto.vintlv %x_neg_odd, %x_even : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
 
                 // complex-multiply: y = x*cos + (i*x)*sin  (3 ops)
                 // vs Cartesian expansion: separate y_even/y_odd updates (8 ops)
+                // First product term: x*cos, preserving the dense interleaved order.
                 %x_cos = pto.vmul %x, %cos, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // Second product term: (i*x)*sin using the rotated partner vector.
                 %rot_sin = pto.vmul %x_rot, %sin, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                // Add the two dense terms: y = x*cos + (i*x)*sin.
                 %y = pto.vadd %x_cos, %rot_sin, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 
+                // Store dense interleaved f16 output. The mask covers the original
+                // dense block, not the half-width pair streams used while building x_rot.
                 pto.vsts %y, %y_ub[%y_elem_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
               }
             }

--- a/docs/examples/vmi/rope_f16_v2.mi.pto
+++ b/docs/examples/vmi/rope_f16_v2.mi.pto
@@ -1,0 +1,256 @@
+module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<vector>, pto.target_arch = "a5"} {
+    func.func @rope_mi_f16_v2(
+        %x_gm16: !pto.ptr<ui16, gm>,
+        %cos_gm16: !pto.ptr<ui16, gm>,
+        %sin_gm16: !pto.ptr<ui16, gm>,
+        %y_gm16: !pto.ptr<ui16, gm>,
+        %sCount: i32,
+        %nCount: i32,
+        %mode: i32) attributes {pto.kernel} {
+      %false = arith.constant false
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c2_i32 = arith.constant 2 : i32
+      %c2_i64 = arith.constant 2 : i64
+      %c15 = arith.constant 15 : index
+      %c16 = arith.constant 16 : index
+      %c31_i64 = arith.constant 31 : i64
+      %c32_i64 = arith.constant 32 : i64
+      %c63 = arith.constant 63 : index
+      %c64 = arith.constant 64 : index
+      %c64_i32 = arith.constant 64 : i32
+      %c127 = arith.constant 127 : index
+      %c128 = arith.constant 128 : index
+      %c128_i32 = arith.constant 128 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %neg_one_f16 = arith.constant -1.000000e+00 : f16
+
+      %x_gm = pto.castptr %x_gm16 : !pto.ptr<ui16, gm> -> !pto.ptr<f16, gm>
+      %cos_gm = pto.castptr %cos_gm16 : !pto.ptr<ui16, gm> -> !pto.ptr<f16, gm>
+      %sin_gm = pto.castptr %sin_gm16 : !pto.ptr<ui16, gm> -> !pto.ptr<f16, gm>
+      %y_gm = pto.castptr %y_gm16 : !pto.ptr<ui16, gm> -> !pto.ptr<f16, gm>
+
+      %s_count = arith.index_cast %sCount : i32 to index
+      %n_count = arith.index_cast %nCount : i32 to index
+      %cos_elems = arith.muli %s_count, %c64 : index
+      %xy_rows = arith.muli %s_count, %n_count : index
+      %xy_elems = arith.muli %xy_rows, %c64 : index
+
+      %cos_elems_i64 = arith.index_cast %cos_elems : index to i64
+      %xy_elems_i64 = arith.index_cast %xy_elems : index to i64
+      %cos_bytes = arith.muli %cos_elems_i64, %c2_i64 : i64
+      %xy_bytes = arith.muli %xy_elems_i64, %c2_i64 : i64
+
+      %cos_lines = arith.addi %cos_bytes, %c31_i64 : i64
+      %cos_lines_q = arith.divui %cos_lines, %c32_i64 : i64
+      %cos_dma_bytes = arith.muli %cos_lines_q, %c32_i64 : i64
+
+      %xy_lines = arith.addi %xy_bytes, %c31_i64 : i64
+      %xy_lines_q = arith.divui %xy_lines, %c32_i64 : i64
+      %xy_dma_bytes = arith.muli %xy_lines_q, %c32_i64 : i64
+
+      %sin_ub_off = arith.addi %cos_dma_bytes, %c0_i64 : i64
+      %x_ub_off = arith.addi %cos_dma_bytes, %cos_dma_bytes : i64
+      %y_ub_off = arith.addi %x_ub_off, %xy_dma_bytes : i64
+
+      %cos_ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+      %sin_ub = pto.castptr %sin_ub_off : i64 -> !pto.ptr<f16, ub>
+      %x_ub = pto.castptr %x_ub_off : i64 -> !pto.ptr<f16, ub>
+      %y_ub = pto.castptr %y_ub_off : i64 -> !pto.ptr<f16, ub>
+
+      pto.copy_gm_to_ubuf %cos_gm, %cos_ub, %c0_i64, %c1_i64, %cos_dma_bytes, %c0_i64, %c0_i64, %false, %c0_i64, %cos_dma_bytes, %cos_dma_bytes : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+      pto.copy_gm_to_ubuf %sin_gm, %sin_ub, %c0_i64, %c1_i64, %cos_dma_bytes, %c0_i64, %c0_i64, %false, %c0_i64, %cos_dma_bytes, %cos_dma_bytes : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+      pto.copy_gm_to_ubuf %x_gm, %x_ub, %c0_i64, %c1_i64, %xy_dma_bytes, %c0_i64, %c0_i64, %false, %c0_i64, %xy_dma_bytes, %xy_dma_bytes : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+
+      pto.set_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]
+
+      // ========================================================================
+      // v2(code here) vs rope_f16.mi.pto — summary of intentional differences
+      // ========================================================================
+      // Same outer kernel shell (GM→UB DMA, flags, UB→GM) as rope_f16.mi.pto.
+      //
+      // HALF mode (mode==0):
+      //   rope_f16.mi.pto:  s -> hoist cos/sin -> n  (no rep loop)
+      //                     fixed pge_b16 "PAT_VL32" mask, high-half at +32
+      //   v2(code here):   s -> rep (VL_F16=128) -> hoist cos/sin -> n
+      //                     plt_b16 from runtime cnt, halfDAl-aligned high half
+      //                     matches rope_cce_compute.h ComputeF16 HALF loop
+      //
+      // INTERLEAVE mode (mode!=0, GPT-J layout):
+      //   rope_f16.mi.pto:  Cartesian expansion form — vdintlv cos/sin/x, even/odd
+      //                     updates, vintlv re-pack; fixed pge_b16 masks
+      //   v2(code here):    complex-multiply form — y=x*cos+(i*x)*sin; cos/sin dense;
+      //                     i*x via vdintlv(x)→negate odd→vintlv; blk loop + plt_b16
+      // ========================================================================
+
+      // Layout math mirrors rope_cce_compute.h ComputeF16: halfD, halfDAl,
+      // repeatTimesF16, dBlocks. (rope_f16.mi.pto hardcodes +32 and skips this.)
+      %half_d_i32 = arith.divui %c64_i32, %c2_i32 : i32
+      %half_d = arith.index_cast %half_d_i32 : i32 to index
+      %half_d_plus = arith.addi %half_d, %c15 : index
+      %half_d_blocks = arith.divui %half_d_plus, %c16 : index
+      %half_d_aligned = arith.muli %half_d_blocks, %c16 : index
+
+      %half_repeat_num = arith.addi %half_d, %c127 : index
+      %half_repeats = arith.divui %half_repeat_num, %c128 : index
+
+      %d_block_num = arith.addi %c64, %c63 : index
+      %d_blocks = arith.divui %d_block_num, %c64 : index
+
+      %x_s_step = arith.muli %n_count, %c64 : index
+      %x_n_step = arith.addi %c64, %c0 : index
+      %cs_s_step = arith.addi %c64, %c0 : index
+      %y_s_step = arith.muli %n_count, %c64 : index
+      %y_n_step = arith.addi %c64, %c0 : index
+      %is_half_mode = arith.cmpi eq, %mode, %c0_i32 : i32
+
+      pto.vecscope {
+        // Compute body aligned to rope_cce_compute.h ComputeF16.
+        // Contrast with rope_f16.mi.pto: see summary block above vecscope.
+        scf.if %is_half_mode {
+          // === HALF mode — v2(code here) vs rope_f16.mi.pto ===
+          // rope_f16.mi.pto: no rep loop; mask16_half = pge_b16 "PAT_VL32" once;
+          //   cs_hi_off = cs_off + 32 (implicit halfD=32 for D=64 demo).
+          // v2(code here): inner rep loop (stride 128 = VL_F16), dynamic plt_b16(cnt),
+          //   high-half base = cs_off + half_d_aligned (calign(halfD, 16)).
+          scf.for %s = %c0 to %s_count step %c1 {
+            %x_s_off = arith.muli %s, %x_s_step : index
+            %cs_off = arith.muli %s, %cs_s_step : index
+            %y_s_off = arith.muli %s, %y_s_step : index
+
+            scf.for %rep = %c0 to %half_repeats step %c1 {
+              // rope_f16.mi.pto has no rep/elem_off — it assumes one 32-lane tile.
+              %elem_off = arith.muli %rep, %c128 : index
+              %elem_off_i32 = arith.index_cast %elem_off : index to i32
+              %rem_i32 = arith.subi %half_d_i32, %elem_off_i32 : i32
+              %lt_vl128 = arith.cmpi slt, %rem_i32, %c128_i32 : i32
+              %cnt_i32 = arith.select %lt_vl128, %rem_i32, %c128_i32 : i32
+              // rope_f16.mi.pto: pge_b16 "PAT_VL32" (static). v2(code here): plt_b16 (CCE make_mask_b16).
+              %mask16, %mask16_next = pto.plt_b16 %cnt_i32 : i32 -> !pto.mask<b16>, i32
+
+              %cos_lo_off = arith.addi %cs_off, %elem_off : index
+              %cos_hi_base = arith.addi %cs_off, %half_d_aligned : index
+              %cos_hi_off = arith.addi %cos_hi_base, %elem_off : index
+              %sin_lo_off = arith.addi %cs_off, %elem_off : index
+              %sin_hi_base = arith.addi %cs_off, %half_d_aligned : index
+              %sin_hi_off = arith.addi %sin_hi_base, %elem_off : index
+
+              %cos_lo = pto.vlds %cos_ub[%cos_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              %cos_hi = pto.vlds %cos_ub[%cos_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              %sin_lo = pto.vlds %sin_ub[%sin_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              %sin_hi = pto.vlds %sin_ub[%sin_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+
+              scf.for %n = %c0 to %n_count step %c1 {
+                %x_n_off = arith.muli %n, %x_n_step : index
+                %y_n_off = arith.muli %n, %y_n_step : index
+                %x_base = arith.addi %x_s_off, %x_n_off : index
+                %y_base = arith.addi %y_s_off, %y_n_off : index
+                %x_lo_off = arith.addi %x_base, %elem_off : index
+                %x_hi_base = arith.addi %x_base, %half_d_aligned : index
+                %x_hi_off = arith.addi %x_hi_base, %elem_off : index
+                %y_lo_off = arith.addi %y_base, %elem_off : index
+                %y_hi_base = arith.addi %y_base, %half_d_aligned : index
+                %y_hi_off = arith.addi %y_hi_base, %elem_off : index
+
+                %x_lo = pto.vlds %x_ub[%x_lo_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+                %x_hi = pto.vlds %x_ub[%x_hi_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+
+                // RoPE half math is the same 6-op sequence in both files;
+                // only the mask source and UB offsets differ (see comments above).
+                %t0 = pto.vmul %cos_lo, %x_lo, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %t1 = pto.vmul %sin_lo, %x_hi, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %y_lo = pto.vsub %t0, %t1, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+
+                %t2 = pto.vmul %cos_hi, %x_hi, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %t3 = pto.vmul %sin_hi, %x_lo, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %y_hi = pto.vadd %t2, %t3, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+
+                pto.vsts %y_lo, %y_ub[%y_lo_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+                pto.vsts %y_hi, %y_ub[%y_hi_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+              }
+            }
+          }
+        } else {
+          // === INTERLEAVE mode (GPT-J layout) — v2(code here) vs rope_f16.mi.pto ===
+          //
+          // Same interleaved RoPE semantics; two equivalent spellings of complex rotation:
+          //
+          // rope_f16.mi.pto — Cartesian expansion form (even/odd deinterleaved compute):
+          //   Treat (x_even, x_odd) as (Re, Im) per 2D block; expand (a+ib)(c+id):
+          //     y_even = x_even*cos_even - x_odd*sin_even
+          //     y_odd  = x_odd*cos_odd  + x_even*sin_odd
+          //   vdintlv cos, sin, AND x → 8 arith ops → vintlv → store
+          //   Fixed pge_b16 masks; no blk loop; no vbr.
+          //
+          // v2(code here) — complex-multiply form (rope_cce_compute.h ComputeF16 INTERLEAVE):
+          //   y = x*cos + (i*x)*sin,  (i*x) = [-x1,x0,-x3,x2,...] in interleaved layout
+          //   cos/sin dense load (no vdintlv on tables)
+          //   Build i*x on x only: vdintlv(x) → vmul(odd,-1) → vintlv
+          //   3 arith ops → single vsts; blk loop (64 f16/block); plt_b16; vbr(-1)
+          %neg_one = pto.vbr %neg_one_f16 : f16 -> !pto.vreg<128xf16>
+
+          scf.for %s = %c0 to %s_count step %c1 {
+            %x_s_off = arith.muli %s, %x_s_step : index
+            %cs_off = arith.muli %s, %cs_s_step : index
+            %y_s_off = arith.muli %s, %y_s_step : index
+
+            scf.for %blk = %c0 to %d_blocks step %c1 {
+              // rope_f16.mi.pto: no blk loop — one cos/sin load at cs_off per s.
+              %off = arith.muli %blk, %c64 : index
+              %off_i32 = arith.index_cast %off : index to i32
+              %remaining_i32 = arith.subi %c64_i32, %off_i32 : i32
+              %lt_blk = arith.cmpi slt, %remaining_i32, %c64_i32 : i32
+              %cnt_i32 = arith.select %lt_blk, %remaining_i32, %c64_i32 : i32
+              %pair_cnt_plus = arith.addi %cnt_i32, %c1_i32 : i32
+              %pair_cnt_i32 = arith.divui %pair_cnt_plus, %c2_i32 : i32
+
+              %mask16, %mask16_next = pto.plt_b16 %cnt_i32 : i32 -> !pto.mask<b16>, i32
+              %mask_pair, %mask_pair_next = pto.plt_b16 %pair_cnt_i32 : i32 -> !pto.mask<b16>, i32
+
+              %cs_elem_off = arith.addi %cs_off, %off : index
+              // rope_f16.mi.pto deinterleaves cos/sin here; v2 keeps tables dense.
+              %cos = pto.vlds %cos_ub[%cs_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+              %sin = pto.vlds %sin_ub[%cs_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+
+              scf.for %n = %c0 to %n_count step %c1 {
+                %x_n_off = arith.muli %n, %x_n_step : index
+                %y_n_off = arith.muli %n, %y_n_step : index
+                %x_off = arith.addi %x_s_off, %x_n_off : index
+                %y_off = arith.addi %y_s_off, %y_n_off : index
+                %x_elem_off = arith.addi %x_off, %off : index
+                %y_elem_off = arith.addi %y_off, %off : index
+
+                %x = pto.vlds %x_ub[%x_elem_off] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+
+                // Build (i*x) for complex-multiply form — v1 builds i*x implicitly
+                // via separate y_even/y_odd updates on deinterleaved streams.
+                %x_even, %x_odd = pto.vdintlv %x, %x : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
+                %x_neg_odd = pto.vmul %x_odd, %neg_one, %mask_pair : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %x_rot, %x_rot_hi = pto.vintlv %x_neg_odd, %x_even : !pto.vreg<128xf16>, !pto.vreg<128xf16> -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
+
+                // complex-multiply: y = x*cos + (i*x)*sin  (3 ops)
+                // vs Cartesian expansion: separate y_even/y_odd updates (8 ops)
+                %x_cos = pto.vmul %x, %cos, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %rot_sin = pto.vmul %x_rot, %sin, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+                %y = pto.vadd %x_cos, %rot_sin, %mask16 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+
+                pto.vsts %y, %y_ub[%y_elem_off], %mask16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+              }
+            }
+          }
+        }
+      }
+
+      pto.set_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.copy_ubuf_to_gm %y_ub, %y_gm, %c0_i64, %c1_i64, %xy_dma_bytes, %c0_i64, %xy_dma_bytes, %xy_dma_bytes : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
+      pto.barrier <PIPE_ALL>
+      return
+    }
+  }
+}

--- a/docs/examples/vmi/rope_f32.mi.pto
+++ b/docs/examples/vmi/rope_f32.mi.pto
@@ -80,12 +80,35 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
       // ========================================================================
 
       pto.vecscope {
+        // Expected UB effect of this vecscope:
+        // - Inputs already in UB: x_ub contains f32 rows x[s,n,0..63];
+        //   cos_ub/sin_ub contain f32 RoPE tables for each s.
+        // - Output modified in UB: y_ub is overwritten with f32 RoPE results.
+        // - mode == 0 (HALF/NeoX): for d in [0,32),
+        //     y[s,n,d]    = x[s,n,d]    * cos[s,d]    - x[s,n,d+32] * sin[s,d]
+        //     y[s,n,d+32] = x[s,n,d+32] * cos[s,d+32] + x[s,n,d]    * sin[s,d+32]
+        // - mode != 0 (INTERLEAVE/GPT-J): deinterleaves adjacent pairs and computes
+        //     y_even = x_even*cos_even - x_odd*sin_even
+        //     y_odd  = x_odd *cos_odd  + x_even*sin_odd
+        //   then writes dense interleaved f32 output.
+        // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
+        // Instruction reading guide for this MI file:
+        // - f32 is the simplest physical case: one 256-byte vector register holds
+        //   64 f32 lanes, so loads/stores are plain pto.vlds/pto.vsts with no
+        //   UNPK/PK distribution mode.
+        // - The low-level burden that remains is predicate plumbing: pge_b32 or
+        //   pset_b32 must be passed to every vmul/vsub/vadd/vsts instruction.
+        // - In INTERLEAVE mode, pto.vdintlv and pto.vintlv are still required to
+        //   split [even,odd] pair channels and merge them back.
+        // VMI equivalents keep the same math but replace the shuffle vocabulary
+        // with channel_split/channel_merge and remove arithmetic mask operands.
         // This is the reference-precision path: fp32 load, fp32 math, fp32 store,
         // with the same two layout branches as the MI implementation.
         scf.if %is_half_mode {
           // MI: pge_b32 创建 32 宽的 b32 mask（f32 half 模式专用）。
           // VMI 对应: vmi.create_mask（逻辑长度创建，统一 vmi.mask<N>）。
 
+          // pge_b32 PAT_VL32 activates the first 32 f32 lanes for one D/2 half.
           %mask32_half = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
@@ -97,9 +120,13 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // load 相对简洁，但仍是物理寄存器视角（64宽）。
             // VMI 对应: vmi.load（统一的逻辑向量接口）。
 
+            // Load low-half cosine table for y_lo = cos_lo*x_lo - sin_lo*x_hi.
             %cos_lo = pto.vlds %cos_ub[%cs_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+            // Load high-half cosine table from the D/2 offset.
             %cos_hi = pto.vlds %cos_ub[%cs_hi_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+            // Load low-half sine table for the low-output cross term.
             %sin_lo = pto.vlds %sin_ub[%cs_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+            // Load high-half sine table for the high-output cross term.
             %sin_hi = pto.vlds %sin_ub[%cs_hi_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
             // HALF layout keeps the two partner halves separate all the way through.
@@ -111,7 +138,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %x_hi_off = arith.addi %x_off, %c32 : index
               %y_hi_off = arith.addi %y_off, %c32 : index
 
+              // Load x low half for this (s,n) row.
               %x_lo = pto.vlds %x_ub[%x_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+              // Load x high half, the rotation partner of x_lo.
               %x_hi = pto.vlds %x_ub[%x_hi_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
               // ========================================================================
@@ -124,18 +153,26 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: vmi.mulf/subf/addf（无 mask 参数）。
               // ========================================================================
 
+              // t0 = cos_lo * x_lo, the direct low-half term.
               %t0 = pto.vmul %cos_lo, %x_lo, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // t1 = sin_lo * x_hi, the cross term subtracted from low half.
               %t1 = pto.vmul %sin_lo, %x_hi, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_lo = cos_lo*x_lo - sin_lo*x_hi.
               %y_lo = pto.vsub %t0, %t1, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
+              // t2 = cos_hi * x_hi, the direct high-half term.
               %t2 = pto.vmul %cos_hi, %x_hi, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // t3 = sin_hi * x_lo, the cross term added to high half.
               %t3 = pto.vmul %sin_hi, %x_lo, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_hi = cos_hi*x_hi + sin_hi*x_lo.
               %y_hi = pto.vadd %t2, %t3, %mask32_half : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
               // MI: vsts 写回，绑定 mask<b32>。
               // VMI 对应: vmi.masked_store。
 
+              // Store low output half with the same 32-lane b32 predicate.
               pto.vsts %y_lo, %y_ub[%y_off], %mask32_half : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+              // Store high output half at +D/2.
               pto.vsts %y_hi, %y_ub[%y_hi_off], %mask32_half : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
             }
           }
@@ -149,14 +186,18 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
           // full mask(64宽) 用于最终写回。vdintlv/vintlv 处理交织/解交织。
           // ========================================================================
 
+          // Pair mask: 32 even/odd pairs after deinterleave.
           %mask32_pair = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
+          // Full mask: all 64 f32 lanes when storing the merged interleaved row.
           %mask32_full = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
           scf.for %s = %c0 to %s_count step %c1 {
             %x_s_off = arith.muli %s, %x_s_step : index
             %cs_off = arith.muli %s, %cs_s_step : index
             %y_s_off = arith.muli %s, %y_s_step : index
 
+            // Load dense interleaved cosine table [c0,c1,c2,c3,...].
             %cos = pto.vlds %cos_ub[%cs_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+            // Load dense interleaved sine table [s0,s1,s2,s3,...].
             %sin = pto.vlds %sin_ub[%cs_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
             // split even/odd -> form rotated partner -> y = x*cos + rot(x)*sin.
             // Here the same relation is written directly in explicit even/odd form.
@@ -164,7 +205,9 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
             // 输入两个相同寄存器，输出两个半宽寄存器。需要理解 lane 映射。
             // VMI 对应: channel_split（语义化奇偶分解）。
 
+            // Split cosine into even-index and odd-index streams for Cartesian RoPE.
             %cos_even, %cos_odd = pto.vdintlv %cos, %cos : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+            // Split sine into even-index and odd-index streams.
             %sin_even, %sin_odd = pto.vdintlv %sin, %sin : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
             scf.for %n = %c0 to %n_count step %c1 {
@@ -173,10 +216,12 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               %x_off = arith.addi %x_s_off, %x_n_off : index
               %y_off = arith.addi %y_s_off, %y_n_off : index
 
+              // Load dense interleaved x row [x0,x1,x2,x3,...].
               %x = pto.vlds %x_ub[%x_off] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
               // MI: vdintlv 解交织 x。
               // VMI 对应: channel_split。
 
+              // Split x into real/even and imaginary/odd streams.
               %x_even, %x_odd = pto.vdintlv %x, %x : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
               // Explicit even/odd RoPE equations for the interleaved layout.
@@ -186,22 +231,30 @@ module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
               // VMI 对应: 6条 vmi.mulf/subf/addf（无 mask）。
               // ========================================================================
 
+              // x_even_cos = x_even * cos_even.
               %x_even_cos = pto.vmul %x_even, %cos_even, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // x_odd_sin = x_odd * sin_even.
               %x_odd_sin = pto.vmul %x_odd, %sin_even, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_even = x_even*cos_even - x_odd*sin_even.
               %y_even = pto.vsub %x_even_cos, %x_odd_sin, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
+              // x_odd_cos = x_odd * cos_odd.
               %x_odd_cos = pto.vmul %x_odd, %cos_odd, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // x_even_sin = x_even * sin_odd.
               %x_even_sin = pto.vmul %x_even, %sin_odd, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+              // y_odd = x_odd*cos_odd + x_even*sin_odd.
               %y_odd = pto.vadd %x_odd_cos, %x_even_sin, %mask32_pair : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 
               // MI: vintlv 硬件交织 even/odd 回交织格式。
               // 产出 y_pack(64xf32) 和 y_pack_hi(64xf32)，只需 store y_pack。
               // VMI 对应: channel_merge（单个 vreg<128xf32>，一次 store）。
 
+              // Interleave even/odd outputs back to [y0,y1,y2,y3,...].
               %y_pack, %y_pack_hi = pto.vintlv %y_even, %y_odd : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
               // MI: vsts 写回，绑定 mask<b32> full mask。
               // VMI 对应: vmi.masked_store。
 
+              // Store the merged interleaved output. y_pack_hi is not needed for D=64.
               pto.vsts %y_pack, %y_ub[%y_off], %mask32_full : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
             }
           }

--- a/docs/examples/vmi/rope_f32.vmi.pto
+++ b/docs/examples/vmi/rope_f32.vmi.pto
@@ -85,6 +85,17 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %is_half_mode = arith.cmpi eq, %mode, %c0_i32 : i32
 
     pto.vecscope {
+      // Expected UB effect of this vecscope:
+      // - Inputs already in UB: x_ub contains f32 rows x[s,n,0..63];
+      //   cos_ub/sin_ub contain f32 RoPE tables for each s.
+      // - Output modified in UB: y_ub is overwritten with f32 RoPE results.
+      // - mode == 0 (HALF/NeoX): for d in [0,32),
+      //     y[s,n,d]    = x[s,n,d]    * cos[s,d]    - x[s,n,d+32] * sin[s,d]
+      //     y[s,n,d+32] = x[s,n,d+32] * cos[s,d+32] + x[s,n,d]    * sin[s,d+32]
+      // - mode != 0 (INTERLEAVE/GPT-J): channel_split separates adjacent pairs and
+      //   computes y_even/y_odd with the Cartesian RoPE equations, then
+      //   channel_merge writes dense interleaved f32 output.
+      // x_ub/cos_ub/sin_ub are read-only from the vector compute perspective.
       // ========================================================================
       // VMI vs MI — RoPE f32 向量计算路径对比概览
       // ========================================================================
@@ -108,6 +119,15 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       // 2. channel_split/merge 替代 vdintlv/vintlv，将"硬件 lane 重排"
       //    提升为"奇偶通道分解"的语义表达
       // ========================================================================
+      // Instruction reading guide for this VMI file:
+      // - pto.vmi.load/pto.vmi.masked_store name logical f32 vectors. Since f32
+      //   already maps cleanly to 64 physical lanes, VMI is mostly improving
+      //   consistency rather than hiding UNPK/PK machinery.
+      // - pto.vmi.mulf/subf/addf are ordinary element-wise f32 operations, but
+      //   unlike MI vmul/vsub/vadd they do not carry a mask operand on every line.
+      // - pto.vmi.channel_split/channel_merge describe the RoPE pair layout in
+      //   algorithm terms. Lowered MI still uses vdintlv/vintlv to realize that
+      //   parity split/merge on registers.
       //
       // ========================================================================
       // Half 模式 — 纯 f32 向量计算
@@ -128,6 +148,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // VMI: create_mask 逻辑长度 → vmi.mask<64xpred>。
             // MI 对应: pge_b32 "PAT_VL32" → !pto.mask<b32>。
             //   VMI 统一了 mask 类型，不再区分 b16/b32/b8。
+            // Create a logical tail predicate for the current half-D tile.
             %mask = pto.vmi.create_mask %active : index -> !pto.vmi.mask<64xpred>
 
             %cos1_off = arith.addi %cs_off, %elem_off : index
@@ -141,12 +162,16 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // MI 对应: pto.vlds %cos_ub[%cs_off] → !pto.vreg<64xf32>
             //   因为 f32 不存在 f16/bf16 的 UNPK/PK 问题，MI 的 load 也相对简洁。
             //   但 VMI 用统一的 vmi.load 接口覆盖所有数据类型，接口一致性更好。
+            // Load low-half cosine as a logical f32 vector.
             %cos1 = pto.vmi.load %cos_ub[%cos1_off]
                 : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+            // Load high-half cosine from the aligned half-D base.
             %cos2 = pto.vmi.load %cos_ub[%cos2_off]
                 : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+            // Load low-half sine.
             %sin1 = pto.vmi.load %sin_ub[%sin1_off]
                 : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+            // Load high-half sine.
             %sin2 = pto.vmi.load %sin_ub[%sin2_off]
                 : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
 
@@ -163,8 +188,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               %y2_base = arith.addi %y_off, %half_d_aligned : index
               %y2_off = arith.addi %y2_base, %elem_off : index
 
+              // Load low-half x for this head row.
               %x1 = pto.vmi.load %x_ub[%x1_off]
                   : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+              // Load high-half x, paired with x1.
               %x2 = pto.vmi.load %x_ub[%x2_off]
                   : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
 
@@ -181,26 +208,34 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
               //   VMI 编译器根据向量宽度自动生成正确的 mask。
               // ========================================================================
               // y1 = x1 * cos - x2 * sin
+              // x1_cos = x1 * cos_low.
               %x1_cos = pto.vmi.mulf %x1, %cos1
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // x2_sin = x2 * sin_low.
               %x2_sin = pto.vmi.mulf %x2, %sin1
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // out1 = x1*cos_low - x2*sin_low.
               %out1 = pto.vmi.subf %x1_cos, %x2_sin
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
               // y2 = x2 * cos + x1 * sin
+              // x2_cos = x2 * cos_high.
               %x2_cos = pto.vmi.mulf %x2, %cos2
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // x1_sin = x1 * sin_high.
               %x1_sin = pto.vmi.mulf %x1, %sin2
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+              // out2 = x2*cos_high + x1*sin_high.
               %out2 = pto.vmi.addf %x2_cos, %x1_sin
                   : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
               // VMI: masked_store 统一掩码写回。
               // MI 对应: pto.vsts %y_lo, %y_ub[%y_off], %mask32_half
               //   → !pto.vreg<64xf32> + !pto.mask<b32>。
+              // Store low-half output using the logical tail mask.
               pto.vmi.masked_store %out1, %y_ub[%y1_off], %mask
                   : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
+              // Store high-half output using the same logical tail mask.
               pto.vmi.masked_store %out2, %y_ub[%y2_off], %mask
                   : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
             }
@@ -234,9 +269,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
           // ========================================================================
           //   y_even = x_even * cos_even - x_odd * sin_even
           //   y_odd  = x_odd  * cos_odd  + x_even * sin_odd
+          // Create a logical predicate for the full D=64 interleaved row.
           %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<128xpred>
+          // Load dense interleaved cosine table.
           %cos = pto.vmi.load %cos_ub[%cs_off]
               : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+          // Load dense interleaved sine table.
           %sin = pto.vmi.load %sin_ub[%cs_off]
               : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
 
@@ -245,8 +283,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
           // 使得后续 RoPE 成对计算可以用分离的向量直接表达。
           // MI 对应: pto.vdintlv %cos, %cos → !pto.vreg<64xf32>, !pto.vreg<64xf32>
           //   硬件解交织指令，需要理解寄存器 lane 映射关系。
+          // Split cosine into even and odd pair channels.
           %cos_even, %cos_odd = "pto.vmi.channel_split"(%cos)
               : (!pto.vmi.vreg<128xf32>) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
+          // Split sine into even and odd pair channels.
           %sin_even, %sin_odd = "pto.vmi.channel_split"(%sin)
               : (!pto.vmi.vreg<128xf32>) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
 
@@ -257,11 +297,13 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             %x_off = arith.addi %x_s_off, %x_n_off : index
             %y_off = arith.addi %y_s_off, %y_n_off : index
 
+            // Load dense interleaved x row.
             %x = pto.vmi.load %x_ub[%x_off]
                 : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
 
             // MI 对应: pto.vdintlv %x, %x → x_even(64xf32), x_odd(64xf32)
             //   硬件解交织——VMI 用 channel_split 语义化表达同样的意图。
+            // Split x into even and odd pair channels.
             %x_even, %x_odd = "pto.vmi.channel_split"(%x)
                 : (!pto.vmi.vreg<128xf32>) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>)
 
@@ -273,17 +315,23 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // VMI: mulf/subf/addf 无 mask——4条乘+2条加减表达完整的成对 RoPE。
             // MI 对应: 8条 vmul/vadd/vsub，每条都带 mask<b32>。
             // ========================================================================
+            // x_even_cos = x_even * cos_even.
             %x_even_cos = pto.vmi.mulf %x_even, %cos_even
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+            // x_odd_sin = x_odd * sin_even.
             %x_odd_sin = pto.vmi.mulf %x_odd, %sin_even
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+            // y_even = x_even*cos_even - x_odd*sin_even.
             %y_even = pto.vmi.subf %x_even_cos, %x_odd_sin
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
+            // x_odd_cos = x_odd * cos_odd.
             %x_odd_cos = pto.vmi.mulf %x_odd, %cos_odd
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+            // x_even_sin = x_even * sin_odd.
             %x_even_sin = pto.vmi.mulf %x_even, %sin_odd
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+            // y_odd = x_odd*cos_odd + x_even*sin_odd.
             %y_odd = pto.vmi.addf %x_odd_cos, %x_even_sin
                 : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
 
@@ -291,6 +339,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // MI 对应: pto.vintlv %y_even, %y_odd → y_pack(64xf32), y_pack_hi(64xf32)
             //   硬件交织指令，产生两个输出（低半/高半），而 channel_merge 直接
             //   产出一个 vreg<128xf32>，更符合"逻辑向量"的思维模型。
+            // Merge even/odd outputs back to dense interleaved order.
             %out = "pto.vmi.channel_merge"(%y_even, %y_odd)
                 : (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<128xf32>
 
@@ -298,6 +347,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             // MI 对应: pto.vsts %y_pack, %y_ub[%y_off], %mask32_full
             //   → 需要 !pto.mask<b32>，且 vintlv 产出的 y_pack_hi 在 MI 中
             //   需要额外的 store 指令——VMI 的单个 128xf32 向量更简洁。
+            // Store the dense interleaved output.
             pto.vmi.masked_store %out, %y_ub[%y_off], %mask
                 : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<128xpred>
           }


### PR DESCRIPTION
Some algorithm background:
- The block_mx_quant SIMD VF implementation closely mirrors [CANN/AscendC dynamic_block_mx_quant](https://gitcode.com/cann/ops-nn/blob/master/quant/dynamic_block_mx_quant/op_kernel/arch35/dynamic_block_mx_quant_base.h). It's similar to open-source TileKernels [per_block_cast_kernel.py](https://github.com/deepseek-ai/TileKernels/blob/main/tile_kernels/quant/per_block_cast_kernel.py), but not identical (current PTO demo hard-codes [32, 32] block while tilelang demo also supports 128 block size)
- The RoPE SIMD VF implementation is similar to [CANN/AscendC apply_rotary_pos_emb](https://gitcode.com/cann/ops-transformer/blob/master/posembedding/apply_rotary_pos_emb/op_kernel/arch35/apply_rotary_pos_emb_common.h), but rewritten to be more efficient and take more variants (layouts, modes)

Note on VF performance: With current SIMD VF + optimized GM-level pipelining (tested internally, excluded here), the whole kernel can reach >3.2 TB/s BW on 950DT, thus quite memory-bound, not vector bound (i.e. the VF part is fast).  In current demo PR the GM<->UB part is kept naive (single-core, no double buffer pipeline). We will polish and release end-to-end kernel as next step.

Note on syntax/styles: The biggest benefit of vmi is on type casting (abstracts away manual odd-even widening/interleaving/packing). ASC [load_store_utils.h](https://gitcode.com/cann/ops-nn/blob/master/common/inc/op_kernel/load_store_utils.h) tries to abstract similar procedures, but not as elegant.